### PR TITLE
resolves issue #8 by removing boundary metabolites

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -545,4 +545,12 @@ def read_legacy_sbml(filename, use_hyphens=False):
             reaction.id = reaction.id[:-3] + "_e"
         reaction.reconstruct_reaction()
     model.reactions._generate_index()
+    # remove boundary metabolites (end in _b and only present in exchanges)
+    for metabolite in model.metabolites:
+        if not metabolite.id.endswith("_b"):
+            continue
+        if len(metabolite._reaction) == 1:
+            if list(metabolite._reaction)[0].id.startswith("EX_"):
+                metabolite.remove_from_model()
+    model.metabolites._generate_index()
     return model


### PR DESCRIPTION
The function read_legacy_sbml now removes metabolites which end in _b
and are present only in a single exchange reaction.
