### PR TITLE
more deterministic lp file writing

### DIFF
--- a/cobra/solvers/glpk_solver.py
+++ b/cobra/solvers/glpk_solver.py
@@ -164,7 +164,7 @@ if __name == 'java':
                 [(row_indices.append(i_offset),
                   column_indices.append(reaction_to_index[k]),
                   constraint_values.append(k._metabolites[the_metabolite]))
-                 for k in the_metabolite._reaction]
+                 for k in sorted(the_metabolite._reaction)]
 
             #Load the constraints into the lp.  Need to use
             #typed arrays.
@@ -407,7 +407,7 @@ else:
                 r.bounds = b, None
             #Add in the linear constraints
 
-            for the_reaction in the_metabolite._reaction:
+            for the_reaction in sorted(the_metabolite._reaction):
                 reaction_index = reaction_to_index[the_reaction]
                 the_coefficient = the_reaction._metabolites[the_metabolite]
                 linear_constraints.append((r.index, reaction_index,


### PR DESCRIPTION
Writing LP files out starting from cobra_model structures is sometimes needed. But the LP files are not deterministically written.

Here is what I mean:

If you load any cobra model pickle and write the LP file (I'm talking about glpk here), you might see:
x1 + x2 = 0 as one of the constraints.  if you do it again later, you might see x2 + x1 = 0 in the LP file.  Now, these are mathematically equivalent.... but since the resulting LP files are not EXACTLY the same the solvers do not always perform the optimization the same way leading to confusing debugging sessions.

This pull requests sorts the dict during writing of LP files so that they are deterministically written.
