### PR TITLE
warnings not imported for core.Reaction

### DIFF
--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -11,6 +11,9 @@ from copy import deepcopy
 from .Object import Object
 from .Metabolite import Metabolite
 from .Gene import Gene
+
+from warnings import warn
+
 class Reaction(Object):
     """Reaction is a class for holding information regarding
     a biochemical reaction in a cobra.Model object 
@@ -576,7 +579,6 @@ def process_prefixed_reaction(self, reaction_string):
     This can be moved to a tools section
     
     """
-    from warnings import warn
     warn('Reaction.process_prefixed_reaction is deprecated')
     the_compartment, the_reaction = reaction_string.split(':')
     the_compartment = the_compartment.rstrip(' ')

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -543,7 +543,6 @@ def read_legacy_sbml(filename, use_hyphens=False):
         reaction.id = fix_legacy_id(reaction.id)
         if reaction.id.startswith("EX_") and reaction.id.endswith("(e)"):
             reaction.id = reaction.id[:-3] + "_e"
-        reaction.reconstruct_reaction()
     model.reactions._generate_index()
     # remove boundary metabolites (end in _b and only present in exchanges)
     for metabolite in model.metabolites:


### PR DESCRIPTION
Reaction raises some warnings for deprecated functions but does not actually import them.
