### PR TITLE
Deprecations of assess_objective and introduction of cobra.flux_analysis.reaction.assess*

### DIFF
--- a/cobra/flux_analysis/objective.py
+++ b/cobra/flux_analysis/objective.py
@@ -11,52 +11,20 @@ if hasattr(sys, 'maxsize') and sys.maxsize > 2**32:
 else:
     int32 = int
     int64 = int
-def assess_objective(cobra_model, the_objective=None,
+
+
+    
+def assess_objective(model, objective=None,
                       objective_cutoff=0.001, growth_medium=None):
-    """Assesses the ability of the model to produce all reactants in the_objective on
-    an individual basis.  Returns True if the_objective can be realized to exceed
-    objective_cutoff.  Otherwise, determines which components of the_objective are
-    lagging and returns a dict of the components and their required and realized values.
-
+    """DEPRECATED
     """
-    cobra_model = cobra_model.copy()
-    if growth_medium:
-        initialize_growth_medium(cobra_model, growth_medium)
-
-    #If the model cannot achieve the objective then check each component for failure
-    #to be produced.
-    if the_objective is None:
-        #Assume a single objective reaction
-        objective_reaction = [x for x in cobra_model.reactions if x.objective_coefficient != 0][0]
-    elif hasattr(the_objective, 'id'):
-        objective_reaction = cobra_model.reactions.get_by_id(the_objective.id) #need to get because we've copied the model
-    elif isinstance(the_objective, str):
-        objective_reaction = cobra_model.reactions.get_by_id(the_objective)
-    else:
-        #assume that it's an index
-        objective_reaction = cobra_model.reactions[the_objective]
-    cobra_model.optimize(new_objective = objective_reaction)
-    #First see if the model can realize the objective
-    if cobra_model.solution.f >= objective_cutoff:
-        return {}
-    components = objective_reaction.get_reactants()
-    simulation_results = {}
-    #TODO:  Speed this section up.  Possibly by modifying Model.optimize() to
-    #use and updated S and reuse the basis.
-    for the_component in objective_reaction.get_reactants():
-        #add in a sink reaction for each component
-        sink_reaction = Reaction('test_sink_' + the_component)
-        #then simulate ability
-        #then check it can exceed objective cutoff * component stoichiometric
-        #coefficient.
-        tmp_coefficient = objective_reaction.get_coefficient(the_component) 
-        sink_reaction.add_metabolites(the_component, tmp_coefficient)
-        sink_reaction.upper_bound = 1000
-        cobra_model.add_reaction(sink_reaction)
-        cobra_model.optimize(new_objective = sink_reaction.id)
-        if objective_cutoff > cobra_model.solution.f:
-            simulation_results.update({the_component:{'required':abs(tmp_coefficient*objective_cutoff), 'produced':cobra_model.solution.f}})
-    return simulation_results
+    from warnings import warn
+    warn("cobra.flux_analysis.objective.assess_objective is deprecated.  " +\
+         "Please use cobra.flux_analysis.reaction.assess instead")
+    return(False)
+    
+    
+ 
 
 def update_objective(cobra_model, the_objectives):
     """Revised to take advantage of the new Reaction classes.

--- a/cobra/flux_analysis/reaction.py
+++ b/cobra/flux_analysis/reaction.py
@@ -1,0 +1,157 @@
+#cobra.flux_analysis.reaction.py
+#functions for analyzing / creating objective functions
+from ..core.Reaction import Reaction
+
+def assess(model, reaction, flux_coefficient_cutoff=0.001):
+    """Assesses the capacity of the model to produce the precursors for the reaction
+    and absorb the production of the reaction while the reaction is operating at, or
+    above, the specified cutoff.
+
+    model: A :class:`~cobra.core.Model` object
+
+    reaction: A :class:`~cobra.core.Reaction` object
+
+
+    flux_coefficient_cutoff:  Float.  The minimum flux that reaction must carry to
+    be considered active.
+
+    returns: True if the model can produce the precursors and absorb the products
+    for the reaction operating at, or above, flux_coefficient_cutoff.  Otherwise,
+    a dictionary of {'precursor': Status, 'product': Status}.  Where Status is the
+    results from assess_precursors and assess_products,
+    respectively.
+
+    """
+    reaction = model.reactions.get_by_id(reaction.id)
+    model.optimize(new_objective={reaction: 1})
+    if model.solution.f >= flux_coefficient_cutoff:
+        return(True)
+    else:
+        results = {}
+        results['precursors'] = assess_precursors(model, reaction, flux_coefficient_cutoff)
+        results['products'] = assess_products(model, reaction, flux_coefficient_cutoff)
+        return(results)
+
+def assess_precursors(model, reaction,  flux_coefficient_cutoff=0.001):
+    """Assesses the ability of the model to provide sufficient precursors for
+    a reaction operating at, or beyond, the specified cutoff.
+
+    model: A :class:`~cobra.core.Model` object
+
+    reaction: A :class:`~cobra.core.Reaction` object
+
+
+    flux_coefficient_cutoff:  Float.  The minimum flux that reaction must carry to
+    be considered active.
+
+    returns: True if  the precursors can be simultaneously produced at the specified cutoff.  False, if the model has
+    the capacity to produce each individual precursor at the specified threshold  but not all precursors at the
+    required level simultaneously.   Otherwise a dictionary of the required and the produced
+    fluxes for each reactant that is not produced in sufficient quantities.
+    
+    """
+    model = model.copy()
+    reaction = model.reactions.get_by_id(reaction.id)
+    model.optimize(new_objective={reaction: 1})
+    if model.solution.f >= flux_coefficient_cutoff:
+        return(True)
+    #
+    simulation_results = {}
+    #build the sink reactions and add all at once
+    sink_reactions = {}
+    for the_component in reaction.get_reactants():
+        #add in a sink reaction for each component
+        sink_reaction = Reaction('test_sink_%s'%the_component.id)
+        #then simulate production ability
+        #then check it can exceed objective cutoff * component stoichiometric
+        #coefficient.
+        coefficient = reaction.get_coefficient(the_component) 
+        sink_reaction.add_metabolites({the_component: coefficient})
+        sink_reaction.upper_bound = 1000
+        sink_reactions[sink_reaction] = (the_component, coefficient)
+    #First assess whether all precursors can pbe produced simultaneously
+    super_sink = Reaction("super_sink")
+    for reaction in sink_reactions:
+        super_sink += reaction
+    super_sink.id = 'super_sink'
+    model.add_reactions(sink_reactions.keys() + [super_sink])
+    model.optimize(new_objective=super_sink)
+    if flux_coefficient_cutoff <= model.solution.f:
+        return(True)
+
+    #Otherwise assess the ability of the model to produce each precursor individually.
+    #Now assess the ability of the model to produce each reactant for a reaction
+    for sink_reaction, (component, coefficient) in sink_reactions.iteritems():
+        model.optimize(new_objective=sink_reaction) #Calculate the maximum amount of the
+        #metabolite that can be produced.
+        if flux_coefficient_cutoff > model.solution.f:
+            #Scale the results to a single unit
+            simulation_results.update({component:{'required':flux_coefficient_cutoff/abs(coefficient),
+                                                  'produced':model.solution.f/abs(coefficient)}})
+    if len(simulation_results) == 0:
+        simulation_results = False
+    return(simulation_results)
+
+def assess_products(model, reaction, flux_coefficient_cutoff=0.001):
+    """Assesses whether the model has the capacity to absorb the products of a reaction
+    at a given flux rate.  Useful for identifying which components might be blocking
+    a reaction from achieving a specific flux rate.
+
+    model: A :class:`~cobra.core.Model` object
+
+    reaction: A :class:`~cobra.core.Reaction` object
+
+    flux_coefficient_cutoff:  Float.  The minimum flux that reaction must carry to
+    be considered active.
+
+    returns: True if the model has the capacity to absorb all the reaction products being
+    simultaneously given the specified cutoff.   False, if the model has
+    the capacity to absorb each individual product but not all products at the
+    required level simultaneously.   Otherwise a dictionary of the required and the
+    capacity fluxes for each product that is not absorbed in sufficient quantities.
+
+    
+    """
+    model = model.copy()
+    reaction = model.reactions.get_by_id(reaction.id)
+    model.optimize(new_objective={reaction: 1})
+    if model.solution.f >= flux_coefficient_cutoff:
+        return(True)
+    #
+    simulation_results = {}
+    #build the sink reactions and add all at once
+    source_reactions = {}
+    for the_component in reaction.get_products():
+        #add in a sink reaction for each component
+        source_reaction = Reaction('test_source_%s'%the_component.id)
+        #then simulate production ability
+        #then check it can exceed objective cutoff * component stoichiometric
+        #coefficient.
+        coefficient = reaction.get_coefficient(the_component) 
+        source_reaction.add_metabolites({the_component: coefficient})
+        source_reaction.upper_bound = 1000
+        source_reactions[source_reaction] = (the_component, coefficient)
+    #
+    super_source = Reaction('super_source')
+    for reaction in source_reactions:
+            super_source += reaction
+    super_source.id = 'super_source'
+    model.add_reactions(source_reactions.keys() + [super_source])
+    model.optimize(new_objective=super_source)
+    if flux_coefficient_cutoff <= model.solution.f:
+        return(True)
+
+    #Now assess the ability of the model to produce each reactant for a reaction
+    for source_reaction, (component, coefficient) in source_reactions.iteritems():
+        model.optimize(new_objective=source_reaction) #Calculate the maximum amount of the
+        #metabolite that can be produced.
+        if flux_coefficient_cutoff > model.solution.f:
+            #Scale the results to a single unit
+            simulation_results.update({component:{'required':flux_coefficient_cutoff/abs(coefficient),
+                                                  'capacity':model.solution.f/abs(coefficient)}})
+    if len(simulation_results) == 0:
+        simulation_results = False
+    return(simulation_results)
+
+    
+    


### PR DESCRIPTION
In response to https://github.com/opencobra/cobrapy/issues/34, I've deprecated the assess_objective function because it's not really capable of assessing a multi-reaction linear objective.  I've introduced the module: cobra.flux_analysis.reaction that can be used to assess whether a given model has:

 1) the capacity to absorb products of a reaction operating at, or above, a specified flux
 2) the capacity to produce precursors for a reaction operating at, or above, a specified flux
