### PR TITLE
Py sbml ext

### DIFF
--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -14,7 +14,7 @@ except ImportError:
 
 ns = {"fbc": "http://www.sbml.org/sbml/level3/version1/fbc/version1",
       "sbml": "http://www.sbml.org/sbml/level3/version1/core",
-      "cobra": "http://github.io/opencobra/cobra_sbml"}
+      "cobra": "http://opencobra.github.io/cobra_sbml"}
 
 
 def strnum(number):


### PR DESCRIPTION
Reads and writes sbml level 3 using only the python xml parsing libraries, which means that sbml i/o can occur without the libsbml dependency. Additionally, being pure python, this code runs identically under jython.

The sbml produced passes [validation](http://sbml.org/Facilities/Validator/).

Some notes concerning the sbml level 3 format:
- Reaction upper bounds, lower bounds, and objective coefficients, along with metabolite formulas and charges, are encoded using the [fbc](http://sbml.org/Documents/Specifications/SBML_Level_3/Packages/Flux_Balance_Constraints_%28flux%29) package.
- Gene reaction rules and subsystems are now encoded under a cobra extension in the annotation field. For example, for reaction PGI in Salmonella:

``` xml
<annotation>
  <cobra:extension>
    <cobra:geneAssociation>STM4221</cobra:geneAssociation>
    <cobra:subsystem>GlycolysisGluconeogenesis</cobra:subsystem>
  </cobra:extension>
</annotation>
```

These are the tasks which need to be accomplished:
- [x] read/write sbml with fbc for reaction bounds and metabolite formulas
- [x] imported model should solve properly
- [x] written sbml should pass validation
- [x] gene reaction rule encoding
- [x] subsystems annotation
- [ ] unit testing

Before a pull request like this can be merged, the field names should be agreed upon, and identical sbml level 3 support should be discussed for the matlab cobra toolbox.
