### PR TITLE
Remove readonly reaction.metabolites dict for now

### DIFF
--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -66,7 +66,8 @@ class Reaction(Object):
     # read-only
     @property
     def metabolites(self):
-        return make_dictproxy(self._metabolites)
+        # TODO make read-only
+        return self._metabolites
 
     @property
     def genes(self):


### PR DESCRIPTION
dictproxy had issues on macs, need a different solution

Fixes #63
