### PR TITLE
Fixes a bug introduced in https://github.com/opencobra/cobrapy/pull/53

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -234,7 +234,7 @@ class Model(Object):
                     reaction._metabolites[model_metabolite] = stoichiometry
                     model_metabolite._reaction.add(reaction)
 
-            for gene in reaction._genes:
+            for gene in reaction.genes:
                 # If the gene is not in the model, add it
                 if not self.genes.has_id(gene.id):
                     self.genes.append(gene)

--- a/cobra/core/Species.py
+++ b/cobra/core/Species.py
@@ -106,7 +106,11 @@ class Species(Object):
         """Returns the Model object that contain this Object
 
         """
+        print("get_model is deprecated. used model property instead")
         return self._model
+    @property
+    def model(self):
+        return(self._model)
 #
 #END Class Species
 ########################

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -203,8 +203,22 @@ class TestCobraCore(CobraTestCase):
             metabolites_copy = reaction_copy._metabolites.keys()
             metabolites_copy.sort()
             self.assertEqual(metabolites, metabolites_copy)
+
+    def test_add_reaction(self):
+        """Verify that no orphan genes are metabolites are contained in reactions after
+        adding them to the model.
         
-        
+        """
+        _model = Model('test')
+        _model.add_reactions([x.copy() for x in self.model.reactions])
+        _genes = []
+        _metabolites = []
+        [(_genes.extend(x.genes), _metabolites.extend(x.metabolites))
+         for x in _model.reactions];
+        _orphan_genes = [x for x in _genes if x.model is not _model]
+        _orphan_metabolites = [x for x in _metabolites if x.model is not _model]
+        self.assertEqual(len(_orphan_genes), 0, msg='It looks like there are dangling genes when running Model.add_reactions')
+        self.assertEqual(len(_orphan_metabolites), 0, msg='It looks like there are dangling metabolites when running Model.add_reactions')
 
 class TestCobraIO(CobraTestCase):
     try:


### PR DESCRIPTION
Iterating through Reaction._genes while modifying Reaction._genes had some weird behavior.  Changed to use the Reaction.genes property and added in a unit test.
