### PR TITLE
install libsbml using pip from built wheel in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,9 @@ virtualenv:
   system_site_packages: true
 before_install:
   - sudo apt-get install libglpk-dev python-scipy libgmp-dev
-  - cd /home/travis
-  - wget http://clostridium.ucsd.edu/libSBML-5.9.0_compiled.tar.gz
-  - tar xzf libSBML-5.9.0_compiled.tar.gz
-  - cd libSBML-5.9.0-Source
-  - sudo make install
-  - cd $TRAVIS_BUILD_DIR
 install:
   - ln -s /usr/lib/python2.7/dist-packages/scipy ~/virtualenv/python2.7/lib/python2.7/site-packages/
+  - pip install http://clostridium.ucsd.edu/python_libsbml_experimental-5.9.2-cp27-none-linux_x86_64.whl
   - pip install glpk cython
   - python setup.py develop
 # # command to run tests


### PR DESCRIPTION
It appears this is experimental on libsbml's side for now, but this is
the "correct" way to install python packages and is much simpler.
