### PR TITLE
double deletion skips singly lethal deletions

### DIFF
--- a/cobra/flux_analysis/double_deletion.py
+++ b/cobra/flux_analysis/double_deletion.py
@@ -29,7 +29,9 @@ except:
 
 def double_reaction_deletion_fba(cobra_model, reaction_list1=None,
                                  reaction_list2=None, solver=None,
-                                 number_of_processes=None, return_frame=False):
+                                 number_of_processes=None,
+                                 return_frame=False, zero_cutoff=1e-12,
+                                 **kwargs):
     """setting n_processes=1 explicitly disables multiprocessing"""
     if reaction_list1 is None:
         reaction_indexes1 = range(len(cobra_model.reactions))
@@ -39,7 +41,8 @@ def double_reaction_deletion_fba(cobra_model, reaction_list1=None,
         reaction_indexes2 = reaction_indexes1
     else:
         reaction_indexes2 = [cobra_model.reactions.index(r) for r in reaction_list2]
-
+    # results are stored in a matrix. reaction_to_result maps a reaction index
+    # to the index in the results matrix
     reaction_indexes = list(set(chain(reaction_indexes1, reaction_indexes2)))
     reaction_to_result = {reaction_index: result_index
                           for result_index, reaction_index in enumerate(reaction_indexes)}
@@ -59,13 +62,29 @@ def double_reaction_deletion_fba(cobra_model, reaction_list1=None,
     else:
         PoolClass = CobraDeletionPool
     with PoolClass(cobra_model, n_processes=number_of_processes,
-                   solver=solver) as pool:
+                   solver=solver, **kwargs) as pool:
         # submit jobs
-        
+
+        # precompute all single deletions in the pool and store them along
+        # the diagonal
+        for reaction_index, result_index in iteritems(reaction_to_result):
+            pool.submit((reaction_index, ), label=result_index)
+        for result_index, value in pool.receive_all():
+            # if singly lethal, set everything in row and column to 0
+            value = value if abs(value) > zero_cutoff else 0.
+            if value == 0.:
+                results[result_index, :] = 0.
+                results[:, result_index] = 0.
+            else:  # only the diagonal needs to be set
+                results[result_index, result_index] = value
+
         for r1_index, r2_index in product(reaction_indexes1, reaction_indexes2):
             r1_result_index = reaction_to_result[r1_index]
             r2_result_index = reaction_to_result[r2_index]
-            if r2_result_index >= r1_result_index:  # upper triangle only
+            if r2_result_index > r1_result_index:  # upper triangle only
+                if results[r1_result_index, r1_result_index] == 0 or \
+                        results[r2_result_index, r2_result_index] == 0:
+                    continue
                 pool.submit((r1_index, r2_index), label=(r1_result_index, r2_result_index))
             # if it's a point only in the lower triangle, compute it
             # and put it in the upper triangle
@@ -95,7 +114,7 @@ def double_reaction_deletion_fba(cobra_model, reaction_list1=None,
 
 def double_gene_deletion_fba(cobra_model, gene_list1=None, gene_list2=None,
                              solver=None, number_of_processes=None,
-                             return_frame=False):
+                             return_frame=False, zero_cutoff=1e-12, **kwargs):
     if gene_list1 is None:
         gene_list1 = cobra_model.genes
     else:
@@ -108,6 +127,8 @@ def double_gene_deletion_fba(cobra_model, gene_list1=None, gene_list2=None,
         gene_list2 = [cobra_model.genes.get_by_id(i)
                       if isinstance(i, string_types) else i
                       for i in gene_list2]
+    # Store results in a matrix. The gene_id_to_result dict will map each
+    # gene id to the index in the result matrix
     gene_ids1 = [i.id for i in gene_list1]
     gene_ids2 = [i.id for i in gene_list2]
     gene_id_to_result = {}
@@ -135,11 +156,30 @@ def double_gene_deletion_fba(cobra_model, gene_list1=None, gene_list2=None,
     else:
         PoolClass = CobraDeletionPool
     with PoolClass(cobra_model, n_processes=number_of_processes,
-                   solver=solver) as pool:
+                   solver=solver, **kwargs) as pool:
+        # precompute all single deletions in the pool and store them along
+        # the diagonal
+        for gene_id, gene_result_index in iteritems(gene_id_to_result):
+            ko_reactions = find_gene_knockout_reactions(cobra_model,
+                (cobra_model.genes.get_by_id(gene_id),))
+            ko_indexes = [cobra_model.reactions.index(i) for i in ko_reactions]
+            pool.submit(ko_indexes, label=gene_result_index)
+        for result_index, value in pool.receive_all():
+            # if singly lethal, set everything in row and column to 0
+            value = value if abs(value) > zero_cutoff else 0.
+            if value == 0.:
+                results[result_index, :] = 0.
+                results[:, result_index] = 0.
+            else:  # only the diagonal needs to be set
+                results[result_index, result_index] = value
         for gene1, gene2 in product(gene_list1, gene_list2):
             g1_result_index = gene_id_to_result[gene1.id]
             g2_result_index = gene_id_to_result[gene2.id]
-            if g2_result_index >= g1_result_index:  # upper triangle only
+            if g2_result_index > g1_result_index:  # upper triangle only
+                # if singly lethal the results have already been set
+                if results[g1_result_index, g1_result_index] == 0 or \
+                        results[g2_result_index, g2_result_index] == 0:
+                    continue
                 ko_reactions = find_gene_knockout_reactions(cobra_model, (gene1, gene2))
                 ko_indexes = [cobra_model.reactions.index(i) for i in ko_reactions]
                 pool.submit(ko_indexes, label=(g1_result_index, g2_result_index))
@@ -151,7 +191,10 @@ def double_gene_deletion_fba(cobra_model, gene_list1=None, gene_list2=None,
                 pool.submit(ko_indexes, label=(g2_result_index, g1_result_index))
 
         for result in pool.receive_all():
-            results[result[0]] = result[1]
+            value = result[1]
+            if value < zero_cutoff:
+                value = 0
+            results[result[0]] = value
 
     del pool
 
@@ -175,7 +218,8 @@ def double_deletion(cobra_model, element_list_1=None, element_list_2=None,
                     method='fba', single_deletion_growth_dict=None,
                     element_type='gene', solver=None,
                     number_of_processes=None,
-                    return_frame=False, **kwargs):
+                    return_frame=False, zero_cutoff=1e-12,
+                    **kwargs):
     """Run double gene or reaction deletions
 
     cobra_model: a cobra.Model object
@@ -194,6 +238,13 @@ def double_deletion(cobra_model, element_list_1=None, element_list_2=None,
         used if available.
 
     element_type: 'gene' or 'reaction'
+
+    zero_cutoff: float
+        For single deletions which are assumed to be lethal, any double 
+        deletion will also be assumed to be lethal. This parameter sets 
+        behavior, set this value to a negative number. the abslolute value 
+        cutoff for considering a deletion to be lethal. To disable this
+        behavior, set this to a negative value.
 
     solver: 'glpk', 'cglpk', 'gurobi', 'cplex' or None
 
@@ -218,13 +269,17 @@ def double_deletion(cobra_model, element_list_1=None, element_list_2=None,
                 gene_list1=element_list_1,
                 gene_list2=element_list_2, solver=solver,
                 return_frame=return_frame,
-                number_of_processes=number_of_processes)
+                zero_cutoff=zero_cutoff,
+                number_of_processes=number_of_processes,
+                **kwargs)
         elif element_type == "reaction":
             return double_reaction_deletion_fba(cobra_model,
                 reaction_list1=element_list_1,
                 reaction_list2=element_list_2, solver=solver,
+                zero_cutoff=zero_cutoff,
                 return_frame=return_frame,
-                number_of_processes=number_of_processes)
+                number_of_processes=number_of_processes,
+                **kwargs)
         else:
             raise ValueError("element_type %s not gene or reaction" % element_type)
 


### PR DESCRIPTION
Assuming that singly lethal deletions give lethal double deletions
improves solves times. I observed speedups of up to 50%.

It also passes solver arguments on correctly.

This fixes #101
