### PR TITLE
Fix cobra.io.json types and attributes

### DIFF
--- a/cobra/io/json.py
+++ b/cobra/io/json.py
@@ -4,27 +4,50 @@ import json
 from warnings import warn
 
 from .. import Model, Metabolite, Reaction, Formula
-from ..external.six import iteritems
+from ..external.six import iteritems, string_types
 
-def load_json_model(infile_path, variable_name=None):
-    """Load a cobra model stored as a json file
+# Detect numpy types to replace them.
+try:
+    from numpy import float_, bool_
+except ImportError:
+    class float_:
+        pass
 
-    infile_path : str
+    class bool_:
+        pass
 
-    """
-    model = Model()
-    with open(infile_path, 'r') as f:
-        obj = json.load(f)
-        
-    if not 'reactions' in obj:
+_DEFAULT_REACTION_ATTRIBUTES = {
+    'id', 'name', 'subsystem', 'lower_bound', 'upper_bound',
+    'objective_coefficient', 'notes', 'gene_reaction_rule', 'variable_kind'}
+
+_DEFAULT_METABOLITE_ATTRIBUTES = {
+    'id', 'annotation', 'charge', 'compartment', 'formula', 'name', 'notes',
+    '_bound', '_constraint_sense'}
+
+
+def _fix_type(value):
+    """convert possible types to str, float, and bool"""
+    # Because numpy floats can not be pickled to json
+    if isinstance(value, string_types):
+        return str(value)
+    if isinstance(value, float_):
+        return float(value)
+    if isinstance(value, bool_):
+        return bool(value)
+    return value
+
+
+def _from_dict(obj):
+    """build a model from a dict"""
+    if 'reactions' not in obj:
         raise Exception('JSON object has no reactions attribute. Cannot load.')
+    model = Model()
     # add metabolites
     new_metabolites = []
     for metabolite in obj['metabolites']:
         new_metabolite = Metabolite()
         for k, v in iteritems(metabolite):
-            setattr(new_metabolite, k, v)
-            # TODO test that these are the right attributes
+            setattr(new_metabolite, k, _fix_type(v))
         new_metabolites.append(new_metabolite)
     model.add_metabolites(new_metabolites)
     # add reactions
@@ -34,13 +57,12 @@ def load_json_model(infile_path, variable_name=None):
         for k, v in iteritems(reaction):
             if k == 'reversibility' or k == "reaction":
                 continue
-            # TODO test that these are the right attributes
-            elif k=='metabolites':
+            elif k == 'metabolites':
                 new_reaction.add_metabolites(
-                    {model.metabolites.get_by_id(met): coeff
+                    {model.metabolites.get_by_id(str(met)): coeff
                      for met, coeff in iteritems(v)})
             else:
-                setattr(new_reaction, k, v)
+                setattr(new_reaction, k, _fix_type(v))
         new_reactions.append(new_reaction)
     model.add_reactions(new_reactions)
     for k, v in iteritems(obj):
@@ -48,24 +70,19 @@ def load_json_model(infile_path, variable_name=None):
             setattr(model, k, v)
     return model
 
-_DEFAULT_REACTION_ATTRIBUTES = {
-    'id', 'name', 'reversibility', 'subsystem', 'lower_bound', 'upper_bound',
-    'objective_coefficient', 'notes', 'gene_reaction_rule', 'reaction'}
 
-_DEFAULT_METABOLITE_ATTRIBUTES = {
-    'id', 'annotation', 'charge', 'compartment', 'formula', 'name', 'notes'}
-
-def _to_dict(model, exclude_attributes=[]):
-    exclude_attributes = set(exclude_attributes)
-    reaction_attributes = _DEFAULT_REACTION_ATTRIBUTES - exclude_attributes
-    metabolite_attributes = _DEFAULT_METABOLITE_ATTRIBUTES - exclude_attributes
+def _to_dict(model):
+    """convert the model to a dict"""
+    reaction_attributes = _DEFAULT_REACTION_ATTRIBUTES
+    metabolite_attributes = _DEFAULT_METABOLITE_ATTRIBUTES
     new_reactions = []
     new_metabolites = []
     for reaction in model.reactions:
-        new_reaction = {key: getattr(reaction, key)
+        new_reaction = {key: _fix_type(getattr(reaction, key))
                         for key in reaction_attributes}
         # set metabolites
-        mets = {str(met): coeff for met, coeff in iteritems(reaction._metabolites)}
+        mets = {str(met): coeff for met, coeff
+                in iteritems(reaction._metabolites)}
         new_reaction['metabolites'] = mets
         new_reactions.append(new_reaction)
     for metabolite in model.metabolites:
@@ -79,29 +96,52 @@ def _to_dict(model, exclude_attributes=[]):
            'notes': model.notes}
     return obj
 
-def to_json(model, exclude_attributes=[]):
-    return json.dumps(_to_dict(model, exclude_attributes=exclude_attributes))
 
-def save_json_model(model, file_name, exclude_attributes=[]):
+def to_json(model):
+    """Save the cobra model as a json string"""
+    return json.dumps(_to_dict(model))
+
+
+def from_json(jsons):
+    """Load cobra model from a json string"""
+    return _from_dict(json.loads(jsons))
+
+
+def load_json_model(file_name):
+    """Load a cobra model stored as a json file
+
+    file_name : str or file-like object
+
+    """
+    # open the file
+    should_close = False
+    if isinstance(file_name, string_types):
+        file_name = open(file_name, 'r')
+        should_close = True
+
+    model = _from_dict(json.load(file_name))
+
+    if should_close:
+        file_name.close()
+
+    return model
+
+
+def save_json_model(model, file_name):
     """Save the cobra model as a json file.
 
     model : :class:`~cobra.core.Model.Model` object
 
     file_name : str or file-like object
 
-    exclude_attributes : A list of reaction or metabolite attributes to ignore.
-
-    .. note :: ignoring attributes will make it impossible to reload the
-                  model with cobra.io.json.load_json_model()
-
     """
     # open the file
     should_close = False
-    if isinstance(file_name, str):
+    if isinstance(file_name, string_types):
         file_name = open(file_name, 'w')
         should_close = True
 
-    json.dump(_to_dict(model, exclude_attributes=exclude_attributes), file_name)
+    json.dump(_to_dict(model), file_name)
 
     if should_close:
         file_name.close()


### PR DESCRIPTION
This fixes issue #98 where numpy objects failed to be saved.

The exclude_attributes functionality was also removed. This will cause
the json input and output to be consistent and reproducible, reducing
the possibility of generating malformed files.

In addition, the module can now load and dump json strings. The code
also passes pep8.
