### PR TITLE
prefer cglpk to glpk

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,17 +68,22 @@ cobrapy comes with bindings to the GNU Linear Programming Kit ([glpk]
 cobrapy. In addition, cobrapy currently supports these linear programming
 solvers:
 
- * ILOG/CPLEX
+ * ILOG/CPLEX (available with
   [Academic](https://www.ibm.com/developerworks/university/academicinitiative/)
+  and
   [Commercial](http://www.ibm.com/software/integration/optimization/cplex-optimizer/)
+  licenses).
  * [gurobi](http://gurobi.com)
- * GLPK through [pyGLPK](http://tfinley.net/software/pyglpk/)
+ * [QSopt_ex esolver](http://www.dii.uchile.cl/~daespino/ESolver_doc/main.html)
+ * [MOSEK](http://www.mosek.com/)
 
 ILOG/CPLEX and Gurobi are commercial software packages that, currently, 
 provide free licenses for academics and support both linear and quadratic 
 programming. GLPK is an opensource linear programming solver; however, it 
 does not support quadratic programming and is not as robust as the 
 commercial solvers when it comes to mixed-integer linear programming.
+QSopt_ex esolver is also open source, and can solve linear programs
+using rational operations, giving exact solutions.
 
 
 # Testing your installation

--- a/cobra/solvers/__init__.py
+++ b/cobra/solvers/__init__.py
@@ -74,8 +74,8 @@ def get_solver_name(mip=False, qp=False):
     if len(solver_dict) == 0:
         raise SolverNotFound("no solvers installed")
     # glpk only does lp, not qp. Gurobi and cplex are better at mip
-    mip_order = ["gurobi", "cplex", "glpk", "cglpk"]
-    lp_order = ["glpk", "cglpk", "gurobi", "cplex"]
+    mip_order = ["gurobi", "cplex", "cglpk", "glpk"]
+    lp_order = ["cglpk", "cplex",  "glpk", "gurobi"]
     qp_order = ["gurobi", "cplex"]
 
     if mip is False and qp is False:

--- a/cobra/solvers/cglpk.pyx
+++ b/cobra/solvers/cglpk.pyx
@@ -19,6 +19,9 @@ __doc__ = """Bindings to GLPK
 The GNU Linear Programming Kit (GLPK) is released under the GPL.
 The source can be downloaded from http://www.gnu.org/software/glpk/
 
+The GNU Multiple Precision Arithmetic Library (GMP) is released under the GPL.
+The source can be downloaded from https://gmplib.org/
+
 """
 
 cdef dict ERROR_CODES = {


### PR DESCRIPTION
cglpk is now faster, more advanced, and more robust than the bindings
through pyglpk, and will be preferred to pyglpk by the automatic solver
selection process in get_solver_name. Pyglpk will remain a solver for
legacy reasons, but has been removed from the installation instructions
page.

Also, this adds the gmp license to the cglpk docstring.
