### PR TITLE
Fixes reaction deletion/removal

### DIFF
--- a/cobra/core/ArrayBasedModel.py
+++ b/cobra/core/ArrayBasedModel.py
@@ -201,26 +201,18 @@ class ArrayBasedModel(Model):
         if update_matrices:
             self._update_matrices(reaction_list)
 
+    def remove_reactions(self, reactions, update_matrices=True, **kwargs):
+        """remove reactions from teh model
 
-    def remove_reactions(self, reaction_list, update_matrices=True):
-        """Will add a cobra.Reaction object to the model, if
-        reaction.id is not in self.reactions.
+        See :func:`cobra.core.Model.Model.remove_reactions`
 
-        reaction_list: A list or instance of :class:`~cobra.core.Reaction` or ids
-
-        update_matrices:  Boolean.  If true populate / update matrices
-        S, lower_bounds, upper_bounds, .... Note this is slow to run
-        for very large models and using this option with repeated calls
-        will degrade performance.  Better to call self.update() after
-        adding all reactions.
-
-        
-         If the stoichiometric matrix is initially empty then initialize a 1x1
-         sparse matrix and add more rows as needed in the self.add_metabolites
-         function
+        update_matrices:  Boolean
+            If true populate / update matrices S, lower_bounds, upper_bounds.
+            Note that this is slow to run for very large models, and using this
+            option with repeated calls will degrade performance.
 
         """
-        Model.remove_reactions(self, reaction_list)
+        Model.remove_reactions(self, reactions, **kwargs)
         if update_matrices:
             self._update_matrices()
 

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -298,27 +298,35 @@ class Model(Object):
         self.solution = the_solution
         return the_solution
 
+    def remove_reactions(self, reactions, delete=True,
+                         remove_orphans=False):
+        """remove reactions from the model
 
-    def remove_reactions(self, the_reactions):
-        """
-        the_reactions: instance or list of cobra.Reactions or strings of
-        self.reactions[:].id.
+        reactions: [:class:`~cobra.core.Reaction.Reaction`] or [str]
+            The reactions (or their id's) to remove
+
+        delete: Boolean
+            Whether or not the reactions should be deleted after removal.
+            If the reactions are not deleted, those objects will be
+            recreated with new metabolite and gene objects.
+
+        remove_orphans: Boolean
+            Remove orphaned genes and metabolites from the model as well
 
         """
-        if not hasattr(the_reactions, '__iter__') or \
-               hasattr(the_reactions, 'id'):
-            the_reactions = [the_reactions]
-        if len(the_reactions) == 0:
-            return
-        if hasattr(the_reactions[0], 'id'):
-            the_reactions = [x.id for x in the_reactions]
-        reactions_to_delete = []
-        for the_reaction in the_reactions:
+        if isinstance(reactions, string_types) or hasattr(reactions, "id"):
+            warn("need to pass in a list")
+            reactions = [reactions]
+        for reaction in reactions:
             try:
-                the_reaction = self.reactions[self.reactions.index(the_reaction)]
-                the_reaction.remove_from_model()
-            except:
-                warn('%s not in %s'%(the_reaction, self))
+                reaction = self.reactions[self.reactions.index(reaction)]
+            except ValueError:
+                warn('%s not in %s' % (reaction, self))
+            else:
+                if delete:
+                    reaction.delete(remove_orphans=remove_orphans)
+                else:
+                    reaction.remove_from_model(remove_orphans=remove_orphans)
 
     def repair(self, rebuild_index=True, rebuild_relationships=True):
         """Update all indexes and pointers in a model"""


### PR DESCRIPTION
This pull request is around the functions Model.remove_reactions,
Reaction.remove_from_model, and Rection.delete.

These fucnctions now all have a flag for removal of orphan
metabolites/genes. Before, this behaviro was unspecified and unclear.
Moreover, this behavior is also tested under the unit tests.

Previously, the function Reaction.delete had bugs which prevented it
from working correctly, and was not under unit testing. This has now
been corrected.
