### PR TITLE
Fix python3 specific issue in create_cobra_model_from_sbml_file.

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -260,13 +260,14 @@ def create_cobra_model_from_sbml_file(sbml_filename, old_sbml=False, legacy_meta
         #TODO: READ IN OTHER NOTES AND GIVE THEM A reaction_ prefix.
         #TODO: Make sure genes get added as objects
         if 'GENE ASSOCIATION' in reaction_note_dict:
+            rule = reaction_note_dict['GENE ASSOCIATION'][0]
             try:
-                rule = reaction_note_dict['GENE ASSOCIATION'][0].encode('ascii')
-                if rule.startswith("&quot;") and rule.endswith("&quot;"):
-                    rule = rule[6:-6]
-                reaction.gene_reaction_rule = str(rule)
-            except:
+                rule.encode('ascii')
+            except UnicodeEncodeError:
                 warn("gene_reaction_rule is not ascii compliant")
+            if rule.startswith("&quot;") and rule.endswith("&quot;"):
+                rule = rule[6:-6]
+            reaction.gene_reaction_rule = rule
             if 'GENE LIST' in reaction_note_dict:
                 reaction.systematic_names = reaction_note_dict['GENE LIST'][0]
             elif 'GENES' in reaction_note_dict and \


### PR DESCRIPTION
The unspecific catch in

    try:
        rule = reaction_note_dict['GENE ASSOCIATION'][0].encode('ascii')
        if rule.startswith("&quot;") and rule.endswith("&quot;"):
            rule = rule[6:-6]
        reaction.gene_reaction_rule = str(rule)
    except:
        warn("gene_reaction_rule is not ascii compliant")

hid the problem that `str.encode` returns byte in python3 letting

    TypeError: startswith first arg must be bytes or a tuple of bytes, not str

go silent.

I reorganized the code a little and made the exception catch `UnicodeEncodeError` (is that what it should catch?) specifically to avoid further problems.