### PR TITLE
core element cleanup - all have id and name

### DIFF
--- a/cobra/core/Gene.py
+++ b/cobra/core/Gene.py
@@ -118,7 +118,7 @@ def parse_gpr(str_expr):
 
 class Gene(Species):
 
-    def __init__(self, id, name=None, functional=True):
+    def __init__(self, id=id, name=None, functional=True):
         """
         id: A string.
 
@@ -129,7 +129,7 @@ class Gene(Species):
         can its products be used.
 
         """
-        Species.__init__(self, id, name=name)
+        Species.__init__(self, id=id, name=name)
         self.functional = functional
 
     def remove_from_model(self, model=None,

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -27,13 +27,17 @@ class Model(Object):
         for y in ['reactions', 'genes', 'metabolites']:
             for x in getattr(self, y):
                 x._model = self
+        if not hasattr(self, "name"):
+            self.name = None
 
-    def __init__(self, description=None):
-        if isinstance(description, Model):
-            self.__dict__ = description.__dict__
+    def __init__(self, id_or_model=None, name=None):
+        if isinstance(id_or_model, Model):
+            Object.__init__(self, name=name)
+            self.__setstate__(id_or_model.__dict__)
+            if not hasattr(self, "name"):
+                self.name = None
         else:
-            Object.__init__(self, description)
-            self.description = self.id
+            Object.__init__(self, id_or_model, name=name)
             self._trimmed = False
             self._trimmed_genes = []
             self._trimmed_reactions = {}
@@ -43,6 +47,16 @@ class Model(Object):
             # genes based on their ids {Gene.id: Gene}
             self.compartments = {}
             self.solution = Solution(None)
+
+    @property
+    def description(self):
+        warn("description deprecated")
+        return self.name if self.name is not None else ""
+
+    @description.setter
+    def description(self, value):
+        self.name = value
+        warn("description deprecated")
 
     def __add__(self, other_model):
         """Adds two models. +

--- a/cobra/core/Object.py
+++ b/cobra/core/Object.py
@@ -4,17 +4,14 @@ from six import iteritems
 class Object(object):
     """Defines common behavior of object in cobra.core"""
 
-    def __init__(self, id=None, mnx_id=None):
+    def __init__(self, id=None, name=None):
         """
         id: None or a string
 
-        mnx_id: None or a String of the MetaNetX.org ID for the Object
         """
         self.id = id
-        self.mnx_id = mnx_id
-        # The following two fields will eventually
-        # be objects that enforce basic rules about
-        # formatting notes and annotation
+        self.name = name
+
         self.notes = {}
         self.annotation = {}
 
@@ -24,38 +21,6 @@ class Object(object):
         if '_model' in state:
             state['_model'] = None
         return state
-
-    def guided_copy(self):
-        """.. deprecated :: 0.3 use copy direclty"""
-        the_copy = self.__class__(self.id)
-        for k, v in iteritems(self.__dict__):
-            # Don't try to set properties
-            if not isinstance(getattr(type(self), k, None), property):
-                setattr(the_copy, k, v)
-        return(the_copy)
-
-    def _copy_parent_attributes(self, gene_object):
-        """Helper function for shallow copying attributes from a parent object
-        into a new child object.
-
-        """
-        for k, v in iteritems(gene_object.__dict__):
-            setattr(self, k, v)
-
-    def startswith(self, x):
-        return self.id.startswith(x)
-
-    def endswith(self, x):
-        return self.id.endswith(x)
-
-    def __contains__(self, x):
-        return self.id.__contains__(x)
-
-    def __getitem__(self, index):
-        return self.id[index]
-
-    def __getslice__(self, i, j):
-        return self.id[i:j]
 
     def __repr__(self):
         return "<%s %s at 0x%x>" % (self.__class__.__name__, self.id, id(self))

--- a/cobra/core/Species.py
+++ b/cobra/core/Species.py
@@ -17,10 +17,7 @@ class Species(Object):
         name: String.  A human readable name.
 
         """
-        Object.__init__(self, id)
-        self.name = name
-        if not name:
-            self.name = self.id
+        Object.__init__(self, id, name)
         self._model = None
         # references to reactions that operate on this species
         self._reaction = set()
@@ -47,16 +44,6 @@ class Species(Object):
         This should be fixed with self.__deecopy__ if possible
         """
         return deepcopy(self)
-
-    def get_reaction(self):
-        """Returns a list of Reactions that contain this Species"""
-        warn("deprecated, used species.reactions instead")
-        return list(self._reaction)
-
-    def get_model(self):
-        """Returns the Model object that contain this Object"""
-        print("get_model is deprecated. used model property instead")
-        return self._model
 
     @property
     def model(self):

--- a/cobra/io/json.py
+++ b/cobra/io/json.py
@@ -43,7 +43,8 @@ _OPTIONAL_GENE_ATTRIBUTES = {
 }
 
 _OPTIONAL_MODEL_ATTRIBUTES = {
-    "description": None,
+    "name": None,
+    #  "description": None, should not actually be included
     "compartments": {},
     "notes": {},
     "annotation": {},
@@ -100,7 +101,7 @@ def _from_dict(obj):
         new_reactions.append(new_reaction)
     model.add_reactions(new_reactions)
     for k, v in iteritems(obj):
-        if k in {'id', 'description', 'notes', 'compartments', 'annotation'}:
+        if k in {'id', 'name', 'notes', 'compartments', 'annotation'}:
             setattr(model, k, v)
     return model
 
@@ -143,8 +144,8 @@ def _to_dict(model):
            'metabolites': new_metabolites,
            'genes': new_genes,
            'id': model.id,
-           'description': model.description,
            }
+
     _update_optional(model, obj, _OPTIONAL_MODEL_ATTRIBUTES)
     # add in the JSON version
     obj["version"] = 1
@@ -213,6 +214,7 @@ json_schema = {
     "type": "object",
     "properties": {
         "id": {"type": "string"},
+        "name": {"type": "string"},
         "description": {"type": "string"},
         "version": {
             "type": "integer",

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -84,7 +84,7 @@ def save_matlab_model(model, file_name):
 
     """
     mat = create_mat_dict(model)
-    savemat(file_name, {str(model.description): mat},
+    savemat(file_name, {str(model.id): mat},
             appendmat=True, oned_as="column")
 
 
@@ -111,7 +111,7 @@ def create_mat_dict(model):
     mat["b"] = array(mets.list_attr("_bound")) * 1.
     mat["c"] = array(rxns.list_attr("objective_coefficient")) * 1.
     mat["rev"] = array(rxns.list_attr("reversibility")) * 1
-    mat["description"] = str(model.description)
+    mat["description"] = str(model.id)
     return mat
 
 
@@ -138,7 +138,6 @@ def from_mat_struct(mat_struct, model_id=None):
         model.id = model_id
     else:
         model.id = "imported_model"
-    model.description = model.id
     for i, name in enumerate(m["mets"][0, 0]):
         new_metabolite = Metabolite()
         new_metabolite.id = str(name[0][0])

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -294,7 +294,7 @@ def create_cobra_model_from_sbml_file(sbml_filename, old_sbml=False, legacy_meta
 
 
     #Now, add all of the reactions to the model.
-    cobra_model.description = sbml_model.getId()
+    cobra_model.id = sbml_model.getId()
     #Populate the compartment list - This will be done based on cobra.Metabolites
     #in cobra.Reactions in the future.
     cobra_model.compartments = compartment_dict
@@ -364,7 +364,7 @@ def write_cobra_model_to_sbml_file(cobra_model, sbml_filename,
         
     
     sbml_doc = SBMLDocument(sbml_level, sbml_version)
-    sbml_model = sbml_doc.createModel(cobra_model.description.split('.')[0])
+    sbml_model = sbml_doc.createModel(cobra_model.id.split('.')[0])
     #Note need to set units
     reaction_units = 'mmol_per_gDW_per_hr'
     model_units = sbml_model.createUnitDefinition()

--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -263,6 +263,7 @@ def parse_xml_into_model(xml, number=float):
 
     model_id = get_attrib(xml_model, "id")
     model = Model(model_id)
+    model.name = xml_model.get("name")
 
     model.compartments = {c.get("id"): c.get("name") for c in
                           xml_model.findall(COMPARTMENT_XPATH)}
@@ -381,6 +382,8 @@ def model_to_xml(cobra_model, units=True):
     set_attrib(xml_model, "fbc:strict", "true")
     if cobra_model.id is not None:
         xml_model.set("id", cobra_model.id)
+    if cobra_model.name is not None:
+        xml_model.set("name", cobra_model.name)
 
     # if using units, add in mmol/gdw/hr
     if units:

--- a/documentation_builder/io.ipynb
+++ b/documentation_builder/io.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Reading and Writing Models\n",
     "\n",
-    "Cobrapy supports reading and writing models in SBML (with and without FBC), JSON, MAT, and pickle formats. Generally, SBML with FBC is the preferred format for general use.\n",
+    "Cobrapy supports reading and writing models in SBML (with and without FBC), JSON, MAT, and pickle formats. Generally, SBML with FBC version 2 is the preferred format for general use. The JSON format may be more useful for cobrapy-specific functionality.\n",
     "\n",
     "The package also ships with test models in various formats for testing purposes."
    ]
@@ -23,7 +23,7 @@
      "output_type": "stream",
      "text": [
       "mini test files: \n",
-      "mini.mat, mini_cobra.xml, mini.json, mini_fbc2.xml, mini_fbc1.xml, mini.pickle\n"
+      "mini.mat, mini_cobra.xml, mini.json, mini_fbc2.xml.gz, mini_fbc2.xml.bz2, mini_fbc2.xml, mini_fbc1.xml, mini.pickle\n"
      ]
     }
    ],
@@ -65,7 +65,7 @@
     {
      "data": {
       "text/plain": [
-       "<Model mini_textbook at 0x7f82fc4aec90>"
+       "<Model mini_textbook at 0x7f35fc0de3d0>"
       ]
      },
      "execution_count": 2,
@@ -107,7 +107,7 @@
     {
      "data": {
       "text/plain": [
-       "<Model mini_textbook at 0x7f82cc744c10>"
+       "<Model mini_textbook at 0x7f35c46c7990>"
       ]
      },
      "execution_count": 4,
@@ -136,7 +136,7 @@
    "source": [
     "## JSON\n",
     "\n",
-    "cobrapy models have a [JSON](https://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) representation. This format was crated for interoperability with [escher](https://escher.github.io). Additional fields, however, will not be saved."
+    "cobrapy models have a [JSON](https://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) representation. This format was crated for interoperability with [escher](https://escher.github.io)."
    ]
   },
   {
@@ -149,7 +149,7 @@
     {
      "data": {
       "text/plain": [
-       "<Model mini_textbook at 0x7f82fc4d4f50>"
+       "<Model mini_textbook at 0x7f35c46dcd50>"
       ]
      },
      "execution_count": 6,
@@ -198,7 +198,7 @@
     {
      "data": {
       "text/plain": [
-       "<Model mini_textbook at 0x7f82cc97b110>"
+       "<Model mini_textbook at 0x7f35c46dcc90>"
       ]
      },
      "execution_count": 8,
@@ -228,7 +228,7 @@
     {
      "data": {
       "text/plain": [
-       "<Model mini_textbook at 0x7f82fc4d4450>"
+       "<Model mini_textbook at 0x7f35c46dcb90>"
       ]
      },
      "execution_count": 9,
@@ -269,26 +269,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cobra models can be serialized using the python serialization format, [pickle](https://docs.python.org/2/library/pickle.html). While this will save any extra fields which may have been created, it does not work with any other tools and can break between cobrapy major versions. JSON, SBML, and MAT are generally the preferred format."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from pickle import load, dump\n",
+    "Cobra models can be serialized using the python serialization format, [pickle](https://docs.python.org/2/library/pickle.html).\n",
     "\n",
-    "# read in the test models\n",
-    "with open(os.path.join(cobra.test.data_directory, \"mini.pickle\"), \"rb\") as infile:\n",
-    "    mini_model = load(infile)\n",
-    "\n",
-    "# output to a file\n",
-    "with open(\"test.pickle\", \"wb\") as outfile:\n",
-    "    dump(textbook_model, outfile)"
+    "Please note that use of the pickle format is generally not recommended for most use cases. JSON, SBML, and MAT are generally the preferred formats."
    ]
   }
  ],


### PR DESCRIPTION
This is more consistent (Model.description instead of Model.name was
arbitrary and confusing). This is also more consistent with SBML.

Model.description is still available as a property for compatibility
reasons, but it will raise a warning when accessed.

Some deprecated methods for core classes were also finally removed.

The I/O has been updated to account for the description attribute being
replaced by name.

This fixes #175