### PR TITLE
add kegg_ids fetching in sbml 2 legacy

### DIFF
--- a/cobra/core/Metabolite.py
+++ b/cobra/core/Metabolite.py
@@ -36,7 +36,7 @@ class Metabolite(Species):
         # because in a Model a metabolite may participate in multiple Reactions
         self.compartment = compartment
         self.charge = None
-
+        self.kegg_ids = None
         self._constraint_sense = 'E'
         self._bound = 0.
 


### PR DESCRIPTION
Just add attribute (a set) to metabolite to store KEGG_IDS. 

Could be applied to reaction if we can retrieve KEGG reaction id in the sbml file (may have another implementation like inheritance). 

Work only for sbml2 legacy.