### PR TITLE
Fix error message for empty model

### DIFF
--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -415,12 +415,11 @@ def model_to_xml(cobra_model, units=True):
     # the most common bounds are the minimum, maxmium, and 0
     try:
         min_value = min(cobra_model.reactions.list_attr("lower_bound"))
-    except ValueError:
-        min_value = -1000
-    try:
         max_value = max(cobra_model.reactions.list_attr("upper_bound"))
     except ValueError:
         max_value = 1000
+        min_value = -1000
+
     SubElement(parameter_list, "parameter", value=strnum(min_value),
                id="cobra_default_lb", sboTerm="SBO:0000626", **param_attr)
     SubElement(parameter_list, "parameter", value=strnum(max_value),

--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -413,8 +413,14 @@ def model_to_xml(cobra_model, units=True):
     if units:
         param_attr["units"] = "mmol_per_gDW_per_hr"
     # the most common bounds are the minimum, maxmium, and 0
-    min_value = min(cobra_model.reactions.list_attr("lower_bound"))
-    max_value = max(cobra_model.reactions.list_attr("upper_bound"))
+    try:
+        min_value = min(cobra_model.reactions.list_attr("lower_bound"))
+    except ValueError:
+        min_value = -1000
+    try:
+        max_value = max(cobra_model.reactions.list_attr("upper_bound"))
+    except ValueError:
+        max_value = 1000
     SubElement(parameter_list, "parameter", value=strnum(min_value),
                id="cobra_default_lb", sboTerm="SBO:0000626", **param_attr)
     SubElement(parameter_list, "parameter", value=strnum(max_value),


### PR DESCRIPTION
Saving a model without a reaction added results in a ValueError from min/max