### PR TITLE
test saving empty models and fix for mat

### DIFF
--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -108,7 +108,7 @@ def create_mat_dict(model):
     mat["rxnNames"] = _cell(rxns.list_attr("name"))
     mat["subSystems"] = _cell(rxns.list_attr("subsystem"))
     mat["csense"] = "".join(model._constraint_sense)
-    mat["S"] = model.S
+    mat["S"] = model.S if model.S is not None else [[]]
     # multiply by 1 to convert to float, working around scipy bug
     # https://github.com/scipy/scipy/issues/4537
     mat["lb"] = array(rxns.list_attr("lower_bound")) * 1.

--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -413,8 +413,13 @@ def model_to_xml(cobra_model, units=True):
     if units:
         param_attr["units"] = "mmol_per_gDW_per_hr"
     # the most common bounds are the minimum, maxmium, and 0
-    min_value = min(cobra_model.reactions.list_attr("lower_bound"))
-    max_value = max(cobra_model.reactions.list_attr("upper_bound"))
+    if len(cobra_model.reactions) > 0:
+        min_value = min(cobra_model.reactions.list_attr("lower_bound"))
+        max_value = max(cobra_model.reactions.list_attr("upper_bound"))
+    else:
+        min_value = -1000
+        max_value = 1000
+
     SubElement(parameter_list, "parameter", value=strnum(min_value),
                id="cobra_default_lb", sboTerm="SBO:0000626", **param_attr)
     SubElement(parameter_list, "parameter", value=strnum(max_value),

--- a/cobra/test/io_tests.py
+++ b/cobra/test/io_tests.py
@@ -94,6 +94,16 @@ class TestCobraIO(object):
         self.validate(test_output_filename)
         unlink(test_output_filename)
 
+    def test_write_empty(self):
+        test_output_filename = join(gettempdir(), split(self.test_file)[-1])
+        m = self.test_model.copy()
+        m.remove_reactions(list(m.reactions))
+        self.write_function(m, test_output_filename)
+        reread_model = self.read_function(test_output_filename)
+        self.assertEqual(len(reread_model.reactions), 0)
+        self.assertEqual(len(reread_model.metabolites), len(m.metabolites))
+        unlink(test_output_filename)
+
     def validate(self, filename):
         # overload if a validator exists
         None


### PR DESCRIPTION
This tests for the bug reported in #187 for all I/O formats. It also
includes a fix for the mat file format.