### PR TITLE
Import izip from itertools for older python versions

### DIFF
--- a/cobra/solvers/glpk_solver.py
+++ b/cobra/solvers/glpk_solver.py
@@ -2,7 +2,11 @@
 #This script provides wrappers for pyglpk 0.3
 from warnings import warn
 from copy import deepcopy
-from itertools import izip
+try:
+    # Import izip for python versions < 3.x
+    from itertools import izip as zip
+except ImportError:
+    pass
 
 from glpk import LPX
 
@@ -79,7 +83,7 @@ def create_problem(cobra_model, **kwargs):
     lp.rows.add(len(cobra_model.metabolites))
     lp.cols.add(len(cobra_model.reactions))
 
-    for r, the_metabolite in izip(lp.rows, cobra_model.metabolites):
+    for r, the_metabolite in zip(lp.rows, cobra_model.metabolites):
         r.name = the_metabolite.id
         b = float(the_metabolite._bound)
         c = the_metabolite._constraint_sense
@@ -94,7 +98,7 @@ def create_problem(cobra_model, **kwargs):
 
     objective_coefficients = []
     linear_constraints = []
-    for c, the_reaction in izip(lp.cols, cobra_model.reactions):
+    for c, the_reaction in zip(lp.cols, cobra_model.reactions):
         c.name = the_reaction.id
         c.kind = variable_kind_dict[the_reaction.variable_kind]
         c.bounds = the_reaction.lower_bound, the_reaction.upper_bound

--- a/cobra/solvers/gurobi_solver.py
+++ b/cobra/solvers/gurobi_solver.py
@@ -1,7 +1,11 @@
 # Interface to gurobipy
 
 from warnings import warn
-from itertools import izip
+try:
+    # Import izip for python versions < 3.x
+    from itertools import izip as zip
+except ImportError:
+    pass
 
 from gurobipy import Model, LinExpr, GRB, QuadExpr
 
@@ -82,13 +86,13 @@ def format_solution(lp, cobra_model, **kwargs):
     else:
         objective_value = lp.ObjVal
         x = [v.X for v in lp.getVars()]
-        x_dict = {r.id: value for r, value in izip(cobra_model.reactions, x)}
+        x_dict = {r.id: value for r, value in zip(cobra_model.reactions, x)}
         if lp.isMIP:
             y = y_dict = None  # MIP's don't have duals
         else:
             y = [c.Pi for c in lp.getConstrs()]
             y_dict = {m.id: value for m, value
-                      in izip(cobra_model.metabolites, y)}
+                      in zip(cobra_model.metabolites, y)}
         the_solution = Solution(objective_value, x=x, x_dict=x_dict, y=y,
                                 y_dict=y_dict, status=status)
     return(the_solution)


### PR DESCRIPTION
izip is no longer present in python versions >3 as zip now has the same functionality and therefore leads to an ImportError for those versions.