### PR TITLE
OptKnock and related functions

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -20,7 +20,7 @@ from .version import get_version
 __version__ = get_version()
 from .core import Object, Metabolite, Gene, Reaction, Model, \
     DictList, Species
-from . import io, flux_analysis
+from . import io, flux_analysis, design
 
 try:
     from .core import ArrayBasedModel

--- a/cobra/design/__init__.py
+++ b/cobra/design/__init__.py
@@ -1,0 +1,1 @@
+from .design_algorithms import *

--- a/cobra/design/design_algorithms.py
+++ b/cobra/design/design_algorithms.py
@@ -5,8 +5,99 @@ from six import iteritems
 from collections import defaultdict
 
 
-def dual_problem(model, already_irreversible=False, copy=True,
-                 variable_max=1000):
+def _add_decision_variable(model, reaction_id):
+    """Add an integer decision variable for the given reaction."""
+    reaction = model.reactions.get_by_id(reaction_id)
+    # add integer variable
+    var = Reaction("%s_decision_var" % reaction_id)
+    var.lower_bound = 0
+    var.upper_bound = 1
+    var.variable_kind = "integer"
+    model.add_reaction(var)
+    # add constraints
+    # v <= ub * y  -->  v - ub * y <= 0
+    ub_constr = Metabolite("%s_upper_bound" % var.id)
+    ub_constr._constraint_sense = "L"
+    # v >= lb * y  -->  v - lb * y >= 0
+    lb_constr = Metabolite("%s_lower_bound" % var.id)
+    lb_constr._constraint_sense = "G"
+    reaction.add_metabolites({ lb_constr: 1, ub_constr: 1 })
+    var.add_metabolites({ lb_constr: - reaction.lower_bound,
+                          ub_constr: - reaction.upper_bound })
+    return var
+
+
+def optknock(model, chemical_objective, knockable_reactions,
+             biomass_objective=None, n_knockouts=5, n_knockouts_required=True,
+             dual_maximum=1000, copy=True):
+    """Run the OptKnock algorithm described by Burgard et al., 2003:
+
+        Burgard AP, Pharkya P, Maranas CD. Optknock: a bilevel programming
+        framework for identifying gene knockout strategies for microbial strain
+        optimization.  Biotechnol Bioeng. 2003;84(6):647–57. doi:10.1002/bit.10803.
+
+
+    model : :class:`~cobra.core.Model` object.
+
+    chemical_objective: str. The ID of the reaction to Maximize in the outer
+    problem.
+
+    knockable_reactions: [str]. A list of reaction IDs that can be knocked out.
+
+    biomass_objective: str. The ID of the reaction to Maximize in the inner
+    problem. By default, this is the existing objective function in the passed
+    model.
+
+    n_knockouts: int. The number of knockouts allowable.
+
+    n_knockouts_required: bool. Require exactly the number of knockouts
+    specified by n_knockouts.
+
+    dual_maximum: float or int. The upper bound for dual variables.
+
+    copy: bool. Copy the model before making any modifications.
+
+
+    Zachary King 2015
+
+    """
+
+    if copy:
+        model = model.copy()
+
+    # add the integer decision variables
+    decision_variable_ids = [_add_decision_variable(model, r_id).id
+                             for r_id in knockable_reactions]
+
+    # inner problem
+    inner_problem = model.copy()
+    if biomass_objective:
+        found = False
+        for reaction in inner_problem.reactions:
+            obj = reaction.id == biomass_objective
+            reaction.objective_coefficient = 1 if obj else 0
+            if obj:
+                found = True
+        if not found:
+            raise Exception("Could not find biomass_objective %s in model" % biomass_objective)
+
+    # dual of inner problem
+    inner_dual = dual_problem(inner_problem, integer_vars_to_maintain=decision_variable_ids,
+                              already_irreversible=False, copy=False,
+                              dual_maximum=dual_maximum)
+
+    # add constraints and variables from inner problem to outer problem
+    model.add_reactions(inner_dual.reactions)
+
+    # constraint to set outer and inner objectives to be equal
+    equal_objectives_constr = Metabolite("equal_objectives_constr")
+    equal_objectives_constr._constraint_sense = "E"
+
+    raise NotImplementedError
+
+
+def dual_problem(model, integer_vars_to_maintain=[], already_irreversible=False,
+                 copy=True, dual_maximum=1000):
     """Return a new model representing the dual of the model.
 
     Make the problem irreversible, then take the dual. Convert the problem:
@@ -17,7 +108,7 @@ def dual_problem(model, already_irreversible=False, copy=True,
 
         Maximize [objective_coefficients] * [reactions]
             subject to
-                (assuming met._sense is 'E')
+                (assuming met._sense is "E")
                 [coefficients by reaction] * [reactions] <= met._bound
                 - [coefficients by reaction] * [reactions] <= - met._bound
                 [reactions] <= [UB]
@@ -30,21 +121,72 @@ def dual_problem(model, already_irreversible=False, copy=True,
 
     which is something like this in COBRApy:
 
-        Minimize [met._bound's, - met._bound's, UB's, - LB's] * [dual_variables]
+        Minimize [met._bound's, - met._bound's, UB's, - LB's] * [dual_vars]
             subject to
-                [coefficients by metabolite, - coefficients by metabolite, diag, - diag] * [dual_variables] >= [objective_coefficients]
-                [dual_variables] >= 0
+                [coefficients by metabolite, - coefficients by metabolite, diag, - diag] * [dual_vars] >= [objective_coefficients]
+                [dual_vars] >= 0
 
+
+    Arguments
+    ---------
 
     model : :class:`~cobra.core.Model` object.
+
+    iteger_vars_to_maintain: [str]. A list of IDs for Boolean integer variables
+    to be maintained in the dual problem. See 'Maintaining integer variables'
+    below for more details
 
     already_irreversible: Boolean. If True, then do not convert the model to
     irreversible.
 
-    copy: Boolean. If True, then make a copy of the model before modifying
+    copy: bool. If True, then make a copy of the model before modifying
     it. This is not necessary if already_irreversible is True.
 
-    variable_max: Number. The upper bound for dual variables.
+    dual_maximum: float or int. The upper bound for dual variables.
+
+
+    Maintaining integer variables
+    -----------------------------
+
+    The argument integer_vars_to_maintain can be used to specify certin Boolean
+    integer variables that will be maintained in the dual problem. This makes it
+    possible to join outer and inner problems in a bi-level MILP. The method for
+    maintaining integer variables is described by Tepper and Shlomi, 2010:
+
+        Tepper N, Shlomi T. Predicting metabolic engineering knockout strategies
+        for chemical production: accounting for competing pathways. Bioinformatics.
+        2010;26(4):536–43. doi:10.1093/bioinformatics/btp704.
+
+    In COBRApy, this roughly translates to transforming:
+
+        (1) Maximize [objective_coefficients] * [reactions]
+              subject to
+        (2)       [coefficients by reaction] * [reactions] <=   met._bound ("L" or "E")
+        (3)     - [coefficients by reaction] * [reactions] <= - met._bound ("G" or "E")
+        (4)       [reactions] <=   [UB]
+        (5)     - [reactions] <= - [LB]   (these are still necessary because they are attributes of Reaction objects)
+        (6)       [reactions] <=   [decision_vars] .* [UB]   (optional)
+        (7)     - [reactions] <= - [decision_vars] .* [LB]
+        (8)       [reactions decision_vars] >= 0
+
+    to the problem:
+
+        (9) Minimize [met._bound's, - met._bound's, UB's, - LB's] * [dual_vars] + [aux_to_decision] * [auxiliary_vars]
+              subject to
+       (10)       [coefficients by metabolite, - coefficients by metabolite, diag, - diag] * [dual_vars] >= [objective_coefficients]
+       (11)       [auxiliary_vars] - dual_maximum * corresponding([decision_vars]) <= 0
+       (12)     - [auxiliary_vars] + corresponding([dual_vars]) >= 0
+       (13)       [auxiliary_vars] - (corresponding([dual_vars]) - dual_maximum * (1 - correspond([decision_vars]))) >= 0
+       (14)       [dual_vars, auxiliary_vars] >= 0
+
+        aux_to_decision gives the coefficients of the decision_variables that
+        correspond to each auxiliary variable. Auxiliary variables exist for
+        each pair of decision variable and dual for the decision variable
+        constraint.
+
+
+
+    Zachary King 2015
 
     """
 
@@ -55,50 +197,102 @@ def dual_problem(model, already_irreversible=False, copy=True,
             irrev_model = irrev_model.copy()
         convert_to_irreversible(irrev_model)
 
-    # new model
+    # new model for the dual
     dual = Model("%s_dual" % irrev_model.id)
 
-    # keep track of variables
-    dual_vars_for_met = defaultdict(list)
+    # keep track of dual variables for the new
+    dual_vars_for_met = defaultdict(lambda: {"LE": None, "GE": None})
 
     # add variables and objective coefficients
     for metabolite in irrev_model.metabolites:
-        # S v = 0 constraints
-        if metabolite._constraint_sense != "E":
-            raise NotImplementedError("Only metabolite._constraint_sense='E' is supported")
-        b_i = metabolite._bound
+        # add constraints based on metabolite constraint sense
+        sense_tuples = []
+        if metabolite._constraint_sense in ("L", "E"):
+            sense_tuples.append(("LE", 1))
+        if metabolite._constraint_sense in ("G", "E"):
+            sense_tuples.append(("GE", -1))
+        if metabolite._constraint_sense not in ("G", "E", "L"):
+            raise Exception("Bad metabolite._constraint_sense = %s" % metabolite._constraint_sense)
 
-        # stoichiometric matrix dual variables
-        for sense, factor in ("LE", 1), ("GE", -1):
+        # constraints (2-7) to objective (9)
+        for sense, factor in sense_tuples:
             var = Reaction("%s_dual_%s" % (metabolite.id, sense))
-            var.objective_coefficient = factor * b_i
-            # [dual_variables] >= 0
+            # Without auxiliary variables, the objective coefficient would
+            # include integer variables when present (for (6) and (7)). However,
+            # we will separate out the integer parts into the auxiliary variable
+            # objective coefficients.
+            var.objective_coefficient = factor * metabolite._bound
+            # [dual_vars] >= 0
             var.lower_bound = 0
-            var.upper_bound = variable_max
+            var.upper_bound = dual_maximum
             dual.add_reaction(var)
             # remember
-            dual_vars_for_met[metabolite.id].append(var)
+            dual_vars_for_met[metabolite.id][sense] = var
 
     # add constraints and upper & lower bound variables
     for reaction in irrev_model.reactions:
-        # objective function -> constraints
-        constr = Metabolite("%s_dual_constraint" % reaction.id)
-        constr._constraint_sense = "G"
-        constr._bound = reaction.objective_coefficient
-        for met, coeff in iteritems(reaction.metabolites):
-            var_le, var_ge = dual_vars_for_met[met.id]
-            var_le.add_metabolites({ constr: coeff })
-            var_ge.add_metabolites({ constr: - coeff })
+        if reaction.id in integer_vars_to_maintain:
+            # keep these integer variables in the dual, with new transformed
+            # constraints
+            if (reaction.lower_bound not in [0, 1] or
+                    reaction.upper_bound not in [0, 1] or
+                    reaction.variable_kind != "integer"):
+                raise Exception("Reaction %s from integer_vars_to_maintain is not a Boolean integer variable" % reaction.id)
+            decision_var = Reaction(reaction.id)
+            decision_var.upper_bound = reaction.upper_bound
+            decision_var.lower_bound = reaction.lower_bound
+            decision_var.variable_kind = reaction.variable_kind
+            decision_var.objective_coefficient = 0
+            # constraints
+            dual.add_reaction(decision_var)
 
-        for bound_name, factor in ("upper_bound", 1), ("lower_bound", -1):
-            # upper/lower bound constraints -> variables
-            var_bound = Reaction("%s_dual_%s" % (reaction.id, bound_name))
-            var_bound.objective_coefficient = factor * getattr(reaction, bound_name)
-            # [dual_variables] >= 0
-            var_bound.lower_bound = 0
-            var_bound.upper_bound = variable_max
-            # add bound dual variables to dual constraints
-            var_bound.add_metabolites({ constr: factor })
-            dual.add_reaction(var_bound)
+            # add auxiliary variable z_k for each pair y_i, w_j
+            # y_i : reaction (and decision_var)
+            # w_j : dual_vars_for_met[met.id]["LE"] and dual_vars_for_met[met.id]["GE"]
+            # A^y_i,j : coeff
+
+            # get the associated duals
+            for met, coeff in iteritems(reaction.metabolites):
+                duals = dual_vars_for_met[met.id]
+                for var, factor in (duals["LE"], 1), (duals["GE"], -1):
+                    if var is None:
+                        continue
+                    # make the auxiliary variable
+                    aux_var = Reaction("%s_auxiliary" % decision_var.id)
+                    aux_var.lower_bound = 0
+                    aux_var.upper_bound = dual_maximum
+                    aux_var.variable_kind = "continuous"
+                    aux_var.objective_coefficient = factor * coeff
+
+                    # add auxiliary constraints (11-13)
+                    # (11)       [auxiliary_vars] - dual_maximum * corresponding([decision_vars]) <= 0
+                    # (12)     - [auxiliary_vars] + corresponding([dual_vars]) >= 0
+                    # (13)       [auxiliary_vars] - (corresponding([dual_vars]) - dual_maximum * (1 - correspond([decision_vars]))) >= 0
+
+                    raise NotImplementedError
+
+        else:
+            # other variables become constraints, (1) to (10)
+            constr = Metabolite("%s_dual_constraint" % reaction.id)
+            constr._constraint_sense = "G"
+            constr._bound = reaction.objective_coefficient
+            for met, coeff in iteritems(reaction.metabolites):
+                duals = dual_vars_for_met[met.id]
+                var_le, var_ge = duals["LE"], duals["GE"]
+                if var_le is not None:
+                    var_le.add_metabolites({ constr: coeff })
+                if var_ge is not None:
+                    var_ge.add_metabolites({ constr: - coeff })
+
+            for bound_name, factor in ("upper_bound", 1), ("lower_bound", -1):
+                # upper/lower bound constraints -> variables
+                var_bound = Reaction("%s_dual_%s" % (reaction.id, bound_name))
+                var_bound.objective_coefficient = factor * getattr(reaction, bound_name)
+                # [dual_vars] >= 0
+                var_bound.lower_bound = 0
+                var_bound.upper_bound = dual_maximum
+                # add bound dual variables to dual constraints
+                var_bound.add_metabolites({ constr: factor })
+                dual.add_reaction(var_bound)
 
     return dual

--- a/cobra/design/design_algorithms.py
+++ b/cobra/design/design_algorithms.py
@@ -1,0 +1,104 @@
+from ..core import Model, Reaction, Metabolite
+from ..manipulation.modify import convert_to_irreversible
+
+from six import iteritems
+from collections import defaultdict
+
+
+def dual_problem(model, already_irreversible=False, copy=True,
+                 variable_max=1000):
+    """Return a new model representing the dual of the model.
+
+    Make the problem irreversible, then take the dual. Convert the problem:
+
+        Maximize (c^T)x subject to Ax <= b, x >= 0
+
+    which is something like this in COBRApy:
+
+        Maximize [objective_coefficients] * [reactions]
+            subject to
+                (assuming met._sense is 'E')
+                [coefficients by reaction] * [reactions] <= met._bound
+                - [coefficients by reaction] * [reactions] <= - met._bound
+                [reactions] <= [UB]
+                - [reactions] <= - [LB]
+                [reactions] >= 0
+
+    to the problem:
+
+        Minimize (b^T)y subject to (A^T)y >= c, y >= 0
+
+    which is something like this in COBRApy:
+
+        Minimize [met._bound's, - met._bound's, UB's, - LB's] * [dual_variables]
+            subject to
+                [coefficients by metabolite, - coefficients by metabolite, diag, - diag] * [dual_variables] >= [objective_coefficients]
+                [dual_variables] >= 0
+
+
+    model : :class:`~cobra.core.Model` object.
+
+    already_irreversible: Boolean. If True, then do not convert the model to
+    irreversible.
+
+    copy: Boolean. If True, then make a copy of the model before modifying
+    it. This is not necessary if already_irreversible is True.
+
+    variable_max: Number. The upper bound for dual variables.
+
+    """
+
+    # make irreversible and copy
+    irrev_model = model
+    if not already_irreversible:
+        if copy:
+            irrev_model = irrev_model.copy()
+        convert_to_irreversible(irrev_model)
+
+    # new model
+    dual = Model("%s_dual" % irrev_model.id)
+
+    # keep track of variables
+    dual_vars_for_met = defaultdict(list)
+
+    # add variables and objective coefficients
+    for metabolite in irrev_model.metabolites:
+        # S v = 0 constraints
+        if metabolite._constraint_sense != "E":
+            raise NotImplementedError("Only metabolite._constraint_sense='E' is supported")
+        b_i = metabolite._bound
+
+        # stoichiometric matrix dual variables
+        for sense, factor in ("LE", 1), ("GE", -1):
+            var = Reaction("%s_dual_%s" % (metabolite.id, sense))
+            var.objective_coefficient = factor * b_i
+            # [dual_variables] >= 0
+            var.lower_bound = 0
+            var.upper_bound = variable_max
+            dual.add_reaction(var)
+            # remember
+            dual_vars_for_met[metabolite.id].append(var)
+
+    # add constraints and upper & lower bound variables
+    for reaction in irrev_model.reactions:
+        # objective function -> constraints
+        constr = Metabolite("%s_dual_constraint" % reaction.id)
+        constr._constraint_sense = "G"
+        constr._bound = reaction.objective_coefficient
+        for met, coeff in iteritems(reaction.metabolites):
+            var_le, var_ge = dual_vars_for_met[met.id]
+            var_le.add_metabolites({ constr: coeff })
+            var_ge.add_metabolites({ constr: - coeff })
+
+        for bound_name, factor in ("upper_bound", 1), ("lower_bound", -1):
+            # upper/lower bound constraints -> variables
+            var_bound = Reaction("%s_dual_%s" % (reaction.id, bound_name))
+            var_bound.objective_coefficient = factor * getattr(reaction, bound_name)
+            # [dual_variables] >= 0
+            var_bound.lower_bound = 0
+            var_bound.upper_bound = variable_max
+            # add bound dual variables to dual constraints
+            var_bound.add_metabolites({ constr: factor })
+            dual.add_reaction(var_bound)
+
+    return dual

--- a/cobra/design/design_algorithms.py
+++ b/cobra/design/design_algorithms.py
@@ -130,14 +130,27 @@ def set_up_optknock(model, chemical_objective, knockable_reactions,
     return model
 
 
-def run_optknock(optknock_problem, solver=None, **kwargs):
+def run_optknock(optknock_problem, solver=None, tolerance_integer=1e-9,
+                 **kwargs):
     """Run the OptKnock problem created with set_up_optknock.
+
+
+    optknock_problem: :class:`~cobra.core.Model` object. The problem generated
+    by set_up_optknock.
+
+    solver: str. The name of the preferred solver.
+
+    tolerance_integer: float. The integer tolerance for the MILP.
+
+    **kwargs: Keyword arguments are passed to Model.optimize().
 
 
     Zachary King 2015
 
     """
-    solution = optknock_problem.optimize(solver=solver, **kwargs)
+    solution = optknock_problem.optimize(solver=solver,
+                                         tolerance_integer=tolerance_integer,
+                                         **kwargs)
     solution.knockouts = []
     for reaction in optknock_problem.reactions:
         if solution.x_dict.get(reaction.id, None) == 0:

--- a/cobra/manipulation/__init__.py
+++ b/cobra/manipulation/__init__.py
@@ -1,3 +1,3 @@
 from .delete import delete_model_genes, undelete_model_genes, remove_genes
 from .modify import initialize_growth_medium, convert_to_irreversible, \
-    revert_to_reversible, escape_ID
+    revert_to_reversible, escape_ID, canonical_form

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -5,7 +5,7 @@ from ast import NodeTransformer
 
 from six import iteritems
 
-from .. import Reaction
+from .. import Reaction, Metabolite
 from .delete import get_compiled_gene_reaction_rules
 from ..core.Gene import ast2str
 from ..io.sbml3 import _renames
@@ -227,3 +227,73 @@ def revert_to_reversible(cobra_model, update_solution=True):
     if update_solution:
         cobra_model.solution.x_dict = x_dict
         cobra_model.solution.x = [x_dict[r.id] for r in cobra_model.reactions]
+
+
+def canonical_form(model, objective_sense='Maximize',
+                   already_irreversible=False, copy=True):
+    """Return a model (problem in canonical_form).
+
+    Converts a minimization problem to a maximization, makes all variables
+    positive by making reactions irreversible, and converts all constraints to
+    <= constraints.
+
+
+    model: class:`~cobra.core.Model`. The model/problem to convert.
+
+    objective_sense: str. The objective sense of the starting problem, either
+    'Maximize' or 'Minimize'. A minimization problems will be converted to a
+    maximization.
+
+    already_irreversible: bool. If the model is already irreversible, then pass
+    True.
+
+    copy: bool. Copy the model before making any modifications.
+
+    """
+    if copy:
+        model = model.copy()
+
+    if not already_irreversible:
+        convert_to_irreversible(model)
+
+    if objective_sense == "Minimize":
+        # if converting min to max, reverse all the objective coefficients
+        for reaction in model.reactions:
+            reaction.objective_coefficient = - reaction.objective_coefficient
+    elif objective_sense != "Maximize":
+        raise Exception("Invalid objective sense '%s'. Must be 'Minimize' or 'Maximize'." % objective_sense)
+
+    # convert G and E constraints to L constraints
+    for metabolite in model.metabolites:
+        if metabolite._constraint_sense == "G":
+            metabolite._constraint_sense = "L"
+            metabolite._bound = - metabolite._bound
+            for reaction in metabolite.reactions:
+                coeff = reaction.get_coefficient(metabolite)
+                # reverse the coefficient
+                reaction.add_metabolites({ metabolite: -2 * coeff })
+        elif metabolite._constraint_sense == "E":
+            # change existing constraint to L
+            metabolite._constraint_sense = "L"
+            # add new constraint
+            new_constr = Metabolite("%s__GE_constraint" % metabolite.id)
+            new_constr._constraint_sense = "L"
+            new_constr._bound = - metabolite._bound
+            for reaction in metabolite.reactions:
+                coeff = reaction.get_coefficient(metabolite)
+                reaction.add_metabolites({ new_constr: -coeff })
+
+    # convert lower bounds to LE constraints
+    for reaction in model.reactions:
+        if reaction.lower_bound < 0:
+            raise Exception("Bounds of irreversible reactions should be >= 0, for %s" % reaction.id)
+        elif reaction.lower_bound == 0:
+            continue
+        # new constraint for lower bound
+        lb_constr = Metabolite("%s__LB_constraint" % reaction.id)
+        lb_constr._constraint_sense = "L"
+        lb_constr._bound = - reaction.lower_bound
+        reaction.add_metabolites({ lb_constr: -1 })
+        reaction.lower_bound = 0
+
+    return model

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -229,7 +229,7 @@ def revert_to_reversible(cobra_model, update_solution=True):
         cobra_model.solution.x = [x_dict[r.id] for r in cobra_model.reactions]
 
 
-def canonical_form(model, objective_sense='Maximize',
+def canonical_form(model, objective_sense='maximize',
                    already_irreversible=False, copy=True):
     """Return a model (problem in canonical_form).
 
@@ -241,7 +241,7 @@ def canonical_form(model, objective_sense='Maximize',
     model: class:`~cobra.core.Model`. The model/problem to convert.
 
     objective_sense: str. The objective sense of the starting problem, either
-    'Maximize' or 'Minimize'. A minimization problems will be converted to a
+    'maximize' or 'minimize'. A minimization problems will be converted to a
     maximization.
 
     already_irreversible: bool. If the model is already irreversible, then pass
@@ -256,12 +256,12 @@ def canonical_form(model, objective_sense='Maximize',
     if not already_irreversible:
         convert_to_irreversible(model)
 
-    if objective_sense == "Minimize":
+    if objective_sense == "minimize":
         # if converting min to max, reverse all the objective coefficients
         for reaction in model.reactions:
             reaction.objective_coefficient = - reaction.objective_coefficient
-    elif objective_sense != "Maximize":
-        raise Exception("Invalid objective sense '%s'. Must be 'Minimize' or 'Maximize'." % objective_sense)
+    elif objective_sense != "maximize":
+        raise Exception("Invalid objective sense '%s'. Must be 'minimize' or 'maximize'." % objective_sense)
 
     # convert G and E constraints to L constraints
     for metabolite in model.metabolites:

--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -10,7 +10,8 @@ except:
 from ..io import read_sbml_model
 
 
-available_tests = ['unit_tests', 'solvers', 'flux_analysis', 'io_tests']
+available_tests = ['unit_tests', 'solvers', 'flux_analysis', 'io_tests',
+                   'design']
 
 
 cobra_directory = abspath(join(dirname(abspath(__file__)), ".."))

--- a/cobra/test/design.py
+++ b/cobra/test/design.py
@@ -1,0 +1,35 @@
+from unittest import TestCase, TestLoader, TextTestRunner
+
+import sys
+
+if __name__ == "__main__":
+    sys.path.insert(0, "../..")
+    from cobra.test import create_test_model, data_directory
+    from cobra.design import *
+    sys.path.pop(0)
+else:
+    from . import create_test_model, data_directory
+    from ..design import *
+
+
+class TestDesignAlgorithms(TestCase):
+    """Test functions in cobra.design"""
+
+    def test_dual(self):
+        model = create_test_model("textbook")
+        dual = dual_problem(model)
+        self.assertAlmostEqual(dual.optimize('Minimize').f,
+                               model.optimize('Maximize').f,
+                               places=3)
+
+
+# make a test suite to run all of the tests
+loader = TestLoader()
+suite = loader.loadTestsFromModule(sys.modules[__name__])
+
+
+def test_all():
+    TextTestRunner(verbosity=2).run(suite)
+
+if __name__ == "__main__":
+    test_all()

--- a/cobra/test/design.py
+++ b/cobra/test/design.py
@@ -7,11 +7,13 @@ if __name__ == "__main__":
     from cobra.test import create_test_model, data_directory
     from cobra.design import *
     from cobra.design.design_algorithms import _add_decision_variable
+    from cobra.solvers import get_solver_name
     sys.path.pop(0)
 else:
     from . import create_test_model, data_directory
     from ..design import *
     from ..design.design_algorithms import _add_decision_variable
+    from ..solvers import get_solver_name
 
 try:
     solver = get_solver_name(mip=True)
@@ -26,57 +28,54 @@ class TestDesignAlgorithms(TestCase):
 
     def test_dual(self):
         model = create_test_model("textbook")
-        self.assertAlmostEqual(model.optimize("Maximize").f, 0.874, places=3)
+        self.assertAlmostEqual(model.optimize("maximize").f, 0.874, places=3)
         dual = dual_problem(model)
-        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.874, places=3)
 
     def test_dual_integer_vars_as_lp(self):
         model = create_test_model("textbook")
-        var = _add_decision_variable(model, "GAPD")
-        self.assertAlmostEqual(model.optimize("Maximize").f, 0.874, places=3)
+        var = _add_decision_variable(model, "AKGDH")
+        self.assertAlmostEqual(model.optimize("maximize").f, 0.874, places=3)
         # as lp: make integer continuous, set to 1
-        dual = dual_problem(model, "Maximize", [var.id], copy=True)
+        dual = dual_problem(model, "maximize", [var.id], copy=True)
         r = dual.reactions.get_by_id(var.id)
-        r.lower_bound = r.upper_bound = 1
         r.variable_kind = "continuous"
-        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+        r.lower_bound = r.upper_bound = 1
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.874, places=3)
+        r.lower_bound = r.upper_bound = 0
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.858, places=3)
 
     @skipIf(no_mip_solver, "no MILP solver found")
     def test_dual_integer_vars_as_mip(self):
-        try:
-            solver = get_solver_name(mip=True)
-        except:
-            raise Exception("no MILP solver found")
-
+        # mip
         model = create_test_model("textbook")
-        var = _add_decision_variable(model, "GAPD")
-        dual = dual_problem(model, "Maximize", [var.id], copy=True)
+        var = _add_decision_variable(model, "AKGDH")
+        dual = dual_problem(model, "maximize", [var.id], copy=True)
         var_in_dual = dual.reactions.get_by_id(var.id)
 
-        # turn off GAPD in model
-        var.lower_bound = var.upper_bound = 0
-        self.assertAlmostEqual(model.optimize("Maximize", presolve=True).f, 0.0, places=3)
-        # should not affect copied dual problem
-        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.874, places=3)
+        # minimization, so the optimal value state is to turn off AKGDH
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.858, places=3)
 
-        # turn off GAPD in dual
+        # turn off AKGDH in dual
         var_in_dual.lower_bound = var_in_dual.upper_bound = 1
-        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.874, places=3)
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.874, places=3)
 
-        # turn on GAPD in dual
+        # turn on AKGDH in dual
         var_in_dual.lower_bound = var_in_dual.upper_bound = 0
-        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.0, places=3)
+        self.assertAlmostEqual(dual.optimize("minimize").f, 0.858, places=3)
 
     @skipIf(no_mip_solver, "no MILP solver found")
     def test_optknock(self):
         model = create_test_model("textbook")
-        knockable_reactions = ["ACKr", "AKGDH", "ACALD", "LDH_L"]
-        optknock_problem = set_up_optknock(model, "EX_lac__L_e",
-                                           model.reactions, n_knockouts=2,
+        model.reactions.get_by_id("EX_o2_e").lower_bound = 0
+        knockable_reactions = ["ACKr", "AKGDH", "ACALD", "LDH_D"]
+        optknock_problem = set_up_optknock(model, "EX_lac__D_e",
+                                           knockable_reactions, n_knockouts=2,
                                            copy=False)
-        solution = run_optknock()
+        solution = run_optknock(optknock_problem)
         self.assertIn("ACKr", solution.knockouts)
         self.assertIn("ACALD", solution.knockouts)
+        self.assertAlmostEqual(solution.f, 17.891, places=3)
 
 # make a test suite to run all of the tests
 loader = TestLoader()

--- a/cobra/test/design.py
+++ b/cobra/test/design.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, TestLoader, TextTestRunner
+from unittest import TestCase, TestLoader, TextTestRunner, skipIf
 
 import sys
 
@@ -13,6 +13,13 @@ else:
     from ..design import *
     from ..design.design_algorithms import _add_decision_variable
 
+try:
+    solver = get_solver_name(mip=True)
+except:
+    no_mip_solver = True
+else:
+    no_mip_solver = False
+
 
 class TestDesignAlgorithms(TestCase):
     """Test functions in cobra.design"""
@@ -23,26 +30,53 @@ class TestDesignAlgorithms(TestCase):
         dual = dual_problem(model)
         self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
 
-    def test_dual_integer_vars(self):
+    def test_dual_integer_vars_as_lp(self):
         model = create_test_model("textbook")
         var = _add_decision_variable(model, "GAPD")
         self.assertAlmostEqual(model.optimize("Maximize").f, 0.874, places=3)
-        dual = dual_problem(model, [var.id])
+        # as lp: make integer continuous, set to 1
+        dual = dual_problem(model, "Maximize", [var.id], copy=True)
+        r = dual.reactions.get_by_id(var.id)
+        r.lower_bound = r.upper_bound = 1
+        r.variable_kind = "continuous"
         self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
 
-    def test_dual_integer_vars_knockout(self):
+    @skipIf(no_mip_solver, "no MILP solver found")
+    def test_dual_integer_vars_as_mip(self):
+        try:
+            solver = get_solver_name(mip=True)
+        except:
+            raise Exception("no MILP solver found")
+
         model = create_test_model("textbook")
         var = _add_decision_variable(model, "GAPD")
-        dual = dual_problem(model, [var.id], copy=True)
+        dual = dual_problem(model, "Maximize", [var.id], copy=True)
+        var_in_dual = dual.reactions.get_by_id(var.id)
+
         # turn off GAPD in model
-        var.upper_bound = 0
-        self.assertAlmostEqual(model.optimize("Maximize").f, 0.0, places=3)
-        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+        var.lower_bound = var.upper_bound = 0
+        self.assertAlmostEqual(model.optimize("Maximize", presolve=True).f, 0.0, places=3)
+        # should not affect copied dual problem
+        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.874, places=3)
+
         # turn off GAPD in dual
-        dual.reactions.get_by_id("GAPD_decision_var").upper_bound = 0
-        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.0, places=3)
+        var_in_dual.lower_bound = var_in_dual.upper_bound = 1
+        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.874, places=3)
 
+        # turn on GAPD in dual
+        var_in_dual.lower_bound = var_in_dual.upper_bound = 0
+        self.assertAlmostEqual(dual.optimize("Minimize", presolve=True).f, 0.0, places=3)
 
+    @skipIf(no_mip_solver, "no MILP solver found")
+    def test_optknock(self):
+        model = create_test_model("textbook")
+        knockable_reactions = ["ACKr", "AKGDH", "ACALD", "LDH_L"]
+        optknock_problem = set_up_optknock(model, "EX_lac__L_e",
+                                           model.reactions, n_knockouts=2,
+                                           copy=False)
+        solution = run_optknock()
+        self.assertIn("ACKr", solution.knockouts)
+        self.assertIn("ACALD", solution.knockouts)
 
 # make a test suite to run all of the tests
 loader = TestLoader()

--- a/cobra/test/design.py
+++ b/cobra/test/design.py
@@ -6,10 +6,12 @@ if __name__ == "__main__":
     sys.path.insert(0, "../..")
     from cobra.test import create_test_model, data_directory
     from cobra.design import *
+    from cobra.design.design_algorithms import _add_decision_variable
     sys.path.pop(0)
 else:
     from . import create_test_model, data_directory
     from ..design import *
+    from ..design.design_algorithms import _add_decision_variable
 
 
 class TestDesignAlgorithms(TestCase):
@@ -17,10 +19,29 @@ class TestDesignAlgorithms(TestCase):
 
     def test_dual(self):
         model = create_test_model("textbook")
+        self.assertAlmostEqual(model.optimize("Maximize").f, 0.874, places=3)
         dual = dual_problem(model)
-        self.assertAlmostEqual(dual.optimize('Minimize').f,
-                               model.optimize('Maximize').f,
-                               places=3)
+        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+
+    def test_dual_integer_vars(self):
+        model = create_test_model("textbook")
+        var = _add_decision_variable(model, "GAPD")
+        self.assertAlmostEqual(model.optimize("Maximize").f, 0.874, places=3)
+        dual = dual_problem(model, [var.id])
+        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+
+    def test_dual_integer_vars_knockout(self):
+        model = create_test_model("textbook")
+        var = _add_decision_variable(model, "GAPD")
+        dual = dual_problem(model, [var.id], copy=True)
+        # turn off GAPD in model
+        var.upper_bound = 0
+        self.assertAlmostEqual(model.optimize("Maximize").f, 0.0, places=3)
+        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.874, places=3)
+        # turn off GAPD in dual
+        dual.reactions.get_by_id("GAPD_decision_var").upper_bound = 0
+        self.assertAlmostEqual(dual.optimize("Minimize").f, 0.0, places=3)
+
 
 
 # make a test suite to run all of the tests

--- a/cobra/test/design.py
+++ b/cobra/test/design.py
@@ -72,7 +72,7 @@ class TestDesignAlgorithms(TestCase):
         optknock_problem = set_up_optknock(model, "EX_lac__D_e",
                                            knockable_reactions, n_knockouts=2,
                                            copy=False)
-        solution = run_optknock(optknock_problem)
+        solution = run_optknock(optknock_problem, tolerance_integer=1e-9)
         self.assertIn("ACKr", solution.knockouts)
         self.assertIn("ACALD", solution.knockouts)
         self.assertAlmostEqual(solution.f, 17.891, places=3)

--- a/cobra/test/manipulation.py
+++ b/cobra/test/manipulation.py
@@ -1,0 +1,54 @@
+from unittest import TestCase, TestLoader, TextTestRunner
+
+import sys
+
+if __name__ == "__main__":
+    sys.path.insert(0, "../..")
+    from cobra.test import create_test_model, data_directory
+    from cobra.core import Metabolite
+    from cobra.manipulation import *
+    sys.path.pop(0)
+else:
+    from . import create_test_model, data_directory
+    from ..core import Metabolite
+    from ..manipulation import *
+
+
+class TestManipulation(TestCase):
+    """Test functions in cobra.manipulation"""
+
+    def test_canonical_form(self):
+        model = create_test_model("textbook")
+        # add G constraint to test
+        g_constr = Metabolite("SUCCt2_2__test_G_constraint")
+        g_constr._constraint_sense = "G"
+        g_constr._bound = 5.0
+        model.reactions.get_by_id("SUCCt2_2").add_metabolites({ g_constr: 1 })
+        self.assertAlmostEqual(model.optimize("Maximize").f, 0.855, places=3)
+        # convert to canonical form
+        model = canonical_form(model)
+        self.assertAlmostEqual(model.optimize("Maximize").f, 0.855, places=3)
+
+    def test_canonical_form_minimize(self):
+        model = create_test_model("textbook")
+        # make a minimization problem
+        model.reactions.get_by_id("Biomass_Ecoli_core").lower_bound = 0.5
+        for reaction in model.reactions:
+            reaction.objective_coefficient = reaction.id == "GAPD"
+        self.assertAlmostEqual(model.optimize("Minimize").f, 6.27, places=3)
+        # convert to canonical form. Convert Minimize to Maximize
+        model = canonical_form(model, objective_sense="Minimize")
+        self.assertAlmostEqual(model.optimize("Maximize").f, -6.27, places=3)
+        # lower bounds should now be <= constraints
+        self.assertEqual(model.reactions.get_by_id("Biomass_Ecoli_core").lower_bound, 0.0)
+
+
+# make a test suite to run all of the tests
+loader = TestLoader()
+suite = loader.loadTestsFromModule(sys.modules[__name__])
+
+def test_all():
+    TextTestRunner(verbosity=2).run(suite)
+
+if __name__ == "__main__":
+    test_all()

--- a/cobra/test/manipulation.py
+++ b/cobra/test/manipulation.py
@@ -24,10 +24,10 @@ class TestManipulation(TestCase):
         g_constr._constraint_sense = "G"
         g_constr._bound = 5.0
         model.reactions.get_by_id("SUCCt2_2").add_metabolites({ g_constr: 1 })
-        self.assertAlmostEqual(model.optimize("Maximize").f, 0.855, places=3)
+        self.assertAlmostEqual(model.optimize("maximize").f, 0.855, places=3)
         # convert to canonical form
         model = canonical_form(model)
-        self.assertAlmostEqual(model.optimize("Maximize").f, 0.855, places=3)
+        self.assertAlmostEqual(model.optimize("maximize").f, 0.855, places=3)
 
     def test_canonical_form_minimize(self):
         model = create_test_model("textbook")
@@ -35,10 +35,10 @@ class TestManipulation(TestCase):
         model.reactions.get_by_id("Biomass_Ecoli_core").lower_bound = 0.5
         for reaction in model.reactions:
             reaction.objective_coefficient = reaction.id == "GAPD"
-        self.assertAlmostEqual(model.optimize("Minimize").f, 6.27, places=3)
-        # convert to canonical form. Convert Minimize to Maximize
-        model = canonical_form(model, objective_sense="Minimize")
-        self.assertAlmostEqual(model.optimize("Maximize").f, -6.27, places=3)
+        self.assertAlmostEqual(model.optimize("minimize").f, 6.27, places=3)
+        # convert to canonical form. Convert minimize to maximize
+        model = canonical_form(model, objective_sense="minimize")
+        self.assertAlmostEqual(model.optimize("maximize").f, -6.27, places=3)
         # lower bounds should now be <= constraints
         self.assertEqual(model.reactions.get_by_id("Biomass_Ecoli_core").lower_bound, 0.0)
 

--- a/setup.py
+++ b/setup.py
@@ -105,12 +105,12 @@ try:
     if name == "posix":
         from subprocess import check_output
         try:
-            glpksol_path = check_output(["which", "glpsol"]).strip()
+            glpksol_path = check_output(["which", "glpsol"], universal_newlines=True).strip()
             glpk_path = abspath(join(dirname(glpksol_path), ".."))
             include_dirs.append(join(glpk_path, "include"))
             library_dirs.append(join(glpk_path, "lib"))
-        except:
-            None
+        except Exception as e:
+            print('Could not add include and library dirs: {}'.format(e))
     if len(include_dirs) > 0:
         build_args["include_dirs"] = include_dirs
     if len(library_dirs) > 0:
@@ -124,7 +124,8 @@ try:
     else:
         ext_modules = [Extension("cobra.solvers.cglpk",
                                  ["cobra/solvers/cglpk.c"], **build_args)]
-except:
+except Exception as e:
+    print('Could not build CGLPK: {}'.format(e))
     ext_modules = None
 
 extras = {


### PR DESCRIPTION
Adds an OptKnock implementation in `cobra.design`.

To create OptKnock, this also includes:

- A general function for taking the dual: `cobra.design.dual_problem()`
- A function for converting a model to the canonical form: `cobra.manipulation.canonical_form()`.

NOTE:  I have only tested this in Python 2.7 with Gurobi (but code runs in Python 3.5). ~~MIPs did not solve with GLPK.~~ EDIT: Decreased integer tolerance to 1e-9 and MIPs solve with GLPK. Maybe this should be the default value in cglpk.pyx.