### PR TITLE
IO SBML Adds export of rxn/met note field

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -503,14 +503,14 @@ def get_libsbml_document(cobra_model,
         #In a cobrapy model the notes section is stored as a dictionary. The following section turns the key-value-pairs
         #of the dictionary into a string and replaces recurring symbols so that the string has the required syntax for
         #an SBML doc.
-        note_str = str(the_reaction.notes.viewitems())
+        note_str = str(list(cameo_model.reactions.MNXR4410_c.notes.items()))
         note_start_tag, note_end_tag, note_delimiter = '<p>', '</p>', ':'
-        note_str = note_str.replace('dict_items([','<html xmlns="http://www.w3.org/1999/xhtml">')
         note_str = note_str.replace('(\'',note_start_tag)
         note_str = note_str.replace('\']),',note_end_tag)
         note_str = note_str.replace('\',',note_delimiter)
         note_str = note_str.replace('\']','')
         note_str = note_str.replace('[\'','')
+        note_str = note_str.replace('[','<html xmlns="http://www.w3.org/1999/xhtml">')
         note_str = note_str.replace(')])',note_end_tag+'</html>')
         sbml_reaction.setNotes(note_str)
 

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -495,12 +495,9 @@ def get_libsbml_document(cobra_model,
         #Checks if GPR and Subsystem annotations are present in the notes section and if they are the same as those in
         #the reaction's gene_reaction_rule/ subsystem attribute
         #If they are not identical, they are set to be identical
-        if 'GENE ASSOCIATION' in the_reaction.notes and the_reaction.notes['GENE ASSOCIATION'] != '':
-            if the_reaction.gene_reaction_rule != the_reaction.notes['GENE ASSOCIATION']:
-        if 'SUBSYSTEM' in the_reaction.notes and the_reaction.notes['SUBSYSTEM']:
-            if the_reaction.subsystem != the_reaction.notes['SUBSYSTEM']:
-                the_reaction.notes.update({'SUBSYSTEM': [str(the_reaction.subsystem)]})
-        else:
+        if the_reaction.gene_reaction_rule:
+            the_reaction.notes.update({'GENE ASSOCIATION': [str(the_reaction.gene_reaction_rule)]})
+        if the_reaction.subsystem:
             the_reaction.notes.update({'SUBSYSTEM': [str(the_reaction.subsystem)]})
         
         #In a cobrapy model the notes section is stored as a dictionary. The following section turns the key-value-pairs
@@ -515,6 +512,7 @@ def get_libsbml_document(cobra_model,
         note_str = note_str.replace('\']','')
         note_str = note_str.replace('[\'','')
         note_str = note_str.replace(')])',note_end_tag+'</html>')
+        sbml_reaction.setNotes(note_str)
 
     if use_fbc_package:
         try:
@@ -584,6 +582,7 @@ def add_sbml_species(sbml_model, cobra_metabolite, note_start_tag,
             return cobra_metabolite
     if cobra_metabolite.charge is not None:
         sbml_species.setCharge(cobra_metabolite.charge)
+    #Deal with cases where the formula in the model is not an object but as a string
     if cobra_metabolite.formula or cobra_metabolite.notes:
         tmp_note =  '<html xmlns="http://www.w3.org/1999/xhtml">'
         if hasattr(cobra_metabolite.formula, 'id'):

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -503,7 +503,7 @@ def get_libsbml_document(cobra_model,
         #In a cobrapy model the notes section is stored as a dictionary. The following section turns the key-value-pairs
         #of the dictionary into a string and replaces recurring symbols so that the string has the required syntax for
         #an SBML doc.
-        note_str = str(list(cameo_model.reactions.MNXR4410_c.notes.items()))
+        note_str = str(list(the_reaction.notes.items()))
         note_start_tag, note_end_tag, note_delimiter = '<p>', '</p>', ':'
         note_str = note_str.replace('(\'',note_start_tag)
         note_str = note_str.replace('\']),',note_end_tag)

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -325,7 +325,7 @@ def parse_legacy_sbml_notes(note_string, note_delimiter = ':'):
             note_field = the_note[:note_delimiter_index].lstrip(' ').rstrip(' ').replace('_',' ').upper()
             note_value = the_note[(note_delimiter_index+1):].lstrip(' ').rstrip(' ')
             if note_field in note_dict:
-                note_dict[note_field ].append(note_value)
+                note_dict[note_field].append(note_value)
             else:
                 note_dict[note_field] = [note_value]
         note_string = note_string[(note_end+len(end_tag)): ]
@@ -497,7 +497,6 @@ def get_libsbml_document(cobra_model,
         #If they are not identical, they are set to be identical
         if 'GENE ASSOCIATION' in the_reaction.notes and the_reaction.notes['GENE ASSOCIATION'] != '':
             if the_reaction.gene_reaction_rule != the_reaction.notes['GENE ASSOCIATION']:
-                the_reaction.notes['GENE ASSOCIATION'][0] = the_reaction.gene_reaction_rule
         if 'SUBSYSTEM' in the_reaction.notes and the_reaction.notes['SUBSYSTEM']:
             if the_reaction.subsystem != the_reaction.notes['SUBSYSTEM']:
                 the_reaction.notes.update({'SUBSYSTEM': [str(the_reaction.subsystem)]})
@@ -516,7 +515,6 @@ def get_libsbml_document(cobra_model,
         note_str = note_str.replace('\']','')
         note_str = note_str.replace('[\'','')
         note_str = note_str.replace(')])',note_end_tag+'</html>')
-
 
     if use_fbc_package:
         try:

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -511,7 +511,7 @@ def get_libsbml_document(cobra_model,
         note_str = note_str.replace('\']','')
         note_str = note_str.replace('[\'','')
         note_str = note_str.replace('[','<html xmlns="http://www.w3.org/1999/xhtml">')
-        note_str = note_str.replace(')])',note_end_tag+'</html>')
+        note_str = note_str.replace(')]',note_end_tag+'</html>')
         sbml_reaction.setNotes(note_str)
 
     if use_fbc_package:


### PR DESCRIPTION
Fixed: Notes field of reactions was not imported into cobrapy or cameo model as reaction.notes. It is now included as a dictionary, which makes parsing/ mapping easier.

Fixed: Notes field of reactions was not included in legacy sbml export from cobrapy or cameo model.

Fixed: When the formula of a metabolite is simply included as a string it will not be exported in the notes section correctly since the original code looked for the ID of a formula object. I changed this to check for a formula attribute regardless of its type. This should allow both options to be exported correctly.