### PR TITLE
Fixes a problem with cplex 12.6

### DIFF
--- a/cobra/solvers/cplex_solver.py
+++ b/cobra/solvers/cplex_solver.py
@@ -241,7 +241,7 @@ def set_quadratic_objective(lp, quadratic_objective):
         raise Exception('quadratic component must have method todok')
     # ensure the matrix is properly read in
     nnz = quadratic_objective.nnz
-    if lp.parameters.read.qpnonzeros < nnz:
+    if lp.parameters.read.qpnonzeros.get() < nnz:
         lp.parameters.read.qpnonzeros.set(nnz + 1)
     # Reset the quadratic coefficient if it exists
     if lp.objective.get_num_quadratic_nonzeros() > 0:


### PR DESCRIPTION
Okay that one should be good now.

Before:

```
======================================================================
ERROR: test_quadratic (cobra.test.solvers.cplexTester)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cdiener/code/cobrapy/cobra/test/solvers.py", line 243, in test_quadratic
    solver.set_quadratic_objective(lp, quadratic_obj)
  File "/home/cdiener/code/cobrapy/cobra/solvers/cplex_solver.py", line 244, in set_quadratic_objective
    if lp.parameters.read.qpnonzeros < nnz:
TypeError: unorderable types: NumParameter() < int()

======================================================================
ERROR: test_single_gene_deletion (cobra.test.flux_analysis.TestCobraFluxAnalysis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cdiener/code/cobrapy/cobra/test/flux_analysis.py", line 181, in test_single_gene_deletion
    method=method)
  File "/home/cdiener/code/cobrapy/cobra/flux_analysis/single_deletion.py", line 133, in single_gene_deletion
    solver=solver, **solver_args)
  File "/home/cdiener/code/cobrapy/cobra/flux_analysis/single_deletion.py", line 177, in single_gene_deletion_moma
    solver=solver, **solver_args)
  File "/home/cdiener/code/cobrapy/cobra/flux_analysis/moma.py", line 79, in solve_moma_model
    lp = create_euclidian_distance_lp(moma_model, solver=solver)
  File "/home/cdiener/code/cobrapy/cobra/flux_analysis/moma.py", line 73, in create_euclidian_distance_lp
    quadratic_component=Q)
  File "/home/cdiener/code/cobrapy/cobra/solvers/cplex_solver.py", line 211, in create_problem
    set_quadratic_objective(lp, quadratic_component)
  File "/home/cdiener/code/cobrapy/cobra/solvers/cplex_solver.py", line 244, in set_quadratic_objective
    if lp.parameters.read.qpnonzeros < nnz:
TypeError: unorderable types: NumParameter() < int()

----------------------------------------------------------------------
Ran 125 tests in 3.502s

FAILED (errors=2, skipped=5)
```

After:

```
Ran 125 tests in 2.941s

OK (skipped=5)
```