### PR TITLE
Added method Model.set_effective_bounds

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -365,6 +365,7 @@ class Model(Object):
             self.change_objective(rxn)
             rxn.lower_bound = self.optimize(objective_sense='minimize', **kwargs).f
             rxn.upper_bound = self.optimize(objective_sense='maximize', **kwargs).f
+            # if the following assert fails, the original model was inconsistent. If it never fails, the model is consistent.
             assert rxn.lower_bound <= rxn.upper_bound
             if delete_inactive and rxn.lower_bound == rxn.upper_bound == 0:
                 rxn.remove_from_model()

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -358,12 +358,15 @@ class Model(Object):
                     if hasattr(objectives, "items") else 1.
     
     def set_effective_bounds(self, delete_inactive=False, **kwargs):
+        """Sets reaction lower and upper bounds to their effective values."""
+        # save original objective so we can restore it later
         original_objective = self.objective
         for rxn in list(self.reactions):
             self.change_objective(rxn)
             rxn.lower_bound = self.optimize(objective_sense='minimize', **kwargs).f
             rxn.upper_bound = self.optimize(objective_sense='maximize', **kwargs).f
             assert rxn.lower_bound <= rxn.upper_bound
-            if delete_inactive and rxn.lower_bound == rxn.upper_bound:
+            if delete_inactive and rxn.lower_bound == rxn.upper_bound == 0:
                 rxn.remove_from_model()
+        # restore original objective
         self.objective = objective

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -356,3 +356,11 @@ class Model(Object):
                 # from a list.
                 reaction.objective_coefficient = objectives[reaction_id] \
                     if hasattr(objectives, "items") else 1.
+    
+    def set_effective_bounds(self):
+        original_objective = self.objective
+        for rxn in self.reactions:
+            self.change_objective(rxn)
+            rxn.lower_bound = self.optimize(objective_sense='minimize').f
+            rxn.upper_bound = self.optimize(objective_sense='maximize').f
+        self.objective = objective

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -357,10 +357,13 @@ class Model(Object):
                 reaction.objective_coefficient = objectives[reaction_id] \
                     if hasattr(objectives, "items") else 1.
     
-    def set_effective_bounds(self):
+    def set_effective_bounds(self, delete_inactive=False, **kwargs):
         original_objective = self.objective
-        for rxn in self.reactions:
+        for rxn in list(self.reactions):
             self.change_objective(rxn)
-            rxn.lower_bound = self.optimize(objective_sense='minimize').f
-            rxn.upper_bound = self.optimize(objective_sense='maximize').f
+            rxn.lower_bound = self.optimize(objective_sense='minimize', **kwargs).f
+            rxn.upper_bound = self.optimize(objective_sense='maximize', **kwargs).f
+            assert rxn.lower_bound <= rxn.upper_bound
+            if delete_inactive and rxn.lower_bound == rxn.upper_bound:
+                rxn.remove_from_model()
         self.objective = objective


### PR DESCRIPTION
The new method Model.set_effective_bounds computes effective lower and upper bounds for all reactions in a model. For a example, in a model in which glucose uptake is restricted to 10, glycolysis reactions may have upper bounds of 1000, but in reality their effective upper bounds will be 10 to 20.