### PR TITLE
Add reactions by formula to model

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -19,7 +19,7 @@ _warnings.formatwarning = _warn_format
 from .version import get_version
 __version__ = get_version()
 from .core import Object, Metabolite, Gene, Reaction, Model, \
-    DictList, Species
+    DictList, Species, parseReactionFormula
 from . import io, flux_analysis, design
 
 try:

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -287,7 +287,7 @@ class Model(Object):
             self.add_metabolites(metabolite_list)
             metabolite_coefficient_dict = {}
             for metabolite, coefficient in zip(metabolite_list,
-                    stoich_coeff_list):
+                                               stoich_coeff_list):
                 metabolite_coefficient_dict[metabolite] = coefficient
 
             reaction.add_metabolites(

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -16,6 +16,7 @@ from .parseReactionFormula import parseReactionFormula
 # performance.  When doing this, take care to monitor metabolite coefficients.
 # Do the same for Model.reactions[:].genes and Model.genes
 
+
 class Model(Object):
     """Metabolic Model
 
@@ -255,44 +256,44 @@ class Model(Object):
             reactionID = reaction_formula[0]
             formula = reaction_formula[1]
             if reactionID in existing_reaction_IDs:
-                reactions_not_added.append((reactionID,'already exists'))
+                reactions_not_added.append((reactionID, 'already exists'))
                 continue
 
             try:
-                [metabolite_list, compartment_list, stoich_coeff_list, 
+                [metabolite_list, compartment_list, stoich_coeff_list,
                     is_reversible] = parseReactionFormula(formula)
             except:
-                reactions_not_added.append((reactionID,'fails to parse'))
+                reactions_not_added.append((reactionID, 'fails to parse'))
                 continue
 
             # Create reaction
             reaction = Reaction(reactionID)
             reaction._model = self
             if is_reversible:
-                reaction.lower_bound=-1000
+                reaction.lower_bound = -1000
             else:
                 reaction.lower_bound = 0
 
             reaction.upper_bound = 1000
-            reaction.subsystem='Unknown'
+            reaction.subsystem = 'Unknown'
 
             # Create/retrieve metabolites
             metabolite_list = [Metabolite(
-                                metabolite, compartment = compartment) for
-                                metabolite, compartment in 
-                                zip(metabolite_list, compartment_list)]
+                metabolite, compartment=compartment) for
+                metabolite, compartment in
+                zip(metabolite_list, compartment_list)]
 
             metabolite_added_list.extend(metabolite_list)
             self.add_metabolites(metabolite_list)
             metabolite_coefficient_dict = {}
-            for metabolite, coefficient in zip(metabolite_list, 
-                                                stoich_coeff_list):
+            for metabolite, coefficient in zip(metabolite_list,
+                    stoich_coeff_list):
                 metabolite_coefficient_dict[metabolite] = coefficient
 
             reaction.add_metabolites(
                 metabolite_coefficient_dict,
-                combine = False,
-                add_to_container_model = False)
+                combine=False,
+                add_to_container_model=False)
 
             reaction_list.append(reaction)
 

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -11,7 +11,6 @@ from .Metabolite import Metabolite
 from .DictList import DictList
 from .parseReactionFormula import parseReactionFormula
 
-
 # Note, when a reaction is added to the Model it will no longer keep personal
 # instances of its Metabolites, it will reference Model.metabolites to improve
 # performance.  When doing this, take care to monitor metabolite coefficients.
@@ -237,21 +236,20 @@ class Model(Object):
 
         reaction_formula_list: A list of iterable objects, each containing a
         reaction ID and a reaction formula.
-        
-        N.B. there is no gene association for any added reaction.
 
+        N.B. there is no gene association for any added reaction.
         """
         # Only add the reaction if one with the same ID is not already
         # present in the model.
-        
+
         if not hasattr(reaction_formula_list, "__len__"):
             reaction_formula_list = [reaction_formula_list]
-                
+
         existing_reaction_IDs = [reaction.id for reaction in self.reactions]
         reactions_not_added = []
         reaction_list = []
         metabolite_added_list = []
-        
+
         # Add reactions. Also take care of genes and metabolites in the loop
         for reaction_formula in reaction_formula_list:
             reactionID = reaction_formula[0]
@@ -259,42 +257,48 @@ class Model(Object):
             if reactionID in existing_reaction_IDs:
                 reactions_not_added.append((reactionID,'already exists'))
                 continue
-            
+
             try:
-                [metabolite_list,compartment_list,stoich_coeff_list,is_reversible] = parseReactionFormula(formula)
+                [metabolite_list, compartment_list, stoich_coeff_list, 
+                    is_reversible] = parseReactionFormula(formula)
             except:
                 reactions_not_added.append((reactionID,'fails to parse'))
                 continue
-            
+
             # Create reaction
             reaction = Reaction(reactionID)
             reaction._model = self
             if is_reversible:
                 reaction.lower_bound=-1000
             else:
-                reaction.lower_bound=0    
-            reaction.upper_bound=1000
+                reaction.lower_bound = 0
+
+            reaction.upper_bound = 1000
             reaction.subsystem='Unknown'
-            
+
             # Create/retrieve metabolites
-            metabolite_list = [Metabolite(metabolite,compartment=compartment) for
-                metabolite, compartment in zip(metabolite_list,compartment_list)]
-            
+            metabolite_list = [Metabolite(
+                                metabolite, compartment = compartment) for
+                                metabolite, compartment in 
+                                zip(metabolite_list, compartment_list)]
+
             metabolite_added_list.extend(metabolite_list)
             self.add_metabolites(metabolite_list)
             metabolite_coefficient_dict = {}
-            for metabolite, coefficient in zip(metabolite_list,stoich_coeff_list):
+            for metabolite, coefficient in zip(metabolite_list, 
+                                                stoich_coeff_list):
                 metabolite_coefficient_dict[metabolite] = coefficient
-            
+
             reaction.add_metabolites(
                 metabolite_coefficient_dict,
-                combine=False,
-                add_to_container_model=False)    
+                combine = False,
+                add_to_container_model = False)
+
             reaction_list.append(reaction)
-        
+
         self.add_reactions(reaction_list)
         return reactions_not_added
-        
+
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
         """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model which
         may be used to perform linear algebra operations with the

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -243,20 +243,19 @@ class Model(Object):
         """
         # Only add the reaction if one with the same ID is not already
         # present in the model.
-
+        
+        if not hasattr(reaction_formula_list, "__len__"):
+            reaction_formula_list = [reaction_formula_list]
+                
         existing_reaction_IDs = [reaction.id for reaction in self.reactions]
-        
         reactions_not_added = []
-        
         reaction_list = []
         metabolite_added_list = []
         
         # Add reactions. Also take care of genes and metabolites in the loop
         for reaction_formula in reaction_formula_list:
-            
             reactionID = reaction_formula[0]
             formula = reaction_formula[1]
-            
             if reactionID in existing_reaction_IDs:
                 reactions_not_added.append((reactionID,'already exists'))
                 continue
@@ -281,11 +280,6 @@ class Model(Object):
             metabolite_list = [Metabolite(metabolite,compartment=compartment) for
                 metabolite, compartment in zip(metabolite_list,compartment_list)]
             
-#             if len(metabolite_list) > 1:
-#                 return metabolite_list
-#             else:
-#                 continue
-            
             metabolite_added_list.extend(metabolite_list)
             self.add_metabolites(metabolite_list)
             metabolite_coefficient_dict = {}
@@ -296,12 +290,9 @@ class Model(Object):
                 metabolite_coefficient_dict,
                 combine=False,
                 add_to_container_model=False)    
-            
             reaction_list.append(reaction)
         
         self.add_reactions(reaction_list)
-        
-        return metabolite_added_list    
         return reactions_not_added
         
     def to_array_based_model(self, deepcopy_model=False, **kwargs):

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -1,0 +1,110 @@
+
+
+def parseReactionFormula(formula=None):
+    """parseRxnFormula Parse reaction formula into a list of metabolites and a
+    list of S coefficients
+    
+     [metaboliteList,stoichCoeffList,revFlag] = parseRxnFormula(formula)
+    
+    INPUT
+    formula           Reaction formula, may contain symbols '+', '->', '<=>' in
+                       addition to stoichiometric coefficients and metabolite names
+                       examples: 
+                       '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]' (irreversible reaction)
+                       'cit[c] + icit[x]  <=> cit[x] + icit[c] ' (reversible reaction)
+                       If no stoichiometric coefficient is provided, it is assumed
+                       to be = 1
+                       Reaction formula should be a string, not a cell array
+                        (default: irreversible reaction above)
+    
+    OUTPUTS
+    metaboliteList    Cell array with metabolite names
+    stoichCoeffList   List of S coefficients
+    revFlag           Indicates whether the reaction is reversible (True) or
+                       not (False)
+    
+    Example:
+         
+    formula = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]'
+    
+    [metaboliteList,stoichCoeffList,revFlag] = parseRxnFormula(formula)
+    
+        metaboliteList = 
+          'cdpdag-SC[m]'    'pg-SC[m]'    'clpn-SC[m]'    'cmp[m]'    'h[m]'
+        stoichCoeffList = 
+           -0.01 -0.01 0.01 1 1
+        revFlag =
+           False
+    
+     Markus Herrgard 6/1/07
+     Richard Que 1/25/10 Modified to handle '-->' and '<==>' as arrows 
+     as well as reactionsformatted as '[compartment] : A --> C'. 
+     IT May 2012 Modified to handle '=>'
+     WBryant Jan 2016 Converted to Python for COBRApy
+     """
+    
+    formula = formula or '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]'
+    
+    tokens = formula.split()
+    
+    stoichCoeffList = []
+    metaboliteList = []
+    revFlag = True
+    
+    # Marks the start of a new stoichiometry + metabolite block
+    newMetFlag = True
+    # Designates products vs reactants
+    productFlag = False
+    compartment = ''
+    forwardArrows = ['->','-->','=>','==>']
+    reversibleArrows = ['<=>','<==>']
+    reverseArrows = ['<-','<--','<=','<==']
+    switchDirection = False
+    for token in tokens:
+        t = token
+        if t.startswith('['):
+            #set compartment
+            compartment = t
+        elif t == ':':
+            pass
+        elif t == '+':
+            newMetFlag = True
+        elif t in forwardArrows:
+            # Irreversible
+            revFlag = False
+            productFlag = True
+            newMetFlag = True
+        elif t in reversibleArrows:
+            # Reversible
+            revFlag = True
+            productFlag = True
+            newMetFlag = True
+        elif t in reverseArrows:
+            revFlag = False
+            productFlag = True
+            newMetFlag = True
+            switchDirection = True            
+        else:
+            try:
+                # Coefficient   
+                sCoeff = float(t)
+                if not productFlag:
+                    sCoeff = -sCoeff
+                if switchDirection:
+                    sCoeff = -sCoeff
+                stoichCoeffList.append(sCoeff)
+                newMetFlag = False
+            except:
+                # Metabolite name
+                metaboliteList.append(t + compartment)
+                if newMetFlag:
+                    if not productFlag:
+                        sCoeff = -1
+                    else:
+                        sCoeff = 1
+                    if switchDirection:
+                        sCoeff = -sCoeff
+                    stoichCoeffList.append(sCoeff)
+                    newMetFlag = True
+    
+    return metaboliteList,stoichCoeffList,revFlag

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -24,7 +24,7 @@ def parseReactionFormula(formula=None):
     revFlag           Indicates whether the reaction is reversible (True) or
                        not (False)
     Example:
-    formula = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] 
+    formula = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m]
                     + h[m]'
     [metaboliteList, stoichCoeffList, revFlag] = parseReactionFormula(formula)
         metaboliteList =

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -102,7 +102,7 @@ def parseReactionFormula(formula=None):
                     metaboliteID = re.sub('\[(.+)\]$', r'_\1', t)
                 except:
                     try:
-                        compartment = re.search('.+_([^_]+)$',t).group(1)
+                        compartment = re.search('.+_([^_]+)$', t).group(1)
                     except:
                         compartment = compartment_default
                         metaboliteID += '_' + compartment

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -1,17 +1,19 @@
 import re
+
+
 def parseReactionFormula(formula=None):
     """Parse formula into a list of metabolites and a list of coefficients
      [metaboliteList, stoichCoeffList, revFlag] = parseReactionFormula(formula)
     INPUT
     formula           Reaction formula, may contain symbols '+', '->', '<=>' in
-                       addition to stoichiometric coefficients and metabolite 
+                       addition to stoichiometric coefficients and metabolite
                        names
                        examples:
-                       '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] 
+                       '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m]
                        + cmp[m] + h[m]' (irreversible reaction)
-                       'cit[c] + icit[x]  <=> cit[x] + icit[c] ' (reversible 
+                       'cit[c] + icit[x]  <=> cit[x] + icit[c] ' (reversible
                        reaction)
-                       If no stoichiometric coefficient is provided, it is 
+                       If no stoichiometric coefficient is provided, it is
                        assumed to be = 1
                        Reaction formula should be a string, not a cell array
                         (default: irreversible reaction above)
@@ -51,9 +53,9 @@ def parseReactionFormula(formula=None):
     # Designates products vs reactants
     productFlag = False
     compartment_default = 'c'
-    forwardArrows = ['->','-->','=>','==>']
-    reversibleArrows = ['<=>','<==>']
-    reverseArrows = ['<-','<--','<=','<==']
+    forwardArrows = ['->', '-->', '=>', '==>']
+    reversibleArrows = ['<=>', '<==>']
+    reverseArrows = ['<-', '<--', '<=', '<==']
     switchDirection = False
     for token in tokens:
         t = token

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -1,61 +1,51 @@
 import re
-
-
 def parseReactionFormula(formula=None):
     """Parse formula into a list of metabolites and a list of coefficients
-    
-     [metaboliteList,stoichCoeffList,revFlag] = parseReactionFormula(formula)
-    
+     [metaboliteList, stoichCoeffList, revFlag] = parseReactionFormula(formula)
     INPUT
     formula           Reaction formula, may contain symbols '+', '->', '<=>' in
-                       addition to stoichiometric coefficients and metabolite names
-                       examples: 
-                       '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]' (irreversible reaction)
-                       'cit[c] + icit[x]  <=> cit[x] + icit[c] ' (reversible reaction)
-                       If no stoichiometric coefficient is provided, it is assumed
-                       to be = 1
+                       addition to stoichiometric coefficients and metabolite 
+                       names
+                       examples:
+                       '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] 
+                       + cmp[m] + h[m]' (irreversible reaction)
+                       'cit[c] + icit[x]  <=> cit[x] + icit[c] ' (reversible 
+                       reaction)
+                       If no stoichiometric coefficient is provided, it is 
+                       assumed to be = 1
                        Reaction formula should be a string, not a cell array
                         (default: irreversible reaction above)
-    
     OUTPUTS
     metaboliteList    List of metabolite names
-    compartmentList   List of compartments 
+    compartmentList   List of compartments
     stoichCoeffList   List of S coefficients
     revFlag           Indicates whether the reaction is reversible (True) or
                        not (False)
-    
     Example:
-         
-    formula = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]'
-    
-    [metaboliteList,stoichCoeffList,revFlag] = parseReactionFormula(formula)
-    
-        metaboliteList = 
+    formula = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] 
+                    + h[m]'
+    [metaboliteList, stoichCoeffList, revFlag] = parseReactionFormula(formula)
+        metaboliteList =
           ['cdpdag-SC[m]','pg-SC[m]','clpn-SC[m]','cmp[m]','h[m]']
-        compartmentList = 
+        compartmentList =
           ['m','m','m','m','m']
-        stoichCoeffList = 
-           [-0.01,-0.01,0.01,1,1]
+        stoichCoeffList =
+           [-0.01,-0.01, 0.01, 1, 1]
         revFlag =
            False
-    
      Markus Herrgard 6/1/07
-     Richard Que 1/25/10 Modified to handle '-->' and '<==>' as arrows 
-     as well as reactionsformatted as '[compartment] : A --> C'. 
+     Richard Que 1/25/10 Modified to handle '-->' and '<==>' as arrows
+     as well as reactionsformatted as '[compartment] : A --> C'.
      IT May 2012 Modified to handle '=>'
      WBryant Jan 2016 Converted to Python for COBRApy
      """
-    
-    formula = formula or '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC[m] + cmp[m] + h[m]'
-    
+    formula = formula or '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC \
+                            [m] + cmp[m] + h[m]'
     tokens = formula.split()
-    
     metaboliteList = []
     compartmentList = []
     stoichCoeffList = []
-    
     revFlag = True
-    
     # Marks the start of a new stoichiometry + metabolite block
     newMetFlag = True
     # Designates products vs reactants
@@ -68,9 +58,9 @@ def parseReactionFormula(formula=None):
     for token in tokens:
         t = token
         if t.startswith('['):
-            #set compartment
+            # set compartment
             try:
-                compartment_default = re.search('\[(.+)\]',t).group(1)
+                compartment_default = re.search('\[(.+)\]', t).group(1)
             except:
                 pass
         elif t == ':':
@@ -91,10 +81,10 @@ def parseReactionFormula(formula=None):
             revFlag = False
             productFlag = True
             newMetFlag = True
-            switchDirection = True            
+            switchDirection = True
         else:
             try:
-                # Coefficient   
+                # Coefficient
                 sCoeff = float(t)
                 if not productFlag:
                     sCoeff = -sCoeff
@@ -106,8 +96,8 @@ def parseReactionFormula(formula=None):
                 # Extract compartment if possible
                 metaboliteID = t
                 try:
-                    compartment = re.search('.+\[(.+)\]$',t).group(1)
-                    metaboliteID = re.sub('\[(.+)\]$',r'_\1',t)
+                    compartment = re.search('.+\[(.+)\]$', t).group(1)
+                    metaboliteID = re.sub('\[(.+)\]$', r'_\1', t)
                 except:
                     try:
                         compartment = re.search('.+_([^_]+)$').group(1)
@@ -115,9 +105,7 @@ def parseReactionFormula(formula=None):
                         compartment = compartment_default
                         metaboliteID += '_' + compartment
                 compartmentList.append(compartment)
-                
                 metaboliteList.append(metaboliteID)
-                
                 if newMetFlag:
                     if not productFlag:
                         sCoeff = -1
@@ -127,5 +115,4 @@ def parseReactionFormula(formula=None):
                         sCoeff = -sCoeff
                     stoichCoeffList.append(sCoeff)
                     newMetFlag = True
-    
-    return metaboliteList,compartmentList,stoichCoeffList,revFlag
+    return metaboliteList, compartmentList, stoichCoeffList, revFlag

--- a/cobra/core/parseReactionFormula.py
+++ b/cobra/core/parseReactionFormula.py
@@ -41,8 +41,8 @@ def parseReactionFormula(formula=None):
      IT May 2012 Modified to handle '=>'
      WBryant Jan 2016 Converted to Python for COBRApy
      """
-    formula = formula or '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC \
-                            [m] + cmp[m] + h[m]'
+    formula = formula or '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC'\
+                         '[m] + cmp[m] + h[m]'
     tokens = formula.split()
     metaboliteList = []
     compartmentList = []
@@ -102,7 +102,7 @@ def parseReactionFormula(formula=None):
                     metaboliteID = re.sub('\[(.+)\]$', r'_\1', t)
                 except:
                     try:
-                        compartment = re.search('.+_([^_]+)$').group(1)
+                        compartment = re.search('.+_([^_]+)$',t).group(1)
                     except:
                         compartment = compartment_default
                         metaboliteID += '_' + compartment

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -401,19 +401,19 @@ class TestCobraModel(CobraTestCase):
         # Construct reaction
         reaction_formula_list = []
         reaction_formula_list.append(('test_formula_reaction1',
-                                      'test_met_1_c + 2 ' +\
-                                      test_met_from_model_id +\
+                                      'test_met_1_c + 2 ' +
+                                      test_met_from_model_id +
                                       ' ==> test_met_3_c + test_met_4_e'))
         self.model.add_reactions_by_formula(reaction_formula_list)
 
         # Does reaction exist?
         new_reaction_count = len(self.model.reactions)
-        self.assertEqual(new_reaction_count-old_reaction_count,1)
+        self.assertEqual(new_reaction_count-old_reaction_count, 1)
         self.assertIn(reaction_formula_list[0][0],
                       [reaction.id for reaction in self.model.reactions])
         formula_reaction = self.model.reactions\
             .get_by_id(reaction_formula_list[0][0])
-        self.assertEqual(formula_reaction.reversibility,False)
+        self.assertEqual(formula_reaction.reversibility, False)
 
         # Have metabolites been added to model?
         self.assertIs(type(self.model.metabolites.get_by_id('test_met_1_c')),
@@ -434,16 +434,16 @@ class TestCobraModel(CobraTestCase):
             metabolite_list.append(
                 self.model.metabolites.get_by_id(metabolite_id)
             )
-        stoichiometry_list = [-1,-2,1,1]
-        compartment_list = ['c','c','c','e']
+        stoichiometry_list = [-1, -2, 1, 1]
+        compartment_list = ['c', 'c', 'c', 'e']
         
         # Are stoichiometries and compartments correct?
         for metabolite, stoichiometry, compartment in\
-                zip(metabolite_list,stoichiometry_list, compartment_list):
-            self.assertIn(metabolite,formula_reaction._metabolites)
+                zip(metabolite_list, stoichiometry_list, compartment_list):
+            self.assertIn(metabolite, formula_reaction._metabolites)
             self.assertEqual(formula_reaction._metabolites[metabolite],
                              stoichiometry)
-            self.assertEqual(metabolite.compartment,compartment)
+            self.assertEqual(metabolite.compartment, compartment)
 
     def test_add_reaction_from_other_model(self):
         model = self.model
@@ -714,17 +714,17 @@ class TestCobraArrayModel(TestCobraModel):
         with self.assertRaises(TypeError):
             model.reactions[[True, False]]
 
+
 class TestParseReactionFormula(TestCase):
-     
+
     def test_formula_parse(self):
         test_formula1 = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC'\
                         '[m] + cmp[m] + h[m]'
         [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
             prf.parseReactionFormula(test_formula1)
-        
-        self.assertEqual(tuple(metabolite_list), ('cdpdag-SC_m', 'pg-SC_m', \
-            'clpn-SC_m', 'cmp_m', 'h_m'))
-        self.assertEqual(tuple(compartment_list),('m', 'm', 'm', 'm', 'm'))
+        self.assertEqual(tuple(metabolite_list), ('cdpdag-SC_m', 'pg-SC_m',
+                                                  'clpn-SC_m', 'cmp_m', 'h_m'))
+        self.assertEqual(tuple(compartment_list), ('m', 'm', 'm', 'm', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-0.01, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, False)
         
@@ -732,14 +732,13 @@ class TestParseReactionFormula(TestCase):
                         '+ c_hdie_c_c + h[m]'
         [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
             prf.parseReactionFormula(test_formula2)
-        
-        self.assertEqual(tuple(metabolite_list), ('testmet1__c', 'pg-SC_c',\
+        self.assertEqual(tuple(metabolite_list), ('testmet1__c', 'pg-SC_c',
             'test_2_e', 'c_hdie_c_c', 'h_m'))
-        self.assertEqual(tuple(compartment_list),('c', 'c', 'e', 'c', 'm'))
+        self.assertEqual(tuple(compartment_list), ('c', 'c', 'e', 'c', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-2.0, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, True)
-        
-        
+
+
 # make a test suite to run all of the tests
 loader = TestLoader()
 suite = loader.loadTestsFromModule(sys.modules[__name__])

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -397,7 +397,7 @@ class TestCobraModel(CobraTestCase):
         old_reaction_count = len(self.model.reactions)
         old_metabolite_count = len(self.model.metabolites)
         test_met_from_model_id = self.model.metabolites[0].id
-        
+
         # Construct reaction
         reaction_formula_list = []
         reaction_formula_list.append(('test_formula_reaction1',
@@ -424,7 +424,7 @@ class TestCobraModel(CobraTestCase):
                       Metabolite)
         new_metabolite_count = len(self.model.metabolites)
         self.assertEqual(new_metabolite_count - old_metabolite_count, 3)
-        
+
         metabolite_id_list = ['test_met_1_c',
                               test_met_from_model_id,
                               'test_met_3_c',
@@ -436,7 +436,7 @@ class TestCobraModel(CobraTestCase):
             )
         stoichiometry_list = [-1, -2, 1, 1]
         compartment_list = ['c', 'c', 'c', 'e']
-        
+
         # Are stoichiometries and compartments correct?
         for metabolite, stoichiometry, compartment in\
                 zip(metabolite_list, stoichiometry_list, compartment_list):
@@ -727,13 +727,13 @@ class TestParseReactionFormula(TestCase):
         self.assertEqual(tuple(compartment_list), ('m', 'm', 'm', 'm', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-0.01, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, False)
-        
+
         test_formula2 = '2 testmet1__c + 0.01 pg-SC <==> 0.01 test_2_e '\
                         '+ c_hdie_c_c + h[m]'
         [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
             prf.parseReactionFormula(test_formula2)
-        self.assertEqual(tuple(metabolite_list), ('testmet1__c', 'pg-SC_c',
-            'test_2_e', 'c_hdie_c_c', 'h_m'))
+        self.assertEqual(tuple(metabolite_list),
+            ('testmet1__c', 'pg-SC_c', 'test_2_e', 'c_hdie_c_c', 'h_m'))
         self.assertEqual(tuple(compartment_list), ('c', 'c', 'e', 'c', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-2.0, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, True)

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -733,7 +733,8 @@ class TestParseReactionFormula(TestCase):
         [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
             prf.parseReactionFormula(test_formula2)
         self.assertEqual(tuple(metabolite_list),
-            ('testmet1__c', 'pg-SC_c', 'test_2_e', 'c_hdie_c_c', 'h_m'))
+                        ('testmet1__c', 'pg-SC_c', 'test_2_e', 'c_hdie_c_c',
+                         'h_m'))
         self.assertEqual(tuple(compartment_list), ('c', 'c', 'e', 'c', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-2.0, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, True)

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -9,10 +9,12 @@ if __name__ == "__main__":
     sys.path.insert(0, "../..")
     from cobra.test import create_test_model
     from cobra import Object, Model, Metabolite, Reaction, DictList
+    from cobra import parseReactionFormula as prf
     sys.path.pop(0)
 else:
     from . import create_test_model
     from .. import Object, Model, Metabolite, Reaction, DictList
+    from .. import parseReactionFormula as prf
 
 # libraries which may or may not be installed
 libraries = ["scipy"]
@@ -391,6 +393,58 @@ class TestCobraModel(CobraTestCase):
         r2.add_metabolites({Metabolite(self.model.metabolites[0].id): 1})
         self.assertIs(self.model.metabolites[0], list(r2._metabolites)[0])
 
+    def test_add_reactions_by_formula(self):
+        old_reaction_count = len(self.model.reactions)
+        old_metabolite_count = len(self.model.metabolites)
+        test_met_from_model_id = self.model.metabolites[0].id
+        
+        # Construct reaction
+        reaction_formula_list = []
+        reaction_formula_list.append(('test_formula_reaction1',
+                                      'test_met_1_c + 2 ' +\
+                                      test_met_from_model_id +\
+                                      ' ==> test_met_3_c + test_met_4_e'))
+        self.model.add_reactions_by_formula(reaction_formula_list)
+
+        # Does reaction exist?
+        new_reaction_count = len(self.model.reactions)
+        self.assertEqual(new_reaction_count-old_reaction_count,1)
+        self.assertIn(reaction_formula_list[0][0],
+                      [reaction.id for reaction in self.model.reactions])
+        formula_reaction = self.model.reactions\
+            .get_by_id(reaction_formula_list[0][0])
+        self.assertEqual(formula_reaction.reversibility,False)
+
+        # Have metabolites been added to model?
+        self.assertIs(type(self.model.metabolites.get_by_id('test_met_1_c')),
+                      Metabolite)
+        self.assertIs(type(self.model.metabolites.get_by_id('test_met_3_c')),
+                      Metabolite)
+        self.assertIs(type(self.model.metabolites.get_by_id('test_met_4_e')),
+                      Metabolite)
+        new_metabolite_count = len(self.model.metabolites)
+        self.assertEqual(new_metabolite_count - old_metabolite_count, 3)
+        
+        metabolite_id_list = ['test_met_1_c',
+                              test_met_from_model_id,
+                              'test_met_3_c',
+                              'test_met_4_e']
+        metabolite_list = []
+        for metabolite_id in metabolite_id_list:
+            metabolite_list.append(
+                self.model.metabolites.get_by_id(metabolite_id)
+            )
+        stoichiometry_list = [-1,-2,1,1]
+        compartment_list = ['c','c','c','e']
+        
+        # Are stoichiometries and compartments correct?
+        for metabolite, stoichiometry, compartment in\
+                zip(metabolite_list,stoichiometry_list, compartment_list):
+            self.assertIn(metabolite,formula_reaction._metabolites)
+            self.assertEqual(formula_reaction._metabolites[metabolite],
+                             stoichiometry)
+            self.assertEqual(metabolite.compartment,compartment)
+
     def test_add_reaction_from_other_model(self):
         model = self.model
         other = model.copy()
@@ -660,7 +714,32 @@ class TestCobraArrayModel(TestCobraModel):
         with self.assertRaises(TypeError):
             model.reactions[[True, False]]
 
-
+class TestParseReactionFormula(TestCase):
+     
+    def test_formula_parse(self):
+        test_formula1 = '0.01 cdpdag-SC[m] + 0.01 pg-SC[m]  -> 0.01 clpn-SC'\
+                        '[m] + cmp[m] + h[m]'
+        [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
+            prf.parseReactionFormula(test_formula1)
+        
+        self.assertEqual(tuple(metabolite_list), ('cdpdag-SC_m', 'pg-SC_m', \
+            'clpn-SC_m', 'cmp_m', 'h_m'))
+        self.assertEqual(tuple(compartment_list),('m', 'm', 'm', 'm', 'm'))
+        self.assertEqual(tuple(stoich_coeff_list), (-0.01, -0.01, 0.01, 1, 1))
+        self.assertIs(rev_flag, False)
+        
+        test_formula2 = '2 testmet1__c + 0.01 pg-SC <==> 0.01 test_2_e '\
+                        '+ c_hdie_c_c + h[m]'
+        [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
+            prf.parseReactionFormula(test_formula2)
+        
+        self.assertEqual(tuple(metabolite_list), ('testmet1__c', 'pg-SC_c',\
+            'test_2_e', 'c_hdie_c_c', 'h_m'))
+        self.assertEqual(tuple(compartment_list),('c', 'c', 'e', 'c', 'm'))
+        self.assertEqual(tuple(stoich_coeff_list), (-2.0, -0.01, 0.01, 1, 1))
+        self.assertIs(rev_flag, True)
+        
+        
 # make a test suite to run all of the tests
 loader = TestLoader()
 suite = loader.loadTestsFromModule(sys.modules[__name__])

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -732,9 +732,10 @@ class TestParseReactionFormula(TestCase):
                         '+ c_hdie_c_c + h[m]'
         [metabolite_list, compartment_list, stoich_coeff_list, rev_flag] =\
             prf.parseReactionFormula(test_formula2)
-        self.assertEqual(tuple(metabolite_list),
-                        ('testmet1__c', 'pg-SC_c', 'test_2_e', 'c_hdie_c_c',
-                         'h_m'))
+        self.assertEqual(
+            tuple(metabolite_list),
+            ('testmet1__c', 'pg-SC_c', 'test_2_e', 'c_hdie_c_c', 'h_m')
+        )
         self.assertEqual(tuple(compartment_list), ('c', 'c', 'e', 'c', 'm'))
         self.assertEqual(tuple(stoich_coeff_list), (-2.0, -0.01, 0.01, 1, 1))
         self.assertIs(rev_flag, True)


### PR DESCRIPTION
I have added a method to the cobra.core.Model class to allow the addition of models from a list of iterables, each containing a reaction ID and a reaction formula.

This has required the addition of a parseReactionFormula function, taken directly from the MATLAB COBRA toolbox, and adapted to run in Python.

I have tested this with my own reaction formulae and it appears to work - would any further testing be required?