### PR TITLE
Add reactions by formula

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -230,29 +230,26 @@ class Model(Object):
         self.reactions += reaction_list
 
     def add_reactions_by_formula(self, reaction_formula_list):
-        """Will add a cobra.Reaction object to the model, if
-        reaction.id is not in self.reactions.
-
-        reaction_formula_list: A list of iterable objects, each containing a
-        reaction ID and a reaction formula.
-
-        N.B. there is no gene association for any added reaction.
+        """Adds a set of reactions to the model specified by a formula string
+        
+        Takes a list of (reactionID, formula) tuples (or other iterables) and
+        for each, if the reactionID is not in self.reactions, the formula is 
+        parsed and the described reaction is added to the model.  N.B. No gene
+        association is added orany of these reactions.
+        
+        Args:
+            reaction_formula_list: a list of (reactionID, formula) tuples
+        
         """
-        # Only add the reaction if one with the same ID is not already
-        # present in the model.
-
         if not hasattr(reaction_formula_list, "__len__"):
             reaction_formula_list = [reaction_formula_list]
-
         existing_reaction_IDs = [reaction.id for reaction in self.reactions]
-        reactions_not_added = []
         
-        # Add reactions. Also take care of genes and metabolites in the loop
+        # Add reactions
         for reaction_formula in reaction_formula_list:
             reactionID = reaction_formula[0]
             formula = reaction_formula[1]
             if reactionID in existing_reaction_IDs:
-                reactions_not_added.append((reactionID, 'already exists'))
                 continue
             
             # Create reaction
@@ -264,8 +261,6 @@ class Model(Object):
                 fwd_arrow=None, rev_arrow=None,
                 reversible_arrow=None, term_split="+"
             )
-
-        return reaction
 
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
         """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model which

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -233,13 +233,13 @@ class Model(Object):
         """Adds a set of reactions to the model specified by a formula string
         
         Takes a list of (reactionID, formula) tuples (or other iterables) and
-        for each, if the reactionID is not in self.reactions, the formula is 
-        parsed and the described reaction is added to the model.  N.B. No gene
-        association is added orany of these reactions.
+        for each, if the reactionID is not in self.reactions, the formula
+        (reaction equation) is parsed and the described reaction is added to
+        the model.  N.B. No gene association is added for any of these
+        reactions.
         
         Args:
             reaction_formula_list: a list of (reactionID, formula) tuples
-        
         """
         if not hasattr(reaction_formula_list, "__len__"):
             reaction_formula_list = [reaction_formula_list]

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -231,30 +231,30 @@ class Model(Object):
 
     def add_reactions_by_formula(self, reaction_formula_list):
         """Adds a set of reactions to the model specified by a formula string
-        
+
         Takes a list of (reactionID, formula) tuples (or other iterables) and
         for each, if the reactionID is not in self.reactions, the formula
         (reaction equation) is parsed and the described reaction is added to
         the model.  N.B. No gene association is added for any of these
         reactions.
-        
+
         Args:
             reaction_formula_list: a list of (reactionID, formula) tuples
         """
         if not hasattr(reaction_formula_list, "__len__"):
             reaction_formula_list = [reaction_formula_list]
         existing_reaction_IDs = [reaction.id for reaction in self.reactions]
-        
+
         # Add reactions
         for reaction_formula in reaction_formula_list:
             reactionID = reaction_formula[0]
             formula = reaction_formula[1]
             if reactionID in existing_reaction_IDs:
                 continue
-            
+
             # Create reaction
             reaction = Reaction(reactionID)
-            self.add_reaction(reaction)            
+            self.add_reaction(reaction)
             reaction.build_reaction_from_string(
                 formula,
                 verbose=False,

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -247,11 +247,8 @@ class Model(Object):
         existing_reaction_IDs = [reaction.id for reaction in self.reactions]
         reactions_not_added = []
         
-        print reaction_formula_list
-        
         # Add reactions. Also take care of genes and metabolites in the loop
         for reaction_formula in reaction_formula_list:
-            print reaction_formula
             reactionID = reaction_formula[0]
             formula = reaction_formula[1]
             if reactionID in existing_reaction_IDs:
@@ -259,16 +256,11 @@ class Model(Object):
                 continue
             
             # Create reaction
-            print("reactionID - {}".format(reactionID))
-            print("formula - '{}'".format(formula))
             reaction = Reaction(reactionID)
-            reaction._model = self
-            
-            print("reaction.model - {}".format(reaction.model))
-            
+            self.add_reaction(reaction)            
             reaction.build_reaction_from_string(
                 formula,
-                verbose=True,
+                verbose=False,
                 fwd_arrow=None, rev_arrow=None,
                 reversible_arrow=None, term_split="+"
             )

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -229,6 +229,52 @@ class Model(Object):
 
         self.reactions += reaction_list
 
+    def add_reactions_by_formula(self, reaction_formula_list):
+        """Will add a cobra.Reaction object to the model, if
+        reaction.id is not in self.reactions.
+
+        reaction_formula_list: A list of iterable objects, each containing a
+        reaction ID and a reaction formula.
+
+        N.B. there is no gene association for any added reaction.
+        """
+        # Only add the reaction if one with the same ID is not already
+        # present in the model.
+
+        if not hasattr(reaction_formula_list, "__len__"):
+            reaction_formula_list = [reaction_formula_list]
+
+        existing_reaction_IDs = [reaction.id for reaction in self.reactions]
+        reactions_not_added = []
+        
+        print reaction_formula_list
+        
+        # Add reactions. Also take care of genes and metabolites in the loop
+        for reaction_formula in reaction_formula_list:
+            print reaction_formula
+            reactionID = reaction_formula[0]
+            formula = reaction_formula[1]
+            if reactionID in existing_reaction_IDs:
+                reactions_not_added.append((reactionID, 'already exists'))
+                continue
+            
+            # Create reaction
+            print("reactionID - {}".format(reactionID))
+            print("formula - '{}'".format(formula))
+            reaction = Reaction(reactionID)
+            reaction._model = self
+            
+            print("reaction.model - {}".format(reaction.model))
+            
+            reaction.build_reaction_from_string(
+                formula,
+                verbose=True,
+                fwd_arrow=None, rev_arrow=None,
+                reversible_arrow=None, term_split="+"
+            )
+
+        return reaction
+
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
         """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model which
         may be used to perform linear algebra operations with the

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -587,9 +587,29 @@ class Reaction(Object):
         self.lower_bound = 0
         self.upper_bound = 0
 
-    def build_reaction_from_string(self, reaction_str, verbose=True,
+    def build_reaction_from_string(self, reaction_str, verbose=False,
                                    fwd_arrow=None, rev_arrow=None,
                                    reversible_arrow=None, term_split="+"):
+        """Builds reaction from reaction equation reaction_str using parser 
+        
+        Takes a string and using the specifications supplied in the optional 
+        arguments infers a set of metabolites, metabolite compartments and 
+        stoichiometries for the reaction.  It also infers the reversibility
+        of the reaction from the reaction arrow.
+        
+        Args:
+            reaction_str: a string containing a reaction formula (equation)
+            verbose: Boolean setting verbosity of function
+                (optional, default=False)
+            fwd_arrow: re.compile for forward irreversible reaction arrows
+                (optional, default=_forward_arrow_finder)
+            reverse_arrow: re.compile for backward irreversible reaction arrows
+                (optional, default=_reverse_arrow_finder)
+            fwd_arrow: re.compile for reversible reaction arrows
+                (optional, default=_reversible_arrow_finder)
+            term_split: String dividing individual metabolite entries
+                (optional, default='+')
+        """
         # set the arrows
         forward_arrow_finder = _forward_arrow_finder if fwd_arrow is None \
             else re.compile(re.escape(fwd_arrow))

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -590,13 +590,13 @@ class Reaction(Object):
     def build_reaction_from_string(self, reaction_str, verbose=False,
                                    fwd_arrow=None, rev_arrow=None,
                                    reversible_arrow=None, term_split="+"):
-        """Builds reaction from reaction equation reaction_str using parser 
-        
-        Takes a string and using the specifications supplied in the optional 
-        arguments infers a set of metabolites, metabolite compartments and 
+        """Builds reaction from reaction equation reaction_str using parser
+
+        Takes a string and using the specifications supplied in the optional
+        arguments infers a set of metabolites, metabolite compartments and
         stoichiometries for the reaction.  It also infers the reversibility
         of the reaction from the reaction arrow.
-        
+
         Args:
             reaction_str: a string containing a reaction formula (equation)
             verbose: Boolean setting verbosity of function
@@ -672,15 +672,14 @@ class Reaction(Object):
                     num = factor
                 # Does met_id contain compartment specification?
                 try:
-                    met_compartment_id = re.search('.+\[([^\[\]]+)\]$', met_id)\
-                        .group(1)
-                    met_id = re.sub('\[[^\[\]]+\]$','_' + met_compartment_id,
+                    met_compartment_id = re.search('.+\[([^\[\]]+)\]$',
+                                                   met_id).group(1)
+                    met_id = re.sub('\[[^\[\]]+\]$', '_' + met_compartment_id,
                                     met_id)
                 except:
                     try:
                         met_compartment_id = re.search('.+_([^_]+)$',
-                            met_id)\
-                            .group(1)
+                                                       met_id).group(1)
                     except:
                         met_compartment_id = "" + compartment_id
                         met_id += "_" + met_compartment_id

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -606,12 +606,10 @@ class Reaction(Object):
         original_str = "" + reaction_str  # copy
         found_compartments = compartment_finder.findall(reaction_str)
         if len(found_compartments) == 1:
-            compartment_string = found_compartments[0]
-            compartment_id = compartment_string[1]
+            compartment_id = found_compartments[0][1]
             reaction_str = compartment_finder.sub("", reaction_str)
         else:
             # set default compartment to cytosol
-            compartment_string = "[c]"
             compartment_id = "c"
 
         # reversible case
@@ -654,19 +652,18 @@ class Reaction(Object):
                     num = factor
                 # Does met_id contain compartment specification?
                 try:
-                    met_compartment_string = re.search('.+(\[.+\])$', met_id).group(1)
-                    met_compartment_id = met_compartment_string[1] 
+                    met_compartment_id = re.search('.+\[([^\[\]]+)\]$', met_id)\
+                        .group(1)
+                    met_id = re.sub('\[[^\[\]]+\]$','_' + met_compartment_id,
+                                    met_id)
                 except:
                     try:
-                        met_compartment_string = re.search('.+_([^_]+)$', met_id)\
+                        met_compartment_id = re.search('.+_([^_]+)$',
+                            met_id)\
                             .group(1)
-                        met_compartment_id = "" + met_compartment_string
-                        met_compartment_string = '[' + met_compartment_string + ']'
-                        met_id = re.sub('_([^_]+)$', met_compartment_string, met_id)
                     except:
-                        met_compartment_id = met_compartment_string[1]
-                        met_compartment_string = compartment_string
-                        met_id += compartment_string
+                        met_compartment_id = "" + compartment_id
+                        met_id += "_" + met_compartment_id
                 try:
                     met = model.metabolites.get_by_id(met_id)
                 except KeyError:

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -649,6 +649,8 @@ class Reaction(Object):
                 else:
                     met_id = term
                     num = factor
+                # Does met_id contain compartment specification?
+                
                 met_id += compartment
                 try:
                     met = model.metabolites.get_by_id(met_id)

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -445,7 +445,7 @@ class TestCobraModel(CobraTestCase):
             self.assertEqual(formula_reaction._metabolites[metabolite],
                              stoichiometry)
             self.assertEqual(metabolite.compartment, compartment)
-            
+
     def test_add_reaction_from_other_model(self):
         model = self.model
         other = model.copy()

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -401,7 +401,7 @@ class TestCobraModel(CobraTestCase):
         reaction_formula_list.append(('test_formula_reaction1',
                                       'test_met_1_c + 2 ' +
                                       test_met_from_model_id +
-                                      ' ==> test_met_3_c + test_met_4_e'))
+                                      ' ==> test_met_3_c + test_met_4[e]'))
         self.model.add_reactions_by_formula(reaction_formula_list)
 
         # Does reaction exist?
@@ -427,8 +427,11 @@ class TestCobraModel(CobraTestCase):
                               test_met_from_model_id,
                               'test_met_3_c',
                               'test_met_4_e']
+        metabolite_ids_in_model = [metabolite.id for metabolite
+                                   in self.model.metabolites]
         metabolite_list = []
         for metabolite_id in metabolite_id_list:
+            self.assertIn(metabolite_id, metabolite_ids_in_model)
             metabolite_list.append(
                 self.model.metabolites.get_by_id(metabolite_id)
             )

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -334,8 +334,8 @@ class TestReactions(CobraTestCase):
         self.assertIn(model.metabolites.h2o_c, pgi._metabolites)
         pgi.build_reaction_from_string("g6p_c --> f6p_c + foo", verbose=False)
         self.assertNotIn(model.metabolites.h2o_c, pgi._metabolites)
-        self.assertIn("foo", model.metabolites)
-        self.assertIn(model.metabolites.foo, pgi._metabolites)
+        self.assertIn("foo_c", model.metabolites)
+        self.assertIn(model.metabolites.foo_c, pgi._metabolites)
         self.assertEqual(len(model.metabolites), m + 1)
 
 


### PR DESCRIPTION
I have added a method to the cobra.core.Model class to allow the addition of models from a list of iterables, each containing a reaction ID and a reaction formula, making use of the `build_reaction_from_string` method in `cobra.core.Reaction`.  It has required an update of this method to take account of compartments in the formula string.