### PR TITLE
Changing Metabolite formula and element methods

### DIFF
--- a/cobra/core/Metabolite.py
+++ b/cobra/core/Metabolite.py
@@ -1,6 +1,8 @@
 from warnings import warn
 import re
 
+from six import iteritems
+
 from .Species import Species
 
 # Numbers are not required because of the |(?=[A-Z])? block. See the
@@ -41,48 +43,58 @@ class Metabolite(Species):
         self._bound = 0.
 
     @property
+    def formula(self):
+        """Describes a Chemical Formula
+        A legal formula string contains only letters and numbers.
+        """
+        try:
+            return self._formula
+        except AttributeError:
+            # Handle loading old pickled classes
+            self._formula = self.__dict__['formula']
+            return self._formula
+
+    @formula.setter
+    def formula(self, formula):
+        self._formula = str(formula) if formula is not None else ''
+
+        if "*" in self._formula:
+            warn("invalid character '*' found in formula '{}'".format(
+                self._formula))
+        if "(" in self._formula or ")" in self._formula:
+            warn("invalid formula (has parenthesis) in '{}'".format(
+                self._formula))
+        for element, stoich in element_re.findall(self._formula):
+            if element not in elements_and_molecular_weights:
+                warn('{} not a valid element'.format(element))
+            try:
+                int(stoich) if stoich else 1
+            except ValueError:
+                warn('{} not a valid element count'.format(stoich))
+
+    @property
     def elements(self):
-        tmp_formula = self.formula
-        if tmp_formula is None:
-            return {}
-        # necessary for some old pickles which use the deprecated
-        # Formula class
-        tmp_formula = str(self.formula)
-        # commonly occuring characters in incorrectly constructed formulas
-        if "*" in tmp_formula:
-            warn("invalid character '*' found in formula '%s'" % self.formula)
-            tmp_formula = tmp_formula.replace("*", "")
-        if "(" in tmp_formula or ")" in tmp_formula:
-            warn("invalid formula (has parenthesis) in '%s'" % self.formula)
-            return None
-        composition = {}
-        parsed = element_re.findall(tmp_formula)
-        for (element, count) in parsed:
-            if count == '':
-                count = 1
-            else:
-                try:
-                    count = float(count)
-                    int_count = int(count)
-                    if count == int_count:
-                        count = int_count
-                    else:
-                        warn("%s is not an integer (in formula %s)" %
-                             (count, self.formula))
-                except ValueError:
-                    warn("failed to parse %s (in formula %s)" %
-                         (count, self.formula))
-                    return None
-            if element in composition:
-                composition[element] += count
-            else:
-                composition[element] = count
-        return composition
+        """A dictionary breaking the chemical formula down by element.
+        
+        Will raise a ValueError if the formula contains non-integer
+        stochiometries, or if being set with an atom not present in the
+        elements_and_molecular_weights dict.
+        
+        """
+        return {element: int(stoich) if stoich else 1
+                for element, stoich in element_re.findall(self.formula)}
+
+    @elements.setter
+    def elements(self, elements_dict):
+        def stringify(element, number):
+            return ''.join((element, str(number) if number != 1 else ''))
+
+        self.formula = ''.join(stringify(e, n) for e, n in
+                                sorted(iteritems(elements_dict)))
 
     @property
     def formula_weight(self):
         """Calculate the formula weight"""
-        weight_dict = elements_and_molecular_weights
         try:
             return sum([count * elements_and_molecular_weights[element]
                         for element, count in self.elements.items()])

--- a/cobra/test/manipulation.py
+++ b/cobra/test/manipulation.py
@@ -225,6 +225,17 @@ class TestManipulation(TestCase):
         errors = check_metabolite_compartment_formula(model)
         self.assertEqual(len(errors), 2)
 
+    def test_validate_formula_setting(self):
+        model = create_test_model("textbook")
+        met = model.metabolites[1]
+        orig_formula = str(met.formula)
+        orig_elements = dict(met.elements)
+        
+        met.formula = ''
+        self.assertEqual(met.elements, {})
+        met.elements = orig_elements
+        self.assertEqual(met.formula, orig_formula)
+
     def test_validate_mass_balance(self):
         model = create_test_model("textbook")
         self.assertEqual(len(check_mass_balance(model)), 0)

--- a/cobra/test/manipulation.py
+++ b/cobra/test/manipulation.py
@@ -225,7 +225,7 @@ class TestManipulation(TestCase):
         errors = check_metabolite_compartment_formula(model)
         self.assertEqual(len(errors), 2)
 
-    def test_validate_formula_setting(self):
+    def test_foruma_element_setting(self):
         model = create_test_model("textbook")
         met = model.metabolites[1]
         orig_formula = str(met.formula)


### PR DESCRIPTION
This is a pretty basic change, really just reformulating the code for the metabolite formulas to be a bit cleaner. We really shouldn't be checking for formula errors when we put in a call to "elements", those warnings should probably get raised when the formula is set.

I try to have all my non-boundary reactions be mass-balanced, and for that reason I'll often need non-integer chemical formulas for things like biomass metabolites (I removed that warning, but its trivial to add it back in)

Its also nice to be able to set the formula using a dictionary, which is implemented in elements.setter. Specifically, you can set a combined metabolite directly from something like:
```
biomass.elements = {element : -stoich for element, stoich in reaction.check_mass_balance().iteritems()}
```
