### PR TITLE
Adding summary methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 before_install:
   - pip install pip --upgrade
   # These get cached
-  - pip install numpy scipy python-libsbml cython coveralls jsonschema six matplotlib
+  - pip install numpy scipy python-libsbml cython coveralls jsonschema six matplotlib pandas
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install lxml glpk pep8 palettable; fi
   # Download esolver and add it to the path
   - wget https://opencobra.github.io/pypi_cobrapy_travis/esolver.gz

--- a/cobra/core/Metabolite.py
+++ b/cobra/core/Metabolite.py
@@ -136,6 +136,25 @@ class Metabolite(Species):
         else:
             raise Exception(method + " is not 'subtractive' or 'destructive'")
 
+    def summary(self, **kwargs):
+        """Print a summary of the reactions which produce and consume this
+        metabolite. This method requires the model for which this metabolite is
+        a part to be solved.
+
+        threshold: float
+            a value below which to ignore reaction fluxes
+
+        fva: float (0->1), or None
+            Whether or not to include flux variability analysis in the output.
+            If given, fva should be a float between 0 and 1, representing the
+            fraction of the optimum objective to be searched.
+
+        """
+        try:
+            from ..flux_analysis.summary import metabolite_summary
+            return metabolite_summary(self, **kwargs)
+        except ImportError:
+            warn('Summary methods require pandas')
 
 elements_and_molecular_weights = {
     'H':   1.007940,

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -356,3 +356,23 @@ class Model(Object):
                 # from a list.
                 reaction.objective_coefficient = objectives[reaction_id] \
                     if hasattr(objectives, "items") else 1.
+
+    def summary(self, **kwargs):
+        """Print a summary of the input and output fluxes of the model. This
+        method requires the model to have been previously solved.
+
+        threshold: float
+            tolerance for determining if a flux is zero (not printed)
+        fva: int or None
+            Whether or not to calculate and report flux variability in the
+            output summary
+        round: int
+            number of digits after the decimal place to print
+
+        """
+
+        try:
+            from ..flux_analysis.summary import model_summary
+            return model_summary(self, **kwargs)
+        except ImportError:
+            warn('Summary methods require pandas')

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -541,7 +541,8 @@ class Reaction(Object):
             id_type = 'name'
         reactant_bits = []
         product_bits = []
-        for the_metabolite, coefficient in iteritems(self._metabolites):
+        for the_metabolite, coefficient in sorted(
+                iteritems(self._metabolites), key=lambda x: x[0].id):
             name = str(getattr(the_metabolite, id_type))
             if _is_positive(coefficient):
                 product_bits.append(format(coefficient) + name)

--- a/cobra/flux_analysis/summary.py
+++ b/cobra/flux_analysis/summary.py
@@ -1,0 +1,190 @@
+from six.moves import zip_longest
+from six import iterkeys, print_, text_type
+
+import pandas as pd
+
+from .variability import flux_variability_analysis
+
+
+def format_long_string(string, max_length):
+    if len(string) > max_length:
+        string = string[:max_length - 3]
+        string += '...'
+    return string
+
+
+def metabolite_summary(met, threshold=0.01, fva=False):
+    """Print a summary of the reactions which produce and consume this
+    metabolite
+
+    threshold: float
+    a value below which to ignore reaction fluxes
+
+    fva: float (0->1), or None
+    Whether or not to include flux variability analysis in the output.
+    If given, fva should be a float between 0 and 1, representing the
+    fraction of the optimum objective to be searched.
+
+    """
+
+    def rxn_summary(r):
+        return {
+            'id': r.id,
+            'flux': r.x * r.metabolites[met],
+            'reaction': r.reaction,
+        }
+
+    flux_summary = pd.DataFrame((rxn_summary(r) for r in met.reactions))
+    assert flux_summary.flux.sum() < 1E-6, "Error in flux balance"
+    producing = flux_summary[flux_summary.flux > 0].copy()
+    consuming = flux_summary[flux_summary.flux < 0].copy()
+
+    for df in [producing, consuming]:
+        df['percent'] = df.flux / df.flux.sum()
+        df.drop(df[df['percent'] < threshold].index, axis=0,
+                inplace=True)
+
+    producing.sort_values('percent', ascending=False, inplace=True)
+    consuming.sort_values('percent', ascending=False, inplace=True)
+
+    if not fva:
+
+        producing.flux = producing.flux.apply(
+            lambda x: '{:6.2g}'.format(x))
+        consuming.flux = consuming.flux.apply(
+            lambda x: '{:6.2g}'.format(x))
+
+        flux_len = 6
+
+    else:
+        fva_results = pd.DataFrame(
+            flux_variability_analysis(met.model, met.reactions,
+                                      fraction_of_optimum=fva)).T
+        half_span = (fva_results.maximum - fva_results.minimum) / 2
+        median = fva_results.minimum + half_span
+
+        producing.flux = producing.id.apply(
+            lambda x, median=median, err=half_span:
+            u'{0:0.2f} \u00B1 {1:0.2f}'.format(median[x], err[x]))
+        consuming.flux = consuming.id.apply(
+            lambda x, median=median, err=half_span:
+            u'{0:0.2f} \u00B1 {1:0.2f}'.format(median[x], err[x]))
+
+        flux_len = max(producing.flux.apply(len).max(),
+                       consuming.flux.apply(len).max()) + 1
+
+    for df in [producing, consuming]:
+
+        df['reaction'] = df['reaction'].map(
+            lambda x: format_long_string(x, 52))
+        df['id'] = df['id'].map(
+            lambda x: format_long_string(x, 8))
+
+    head = "PRODUCING REACTIONS -- " + format_long_string(met.name, 55)
+    print_(head)
+    print_("-" * len(head))
+    print_(("{0:^6} {1:>" + str(flux_len) + "} {2:>8} {3:^54}").format(
+        '%', 'FLUX', 'RXN ID', 'REACTION'))
+
+    for row in producing.iterrows():
+        print_((u"{0.percent:6.1%} {0.flux:>" + str(flux_len) +
+               "} {0.id:>8} {0.reaction:>54}").format(row[1]))
+
+    print_()
+    print_("CONSUMING REACTIONS -- " + format_long_string(met.name, 55))
+    print_("-" * len(head))
+    print_(("{0:^6} {1:>" + str(flux_len) + "} {2:>8} {3:^54}").format(
+        '%', 'FLUX', 'RXN ID', 'REACTION'))
+
+    for row in consuming.iterrows():
+        print_((u"{0.percent:6.1%} {0.flux:>" + str(flux_len) +
+                "} {0.id:>8} {0.reaction:>54}").format(row[1]))
+
+
+def model_summary(model, threshold=1E-8, fva=None, round=2):
+    """Print a summary of the input and output fluxes of the model.
+
+    threshold: float
+        tolerance for determining if a flux is zero (not printed)
+    fva: int or None
+        Whether or not to calculate and report flux variability in the
+        output summary
+    round: int
+        number of digits after the decimal place to print
+
+    """
+    obj_fluxes = pd.Series({'{:<15}'.format(r.id): '{:.3f}'.format(r.x)
+                            for r in iterkeys(model.objective)})
+
+    if not fva:
+
+        out_rxns = model.reactions.query(
+            lambda rxn: rxn.x > threshold, None
+        ).query(lambda x: x, 'boundary')
+
+        in_rxns = model.reactions.query(
+            lambda rxn: rxn.x < -threshold, None
+        ).query(lambda x: x, 'boundary')
+
+        out_fluxes = pd.Series({r.reactants[0]: r.x for r in out_rxns})
+        in_fluxes = pd.Series({r.reactants[0]: r.x for r in in_rxns})
+
+        out_fluxes = pd.np.round(
+            out_fluxes.sort_values(ascending=False), round)
+        in_fluxes = pd.np.round(in_fluxes.sort_values(), round)
+
+        table = pd.np.array(
+            [((a if a else ''), (b if b else ''), (c if c else ''))
+             for a, b, c in zip_longest(
+                ['IN FLUXES'] + in_fluxes.to_string().split('\n'),
+                ['OUT FLUXES'] + out_fluxes.to_string().split('\n'),
+                ['OBJECTIVES'] + obj_fluxes.to_string().split('\n'))])
+
+    else:
+        fva_results = pd.DataFrame(
+            flux_variability_analysis(model, fraction_of_optimum=fva)).T
+
+        half_span = (fva_results.maximum - fva_results.minimum) / 2
+        median = fva_results.minimum + half_span
+
+        out_rxns = model.reactions.query(
+            lambda rxn: median.loc[rxn.id] > threshold, None
+        ).query(lambda x: x, 'boundary')
+
+        in_rxns = model.reactions.query(
+            lambda rxn: median.loc[rxn.id] < -threshold, None
+        ).query(lambda x: x, 'boundary')
+
+        out_fluxes = pd.DataFrame(
+            {r.reactants[0]: {'x': median.loc[r.id],
+                              'err': half_span.loc[r.id]}
+             for r in out_rxns}).T
+
+        in_fluxes = pd.DataFrame(
+            {r.reactants[0]: {'x': median.loc[r.id],
+                              'err': half_span.loc[r.id]}
+             for r in in_rxns}).T
+
+        out_fluxes = pd.np.round(
+            out_fluxes.sort_values(by='x', ascending=False), round)
+        in_fluxes = pd.np.round(
+            in_fluxes.sort_values(by='x'), round)
+
+        in_fluxes_s = in_fluxes.apply(
+            lambda x: u'{0:0.2f} \u00B1 {1:0.2f}'.format(x.x, x.err),
+            axis=1)
+        out_fluxes_s = out_fluxes.apply(
+            lambda x: u'{0:0.2f} \u00B1 {1:0.2f}'.format(x.x, x.err),
+            axis=1)
+        out_fluxes_s = out_fluxes.apply(lambda x: text_type(x.x) +
+                                        u" \u00B1 " + text_type(x.err), axis=1)
+
+        table = pd.np.array(
+            [((a if a else ''), (b if b else ''), (c if c else ''))
+             for a, b, c in zip_longest(
+                     ['IN FLUXES'] + in_fluxes_s.to_string().split('\n'),
+                     ['OUT FLUXES'] + out_fluxes_s.to_string().split('\n'),
+                     ['OBJECTIVES'] + obj_fluxes.to_string().split('\n'))])
+
+    print_(u'\n'.join([u"{a:<30}{b:<30}{c:<20}".format(a=a, b=b, c=c) for
+                       a, b, c in table]))

--- a/documentation_builder/simulating.ipynb
+++ b/documentation_builder/simulating.ipynb
@@ -41,7 +41,7 @@
     {
      "data": {
       "text/plain": [
-       "<Solution 0.87 at 0x7ff4fc14b210>"
+       "<Solution 0.87 at 0x10f309b10>"
       ]
      },
      "execution_count": 2,
@@ -106,7 +106,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8739215069684305"
+       "0.8739215069684304"
       ]
      },
      "execution_count": 4,
@@ -122,6 +122,114 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Analyzing FBA solutions\n",
+    "Models solved using FBA can be further analyzed by using summary methods, which output printed text to give a quick representation of model behavior. Calling the summary method on the entire model displays information on the input and output behavior of the model, along with the optimized objective."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IN FLUXES                     OUT FLUXES                    OBJECTIVES          \n",
+      "o2_e       -21.80             h2o_e    29.18                Biomass_Ecoli_core    0.874\n",
+      "glc__D_e   -10.00             co2_e    22.81                                    \n",
+      "nh4_e       -4.77             h_e      17.53                                    \n",
+      "pi_e        -3.21                                                               \n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, the input-output behavior of individual metabolites can also be inspected using summary methods. For instance, the following commands can be used to examine the overall redox balance of the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PRODUCING REACTIONS -- Nicotinamide adenine dinucleotide - reduced\n",
+      "------------------------------------------------------------------\n",
+      "  %      FLUX   RXN ID                        REACTION                       \n",
+      " 41.6%     16     GAPD        g3p_c + nad_c + pi_c <=> 13dpg_c + h_c + nadh_c\n",
+      " 24.1%    9.3      PDH     coa_c + nad_c + pyr_c --> accoa_c + co2_c + nadh_c\n",
+      " 13.1%    5.1      MDH              mal__L_c + nad_c <=> h_c + nadh_c + oaa_c\n",
+      " 13.1%    5.1    AKGDH    akg_c + coa_c + nad_c --> co2_c + nadh_c + succoa_c\n",
+      "  8.0%    3.1 Bioma...   1.496 3pg_c + 3.7478 accoa_c + 59.81 atp_c + 0.36...\n",
+      "\n",
+      "CONSUMING REACTIONS -- Nicotinamide adenine dinucleotide - reduced\n",
+      "------------------------------------------------------------------\n",
+      "  %      FLUX   RXN ID                        REACTION                       \n",
+      "100.0%    -39   NADH16   4.0 h_c + nadh_c + q8_c --> 3.0 h_e + nad_c + q8h2_c\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.metabolites.nadh_c.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or to get a sense of the main energy production and consumption reactions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PRODUCING REACTIONS -- ATP\n",
+      "--------------------------\n",
+      "  %      FLUX   RXN ID                        REACTION                       \n",
+      " 66.6%     46   ATPS4r     adp_c + 4.0 h_e + pi_c <=> atp_c + h2o_c + 3.0 h_c\n",
+      " 23.4%     16      PGK                      3pg_c + atp_c <=> 13dpg_c + adp_c\n",
+      "  7.4%    5.1   SUCOAS     atp_c + coa_c + succ_c <=> adp_c + pi_c + succoa_c\n",
+      "  2.6%    1.8      PYK                  adp_c + h_c + pep_c --> atp_c + pyr_c\n",
+      "\n",
+      "CONSUMING REACTIONS -- ATP\n",
+      "--------------------------\n",
+      "  %      FLUX   RXN ID                        REACTION                       \n",
+      " 76.5%    -52 Bioma...   1.496 3pg_c + 3.7478 accoa_c + 59.81 atp_c + 0.36...\n",
+      " 12.3%   -8.4     ATPM                   atp_c + h2o_c --> adp_c + h_c + pi_c\n",
+      " 10.9%   -7.5      PFK                  atp_c + f6p_c --> adp_c + fdp_c + h_c\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.metabolites.atp_c.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Changing the Objectives\n",
     "\n",
     "The objective function is determined from the objective_coefficient attribute of the objective reaction(s). Generally, a \"biomass\" function which describes the composition of metabolites which make up a cell is used."
@@ -129,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -147,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -155,10 +263,10 @@
     {
      "data": {
       "text/plain": [
-       "{<Reaction Biomass_Ecoli_core at 0x7ff4cb9a8d90>: 1.0}"
+       "{<Reaction Biomass_Ecoli_core at 0x10f085bd0>: 1.0}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -184,10 +292,10 @@
     {
      "data": {
       "text/plain": [
-       "{<Reaction ATPM at 0x7ff4cb9a8b10>: 1}"
+       "{<Reaction ATPM at 0x10f0b1dd0>: 1}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -204,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -212,10 +320,10 @@
     {
      "data": {
       "text/plain": [
-       "174.99999999999997"
+       "175.0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -233,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -241,10 +349,10 @@
     {
      "data": {
       "text/plain": [
-       "{<Reaction Biomass_Ecoli_core at 0x7ff4cb9a8d90>: 1.0}"
+       "{<Reaction Biomass_Ecoli_core at 0x10f085bd0>: 1.0}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -287,133 +395,133 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>ACALD</th>\n",
-       "      <td>9.466331e-29</td>\n",
-       "      <td>3.720797e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACALDt</th>\n",
-       "      <td>-6.310887e-29</td>\n",
-       "      <td>3.720797e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACKr</th>\n",
-       "      <td>-2.524355e-28</td>\n",
-       "      <td>3.933509e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACONTa</th>\n",
-       "      <td>6.007250e+00</td>\n",
-       "      <td>6.007250e+00</td>\n",
+       "      <td>6.007250</td>\n",
+       "      <td>6.007250</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACONTb</th>\n",
-       "      <td>6.007250e+00</td>\n",
-       "      <td>6.007250e+00</td>\n",
+       "      <td>6.007250</td>\n",
+       "      <td>6.007250</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACt2r</th>\n",
-       "      <td>6.121561e-28</td>\n",
-       "      <td>3.933509e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ADK1</th>\n",
-       "      <td>-4.042971e-14</td>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>AKGDH</th>\n",
-       "      <td>5.064376e+00</td>\n",
-       "      <td>5.064376e+00</td>\n",
+       "      <td>5.064376</td>\n",
+       "      <td>5.064376</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>AKGt2r</th>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>7.079399e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ALCD2x</th>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>5.729185e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ATPM</th>\n",
-       "      <td>8.390000e+00</td>\n",
-       "      <td>8.390000e+00</td>\n",
+       "      <td>8.390000</td>\n",
+       "      <td>8.390000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ATPS4r</th>\n",
-       "      <td>4.551401e+01</td>\n",
-       "      <td>4.551401e+01</td>\n",
+       "      <td>45.514010</td>\n",
+       "      <td>45.514010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Biomass_Ecoli_core</th>\n",
-       "      <td>8.739215e-01</td>\n",
-       "      <td>8.739215e-01</td>\n",
+       "      <td>0.873922</td>\n",
+       "      <td>0.873922</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CO2t</th>\n",
-       "      <td>-2.280983e+01</td>\n",
-       "      <td>-2.280983e+01</td>\n",
+       "      <td>-22.809833</td>\n",
+       "      <td>-22.809833</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CS</th>\n",
-       "      <td>6.007250e+00</td>\n",
-       "      <td>6.007250e+00</td>\n",
+       "      <td>6.007250</td>\n",
+       "      <td>6.007250</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CYTBD</th>\n",
-       "      <td>4.359899e+01</td>\n",
-       "      <td>4.359899e+01</td>\n",
+       "      <td>43.598985</td>\n",
+       "      <td>43.598985</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>D_LACt2</th>\n",
-       "      <td>3.660315e-28</td>\n",
-       "      <td>4.140787e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ENO</th>\n",
-       "      <td>1.471614e+01</td>\n",
-       "      <td>1.471614e+01</td>\n",
+       "      <td>14.716140</td>\n",
+       "      <td>14.716140</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ETOHt2r</th>\n",
-       "      <td>0.000000e+00</td>\n",
-       "      <td>5.729185e-15</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_ac_e</th>\n",
-       "      <td>-3.933509e-15</td>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                         maximum       minimum\n",
-       "ACALD               9.466331e-29  3.720797e-15\n",
-       "ACALDt             -6.310887e-29  3.720797e-15\n",
-       "ACKr               -2.524355e-28  3.933509e-15\n",
-       "ACONTa              6.007250e+00  6.007250e+00\n",
-       "ACONTb              6.007250e+00  6.007250e+00\n",
-       "ACt2r               6.121561e-28  3.933509e-15\n",
-       "ADK1               -4.042971e-14  0.000000e+00\n",
-       "AKGDH               5.064376e+00  5.064376e+00\n",
-       "AKGt2r              0.000000e+00  7.079399e-15\n",
-       "ALCD2x              0.000000e+00  5.729185e-15\n",
-       "ATPM                8.390000e+00  8.390000e+00\n",
-       "ATPS4r              4.551401e+01  4.551401e+01\n",
-       "Biomass_Ecoli_core  8.739215e-01  8.739215e-01\n",
-       "CO2t               -2.280983e+01 -2.280983e+01\n",
-       "CS                  6.007250e+00  6.007250e+00\n",
-       "CYTBD               4.359899e+01  4.359899e+01\n",
-       "D_LACt2             3.660315e-28  4.140787e-15\n",
-       "ENO                 1.471614e+01  1.471614e+01\n",
-       "ETOHt2r             0.000000e+00  5.729185e-15\n",
-       "EX_ac_e            -3.933509e-15  0.000000e+00"
+       "                      maximum    minimum\n",
+       "ACALD                0.000000   0.000000\n",
+       "ACALDt               0.000000   0.000000\n",
+       "ACKr                 0.000000   0.000000\n",
+       "ACONTa               6.007250   6.007250\n",
+       "ACONTb               6.007250   6.007250\n",
+       "ACt2r                0.000000   0.000000\n",
+       "ADK1                 0.000000   0.000000\n",
+       "AKGDH                5.064376   5.064376\n",
+       "AKGt2r               0.000000   0.000000\n",
+       "ALCD2x               0.000000   0.000000\n",
+       "ATPM                 8.390000   8.390000\n",
+       "ATPS4r              45.514010  45.514010\n",
+       "Biomass_Ecoli_core   0.873922   0.873922\n",
+       "CO2t               -22.809833 -22.809833\n",
+       "CS                   6.007250   6.007250\n",
+       "CYTBD               43.598985  43.598985\n",
+       "D_LACt2              0.000000   0.000000\n",
+       "ENO                 14.716140  14.716140\n",
+       "ETOHt2r              0.000000   0.000000\n",
+       "EX_ac_e              0.000000   0.000000"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -433,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -453,102 +561,102 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>ACALD</th>\n",
-       "      <td>9.466331e-29</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-2.542370</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACALDt</th>\n",
-       "      <td>-6.310887e-29</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-2.542370</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACKr</th>\n",
-       "      <td>-3.029226e-28</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-3.813556</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACONTa</th>\n",
-       "      <td>8.894520e+00</td>\n",
+       "      <td>8.894520</td>\n",
        "      <td>0.848587</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACONTb</th>\n",
-       "      <td>8.894520e+00</td>\n",
+       "      <td>8.894520</td>\n",
        "      <td>0.848587</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACt2r</th>\n",
-       "      <td>3.407879e-28</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-3.813556</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ADK1</th>\n",
-       "      <td>1.716100e+01</td>\n",
+       "      <td>17.161000</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>AKGDH</th>\n",
-       "      <td>8.045934e+00</td>\n",
+       "      <td>8.045934</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>AKGt2r</th>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-1.430083</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ALCD2x</th>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-2.214323</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ATPM</th>\n",
-       "      <td>2.555100e+01</td>\n",
+       "      <td>25.551000</td>\n",
        "      <td>8.390000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ATPS4r</th>\n",
-       "      <td>5.938106e+01</td>\n",
+       "      <td>59.381062</td>\n",
        "      <td>34.825618</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Biomass_Ecoli_core</th>\n",
-       "      <td>8.739215e-01</td>\n",
+       "      <td>0.873922</td>\n",
        "      <td>0.786529</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CO2t</th>\n",
-       "      <td>-1.520653e+01</td>\n",
+       "      <td>-15.206526</td>\n",
        "      <td>-26.528850</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CS</th>\n",
-       "      <td>8.894520e+00</td>\n",
+       "      <td>8.894520</td>\n",
        "      <td>0.848587</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CYTBD</th>\n",
-       "      <td>5.123909e+01</td>\n",
+       "      <td>51.239087</td>\n",
        "      <td>35.984865</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>D_LACt2</th>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-2.145125</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ENO</th>\n",
-       "      <td>1.673252e+01</td>\n",
+       "      <td>16.732521</td>\n",
        "      <td>8.686588</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ETOHt2r</th>\n",
-       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-2.214323</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_ac_e</th>\n",
-       "      <td>3.813556e+00</td>\n",
+       "      <td>3.813556</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -556,30 +664,30 @@
        "</div>"
       ],
       "text/plain": [
-       "                         maximum    minimum\n",
-       "ACALD               9.466331e-29  -2.542370\n",
-       "ACALDt             -6.310887e-29  -2.542370\n",
-       "ACKr               -3.029226e-28  -3.813556\n",
-       "ACONTa              8.894520e+00   0.848587\n",
-       "ACONTb              8.894520e+00   0.848587\n",
-       "ACt2r               3.407879e-28  -3.813556\n",
-       "ADK1                1.716100e+01   0.000000\n",
-       "AKGDH               8.045934e+00   0.000000\n",
-       "AKGt2r              0.000000e+00  -1.430083\n",
-       "ALCD2x              0.000000e+00  -2.214323\n",
-       "ATPM                2.555100e+01   8.390000\n",
-       "ATPS4r              5.938106e+01  34.825618\n",
-       "Biomass_Ecoli_core  8.739215e-01   0.786529\n",
-       "CO2t               -1.520653e+01 -26.528850\n",
-       "CS                  8.894520e+00   0.848587\n",
-       "CYTBD               5.123909e+01  35.984865\n",
-       "D_LACt2             0.000000e+00  -2.145125\n",
-       "ENO                 1.673252e+01   8.686588\n",
-       "ETOHt2r             0.000000e+00  -2.214323\n",
-       "EX_ac_e             3.813556e+00   0.000000"
+       "                      maximum    minimum\n",
+       "ACALD                0.000000  -2.542370\n",
+       "ACALDt               0.000000  -2.542370\n",
+       "ACKr                 0.000000  -3.813556\n",
+       "ACONTa               8.894520   0.848587\n",
+       "ACONTb               8.894520   0.848587\n",
+       "ACt2r                0.000000  -3.813556\n",
+       "ADK1                17.161000   0.000000\n",
+       "AKGDH                8.045934   0.000000\n",
+       "AKGt2r               0.000000  -1.430083\n",
+       "ALCD2x               0.000000  -2.214323\n",
+       "ATPM                25.551000   8.390000\n",
+       "ATPS4r              59.381062  34.825618\n",
+       "Biomass_Ecoli_core   0.873922   0.786529\n",
+       "CO2t               -15.206526 -26.528850\n",
+       "CS                   8.894520   0.848587\n",
+       "CYTBD               51.239087  35.984865\n",
+       "D_LACt2              0.000000  -2.145125\n",
+       "ENO                 16.732521   8.686588\n",
+       "ETOHt2r              0.000000  -2.214323\n",
+       "EX_ac_e              3.813556   0.000000"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -594,6 +702,87 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Running FVA in summary methods\n",
+    "Flux variability analysis can also be embedded in calls to summary methods. For instance, the expected variability in substrate consumption and product formation can be quickly found by"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IN FLUXES                     OUT FLUXES                    OBJECTIVES          \n",
+      "o2_e        -21.80 ± 1.91     h2o_e       27.86 ± 2.86      Biomass_Ecoli_core    0.000\n",
+      "glc__D_e     -9.76 ± 0.24     co2_e       21.81 ± 2.86                          \n",
+      "nh4_e        -4.84 ± 0.32     h_e         19.51 ± 2.86                          \n",
+      "pi_e         -3.13 ± 0.08     for_e        2.86 ± 2.86                          \n",
+      "                              ac_e         0.95 ± 0.95                          \n",
+      "                              acald_e      0.64 ± 0.64                          \n",
+      "                              pyr_e        0.64 ± 0.64                          \n",
+      "                              etoh_e       0.55 ± 0.55                          \n",
+      "                              lac__D_e     0.54 ± 0.54                          \n",
+      "                              succ_e       0.42 ± 0.42                          \n",
+      "                              akg_e        0.36 ± 0.36                          \n",
+      "                              glu__L_e     0.32 ± 0.32                          \n"
+     ]
+    }
+   ],
+   "source": [
+    "model.summary(fva=0.95)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, variability in metabolite mass balances can also be checked with flux variability analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PRODUCING REACTIONS -- Pyruvate\n",
+      "-------------------------------\n",
+      "  %             FLUX   RXN ID                        REACTION                       \n",
+      " 50.0%   9.76 ± 0.24   GLCpts                     glc__D_e + pep_c --> g6p_c + pyr_c\n",
+      " 50.0%   6.13 ± 6.13      PYK                  adp_c + h_c + pep_c --> atp_c + pyr_c\n",
+      "\n",
+      "CONSUMING REACTIONS -- Pyruvate\n",
+      "-------------------------------\n",
+      "  %             FLUX   RXN ID                        REACTION                       \n",
+      "100.0%  11.34 ± 7.43      PDH     coa_c + nad_c + pyr_c --> accoa_c + co2_c + nadh_c\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.metabolites.pyr_c.summary(fva=0.95)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In these summary methods, the values are reported as a the center point +/- the range of the FVA solution, calculated from the maximum and minimum values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Running pFBA\n",
     "\n",
     "Parsimonious FBA (often written pFBA) finds a flux distribution which gives the optimal growth rate, but minimizes the total sum of flux. This involves solving two sequential linear programs, but is handled transparently by cobrapy. For more details on pFBA, please see [Lewis et al. (2010)](http://dx.doi.org/10.1038/msb.2010.47)."
@@ -601,7 +790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -620,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -628,10 +817,10 @@
     {
      "data": {
       "text/plain": [
-       "1.1102230246251565e-16"
+       "0.0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -657,7 +846,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses #223, i.e., adding summary methods to model and metabolite objects.

The summary code is sadly quite messy, but there isn't a great way to pretty-print objects without adding yet another dependency.

I also had to change the Reaction.build_reaction_string method slightly in order to make sure it is deterministic for testing purposes.