### PR TITLE
Updates to cobra.flux_analysis.parsimonious

### DIFF
--- a/cobra/solvers/coin.py
+++ b/cobra/solvers/coin.py
@@ -27,7 +27,7 @@ class Coin(CyClpSimplex):
 
 
 def create_problem(cobra_model, objective_sense="maximize", **kwargs):
-    m = cobra_model.to_array_based_model()
+    m = cobra_model.to_array_based_model(deepcopy_model=True)
     lp = Coin()
     v = lp.addVariable("v", len(m.reactions))
     for i, rxn in enumerate(m.reactions):


### PR DESCRIPTION
From my experience, there's very few times when I wouldn't prefer a parsimonious FBA solution, especially when the computational cost is just one additional LP solve. With the current implementation, however, it can be tedious to use the existing pFBA implementation.
These edits allow users to simply call:
```python
>>> model.optimize(minimize_absolute_flux=1.0)
<Solution 0.87 at 0x1190ed810>
```
to get a parsimonious FBA solution. Additionally, it borrows the concept from flux variability analysis of the fraction of optimum parameter,where passing a value of less than one will find the minimum absolute solution within a given fraction of the optimum.

Sadly If runtime imports are discouraged, this PR may also run into some troubles.