### PR TITLE
Fix for memory leak in cglpk change_coefficient

### DIFF
--- a/cobra/solvers/cglpk.pyx
+++ b/cobra/solvers/cglpk.pyx
@@ -283,6 +283,8 @@ cdef class GLP:
             # if a duplicate exists replace that value and exit
             if indexes[i + 1] == met_index:
                 values[i + 1] = value
+                free(indexes)
+                free(values)
                 glp_set_mat_col(self.glp, rxn_index, col_length, indexes, values)
                 return
         # need to add a new entry


### PR DESCRIPTION
There was a premature return statement that did not clean up the mallocs.