### PR TITLE
Fix for memory leak in cglpk change_coefficient

### DIFF
--- a/cobra/solvers/cglpk.pyx
+++ b/cobra/solvers/cglpk.pyx
@@ -284,6 +284,8 @@ cdef class GLP:
             if indexes[i + 1] == met_index:
                 values[i + 1] = value
                 glp_set_mat_col(self.glp, rxn_index, col_length, indexes, values)
+                free(indexes)
+                free(values)
                 return
         # need to add a new entry
         indexes[col_length + 1] = met_index


### PR DESCRIPTION
There was a premature return statement that did not clean up the mallocs.