### PR TITLE
Added handler for 'near_optimal'. Fixes #245.

### DIFF
--- a/cobra/solvers/mosek.py
+++ b/cobra/solvers/mosek.py
@@ -20,6 +20,7 @@ _SUPPORTS_MILP = True
 status_dict = {
     mosek.solsta.dual_infeas_cer: 'infeasible',
     mosek.solsta.prim_infeas_cer: 'infeasible',
+    mosel.solsta.near_optimal: 'optimal',
     mosek.solsta.optimal: 'optimal',
     mosek.solsta.integer_optimal: 'optimal'}
 


### PR DESCRIPTION
Mosek did not handle 'near_optimal' before. Now it is handled as optimal.