### PR TITLE
Set version requirement for pandas.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ extras = {
     'matlab': ["pymatbridge"],
     'sbml': ["python-libsbml", "lxml"],
     'array': ["numpy>=1.6", "scipy>=0.11.0"],
-    'display': ["matplotlib", "palettable", "pandas"]
+    'display': ["matplotlib", "palettable", "pandas>=0.17.0"]
 }
 
 all_extras = {'Cython>=0.21'}


### PR DESCRIPTION
The new summary functions use `sort_values` which requires pandas>=0.17. This pull request adds that requirement to setup.py. Also see the mailing list where that problem was first reported.