### PR TITLE
Allow add_reactions to accept a generator

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -174,15 +174,16 @@ class Model(Object):
         reaction_list: A list of :class:`~cobra.core.Reaction` objects
 
         """
-        # Only add the reaction if one with the same ID is not already
-        # present in the model.
 
-        # This function really should not used for single reactions
-        if not hasattr(reaction_list, "__len__"):
-            reaction_list = [reaction_list]
+        try:
+            reaction_list = DictList(reaction_list)
+        except TypeError:
+            # This function really should not used for single reactions
+            reaction_list = DictList([reaction_list])
             warn("Use add_reaction for single reactions")
 
-        reaction_list = DictList(reaction_list)
+        # Only add the reaction if one with the same ID is not already
+        # present in the model.
         reactions_in_model = [
             i.id for i in reaction_list if self.reactions.has_id(
                 i.id)]

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -649,7 +649,7 @@ class TestCobraModel(CobraTestCase):
         contained in reactions after adding them to the model.
         """
         _model = self.model_class('test')
-        _model.add_reactions([x.copy() for x in self.model.reactions])
+        _model.add_reactions((x.copy() for x in self.model.reactions))
         _genes = []
         _metabolites = []
         for x in _model.reactions:


### PR DESCRIPTION
This commit allows Model.add_reactions to accept a generator input. Also
changes a unittest to pass a generator rather than an equivalent list.