### PR TITLE
doc: clarify Metabolite docstring regarding compartment arg

### DIFF
--- a/cobra/core/Metabolite.py
+++ b/cobra/core/Metabolite.py
@@ -28,10 +28,8 @@ class Metabolite(Species):
         name: str
             A human readable name.
 
-        compartment: None or a dictionary indicating the cellular location
-        of the metabolite.  Used when in a cobra.Reaction or Model
-        object
-
+        compartment: str or None
+            Compartment of metabolite.
         """
         Species.__init__(self, id, name)
         self.formula = formula


### PR DESCRIPTION
`None or a dictionary` was probably intended be put in as the documentation for `Model.compartements`.