### PR TITLE
Rewrite of summary methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 before_install:
   - pip install pip --upgrade
   # These get cached
-  - pip install numpy scipy python-libsbml cython coveralls jsonschema six matplotlib pandas
+  - pip install numpy scipy python-libsbml cython coveralls jsonschema six matplotlib pandas tabulate
   - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install lxml glpk pep8 palettable; fi
   # Download esolver and add it to the path
   - wget https://opencobra.github.io/pypi_cobrapy_travis/esolver.gz

--- a/cobra/core/Metabolite.py
+++ b/cobra/core/Metabolite.py
@@ -157,12 +157,15 @@ class Metabolite(Species):
             If given, fva should be a float between 0 and 1, representing the
             fraction of the optimum objective to be searched.
 
+        floatfmt: string
+            format method for floats, passed to tabulate. Default is '.3g'.
+
         """
         try:
             from ..flux_analysis.summary import metabolite_summary
             return metabolite_summary(self, **kwargs)
         except ImportError:
-            warn('Summary methods require pandas')
+            warn('Summary methods require pandas/tabulate')
 
 elements_and_molecular_weights = {
     'H':   1.007940,

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -364,11 +364,13 @@ class Model(Object):
 
         threshold: float
             tolerance for determining if a flux is zero (not printed)
+
         fva: int or None
             Whether or not to calculate and report flux variability in the
             output summary
-        round: int
-            number of digits after the decimal place to print
+
+        floatfmt: string
+            format method for floats, passed to tabulate. Default is '.3g'.
 
         """
 
@@ -376,4 +378,4 @@ class Model(Object):
             from ..flux_analysis.summary import model_summary
             return model_summary(self, **kwargs)
         except ImportError:
-            warn('Summary methods require pandas')
+            warn('Summary methods require pandas/tabulate')

--- a/cobra/test/flux_analysis.py
+++ b/cobra/test/flux_analysis.py
@@ -340,22 +340,27 @@ class TestCobraFluxAnalysis(TestCase):
 
         # Test model summary methods
         model = create_test_model("textbook")
+        with self.assertRaises(Exception):
+            model.summary()
         model.optimize()
         desired_entries = [
-            u'glc__D_e     -9.76 \u00B1 0.24'
-            u'co2_e       21.81 \u00B1 2.86',
-            u'nh4_e        -4.84 \u00B1 0.32'
-            u'h_e         19.51 \u00B1 2.86',
-            u'pi_e         -3.13 \u00B1 0.08'
-            u'for_e        2.86 \u00B1 2.86',
-            u'ac_e         0.95 \u00B1 0.95',
-            u'acald_e      0.64 \u00B1 0.64',
-            u'pyr_e        0.64 \u00B1 0.64',
-            u'etoh_e       0.55 \u00B1 0.55',
-            u'lac__D_e     0.54 \u00B1 0.54',
-            u'succ_e       0.42 \u00B1 0.42',
-            u'akg_e        0.36 \u00B1 0.36',
-            u'glu__L_e     0.32 \u00B1 0.32'
+            'idFluxRangeidFluxRangeBiomass_Ecol...0.874',
+            'o2_e       21.8   [19.9, 23.7]'
+            'h2o_e       29.2  [25, 30.7]',
+            'glc__D_e   10     [9.52, 10]'
+            'co2_e       22.8  [18.9, 24.7]',
+            'nh4_e       4.77  [4.53, 5.16]'
+            'h_e         17.5  [16.7, 22.4]',
+            'pi_e        3.21  [3.05, 3.21]'
+            'for_e        0    [0, 5.72]',
+            'ac_e         0    [0, 1.91]',
+            'pyr_e        0    [0, 1.27]',
+            'lac__D_e     0    [0, 1.07]',
+            'succ_e       0    [0, 0.837]',
+            'glu__L_e     0    [0, 0.636]',
+            'akg_e        0    [0, 0.715]',
+            'etoh_e       0    [0, 1.11]',
+            'acald_e      0    [0, 1.27]',
         ]
         for solver in solver_dict:
             with captured_output() as (out, err):
@@ -364,14 +369,14 @@ class TestCobraFluxAnalysis(TestCase):
 
         # test non-fva version (these should be fixed for textbook model
         desired_entries = [
-            "o2_e       -21.80",
-            "glc__D_e   -10.00",
-            "nh4_e       -4.77",
-            "pi_e        -3.21",
-            "h2o_e    29.18",
-            "co2_e    22.81",
-            "h_e      17.53",
-            "Biomass_Ecoli_core    0.874"
+            'o2_e      21.8',
+            'glc__D_e  10',
+            'nh4_e      4.77',
+            'pi_e       3.21',
+            'h2o_e  29.2',
+            'co2_e  22.8',
+            'h_e    17.5',
+            'Biomass_Ecol...  0.874',
         ]
         # Need to use a different method here because
         # there are multiple entries per line.
@@ -383,36 +388,32 @@ class TestCobraFluxAnalysis(TestCase):
 
         # Test metabolite summary methods
         desired_entries = [
-            'PRODUCING REACTIONS -- Ubiquinone-8',
-            '-----------------------------------',
-            '%      FLUX   RXN ID'
-            'REACTION',
-            '100.0%     44    CYTBD'
-            '2.0 h_c + 0.5 o2_c + q8h2_c --> h2o_c + 2.0 h_e +...',
-            'CONSUMING REACTIONS -- Ubiquinone-8',
-            '-----------------------------------',
-            '88.4%    -39   NADH16'
-            '4.0 h_c + nadh_c + q8_c --> 3.0 h_e + nad_c + q8h2_c',
-            '11.6%   -5.1    SUCDi'
-            'q8_c + succ_c --> fum_c + q8h2_c',
+            'PRODUCING REACTIONS -- Ubiquinone-8 (q8_c)',
+            '%       FLUX  RXN ID    REACTION',
+            '100%   43.6   CYTBD     '
+            '2.0 h_c + 0.5 o2_c + q8h2_c --> h2o_c + 2.0 h_e...',
+            'CONSUMING REACTIONS -- Ubiquinone-8 (q8_c)',
+            '%       FLUX  RXN ID    REACTION',
+            '88%    38.5   NADH16    '
+            '4.0 h_c + nadh_c + q8_c --> 3.0 h_e + nad_c + q...',
+            '12%     5.06  SUCDi     q8_c + succ_c --> fum_c + q8h2_c',
         ]
         with captured_output() as (out, err):
             model.metabolites.q8_c.summary()
         self.check_entries(out, desired_entries)
 
         desired_entries = [
-            u'PRODUCING REACTIONS -- D-Fructose 1,6-bisphosphate',
-            u'--------------------------------------------------',
-            u'  %            FLUX   RXN ID'
-            u'REACTION',
-            u'100.0%  7.71 \u00B1 1.54      PFK'
-            u'atp_c + f6p_c --> adp_c + fdp_c + h_c',
-            u'CONSUMING REACTIONS -- D-Fructose 1,6-bisphosphate',
-            u'--------------------------------------------------',
-            u'  %            FLUX   RXN ID'
-            u'REACTION',
-            u'100.0%  7.54 \u00B1 1.37      FBA'
-            u'fdp_c <=> dhap_c + g3p_c',
+            'PRODUCING REACTIONS -- D-Fructose 1,6-bisphosphate (fdp_c)',
+            '----------------------------------------------------------',
+            '%       FLUX  RANGE         RXN ID    REACTION',
+            '100%    7.48  [6.17, 9.26]  PFK       '
+            'atp_c + f6p_c --> adp_c + fdp_c + h_c',
+            'CONSUMING REACTIONS -- D-Fructose 1,6-bisphosphate (fdp_c)',
+            '----------------------------------------------------------',
+            '%       FLUX  RANGE         RXN ID    REACTION',
+            '100%    7.48  [6.17, 8.92]  FBA       fdp_c <=> dhap_c + g3p_c',
+            '0%      0     [0, 1.72]     FBP       '
+            'fdp_c + h2o_c --> f6p_c + pi_c',
         ]
         for solver in solver_dict:
             with captured_output() as (out, err):

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ extras = {
     'matlab': ["pymatbridge"],
     'sbml': ["python-libsbml", "lxml"],
     'array': ["numpy>=1.6", "scipy>=0.11.0"],
-    'display': ["matplotlib", "palettable", "pandas>=0.17.0"]
+    'display': ["matplotlib", "palettable", "pandas>=0.17.0", "tabulate"]
 }
 
 all_extras = {'Cython>=0.21'}


### PR DESCRIPTION
Here's a possible update to the summary methods. This PR should address the issues raised in #240, #266, (and possibly some new ones introduced in #268).

The output has changed slightly, here's a demo of the new methods:

## Model summary
```python
from cobra.test import create_test_model
model = create_test_model('textbook')
model.optimize()
model.summary()
```

    IN FLUXES        OUT FLUXES    OBJECTIVES
    ---------------  ------------  ----------------------
    o2_e      21.8   h2o_e  29.2   Biomass_Ecol...  0.874
    glc__D_e  10     co2_e  22.8
    nh4_e      4.77  h_e    17.5
    pi_e       3.21

Outputs are sorted first by flux value, then by metabolite ID. It should now handle odd model formats, i.e., 

```python
import cobra
model = cobra.io.read_sbml_model('cemet.xml')
model.optimize()
model.summary()
```
    IN FLUXES      OUT FLUXES      OBJECTIVES
    -------------  --------------  ------------
    nadp    1e+03  lac_L    1e+03  r60  173
    g1p   600      nadph    1e+03
    gtp   496      pi       1e+03
    gln   488      gdp    496
    adp    18.5    amp      9.24

## Model summary with FVA
```python
model.summary(fva=.95)
```

    IN FLUXES                       OUT FLUXES                      OBJECTIVES
    ------------------------------  ------------------------------  ----------------------
    id          Flux  Range         id          Flux  Range         Biomass_Ecol...  0.874
    --------  ------  ------------  --------  ------  ------------
    o2_e       21.8   [19.9, 23.7]  h2o_e       29.2  [25, 30.7]
    glc__D_e   10     [9.52, 10]    co2_e       22.8  [18.9, 24.7]
    nh4_e       4.77  [4.53, 5.16]  h_e         17.5  [16.7, 22.4]
    pi_e        3.21  [3.05, 3.21]  for_e        0    [0, 5.72]
                                    ac_e         0    [0, 1.91]
                                    acald_e      0    [0, 1.27]
                                    pyr_e        0    [0, 1.27]
                                    etoh_e       0    [0, 1.11]
                                    lac__D_e     0    [0, 1.07]
                                    succ_e       0    [0, 0.837]
                                    akg_e        0    [0, 0.715]
                                    glu__L_e     0    [0, 0.636]

here the fluxes get sorted by the flux, then the maximum flux, then the minimum. There could probably be some improvements to how the ranges get formatted, but this seems good enough for now.

## Metabolite summaries
```python
model.metabolites.pyr_c.summary()
```

    PRODUCING REACTIONS -- Pyruvate (pyr_c)
    ---------------------------------------
    %      FLUX  RXN ID      REACTION
    ---  ------  ----------  --------------------------------------------------
    85%   10     GLCpts      glc__D_e + pep_c --> g6p_c + pyr_c
    15%    1.76  PYK         adp_c + h_c + pep_c --> atp_c + pyr_c
    
    CONSUMING REACTIONS -- Pyruvate (pyr_c)
    ---------------------------------------
    %      FLUX  RXN ID      REACTION
    ---  ------  ----------  --------------------------------------------------
    79%    9.28  PDH         coa_c + nad_c + pyr_c --> accoa_c + co2_c + nadh_c
    21%    2.48  Biomass...  1.496 3pg_c + 3.7478 accoa_c + 59.81 atp_c + 0....

This now includes the metabolite ID as well as the name. I'm not sure if we want to mess around with reversing the reaction arrow or stoichiometry, so right now you'll have to pay attention that if the reaction is listed as producing/consuming, the flux means for the _metabolite_, not the _reaction_.

## Metabolite with FVA
```python
model.metabolites.pyr_c.summary(fva=.95)
```

    PRODUCING REACTIONS -- Pyruvate (pyr_c)
    ---------------------------------------
    %      FLUX  RANGE         RXN ID      REACTION
    ---  ------  ------------  ----------  ----------------------------------------
    85%   10     [9.52, 10]    GLCpts      glc__D_e + pep_c --> g6p_c + pyr_c
    15%    1.76  [0, 12.3]     PYK         adp_c + h_c + pep_c --> atp_c + pyr_c
    0%     0     [0, 9.32]     ME2         mal__L_c + nadp_c --> co2_c + nadph_c...
    0%     0     [0, 6.88]     ME1         mal__L_c + nad_c --> co2_c + nadh_c +...
    
    CONSUMING REACTIONS -- Pyruvate (pyr_c)
    ---------------------------------------
    %      FLUX  RANGE         RXN ID      REACTION
    ---  ------  ------------  ----------  ----------------------------------------
    79%    9.28  [3.9, 18.8]   PDH         coa_c + nad_c + pyr_c --> accoa_c + c...
    21%    2.48  [2.35, 2.48]  Biomass...  1.496 3pg_c + 3.7478 accoa_c + 59.81 ...
    0%     0     [0, 8.58]     PPS         atp_c + h2o_c + pyr_c --> amp_c + 2.0...
    0%     0     [0, 5.72]     PFL         coa_c + pyr_c --> accoa_c + for_c
    0%     0     [0, 1.27]     PYRt2       h_e + pyr_e <=> h_c + pyr_c
    0%     0     [0, 1.07]     LDH_D       lac__D_c + nad_c <=> h_c + nadh_c + p...

Now the percentages should make more sense, and the fluxes are sorted by the same function as the model summaries. 


Let me know what you guys think, or if there's any other improvements we should consider.