### PR TITLE
Adding bounds property to reaction

### DIFF
--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -179,6 +179,20 @@ class Reaction(Object):
             raise e  # Not sure what the exact problem was
 
     @property
+    def bounds(self):
+        """ A more convienient bounds structure than seperate upper and lower
+        bounds """
+
+        return (self.lower_bound, self.upper_bound)
+
+    @bounds.setter
+    def bounds(self, value):
+        """ Set the bounds directly from a tuple """
+
+        self.lower_bound = value[0]
+        self.upper_bound = value[1]
+
+    @property
     def reversibility(self):
         """Whether the reaction can proceed in both directions (reversible)
 

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -357,6 +357,9 @@ class TestReactions(CobraTestCase):
         pgi = model.reactions.get_by_id("PGI")
         pgi.reaction = "g6p_c --> f6p_c"
         self.assertEqual(pgi.lower_bound, 0)
+        pgi.bounds = (0, 1000)
+        self.assertEqual(pgi.bounds, (0, 1000))
+        self.assertEqual(pgi.reversibility, False)
         pgi.reaction = "g6p_c <== f6p_c"
         self.assertEqual(pgi.upper_bound, 0)
         self.assertEqual(pgi.reaction.strip(), "g6p_c <-- f6p_c")


### PR DESCRIPTION
This PR adds a `bounds` attribute to `cobra.Reaction`, which allows
bounds to be checked and changed with a single line:

```
model.reactions.PGI.bounds = (0, 1000)
```

```
>>> model.reactions.PGI.bounds
(0, 1000)
```

It's a pretty small change, but it parallels the MATLAB toolbox's `changeRxnBounds` function, which had a `b` option to set both bounds at once.