### PR TITLE
Fixed a bug in ArrayBasedModel bounds setting in Python 3

### DIFF
--- a/cobra/core/ArrayBasedModel.py
+++ b/cobra/core/ArrayBasedModel.py
@@ -321,7 +321,7 @@ class LinkedArray(ndarray):
         ndarray.__setitem__(self, index, value)
         if isinstance(index, slice):
             for i, entry in enumerate(self._list[index]):
-                setattr(entry, self._attr, value)
+                setattr(entry, self._attr, value[i])
         else:
             setattr(self._list[index], self._attr, value)
 

--- a/cobra/core/ArrayBasedModel.py
+++ b/cobra/core/ArrayBasedModel.py
@@ -320,21 +320,20 @@ class LinkedArray(ndarray):
     def __setitem__(self, index, value):
         ndarray.__setitem__(self, index, value)
         if isinstance(index, slice):
-            for i, entry in enumerate(self._list[index]):
-                setattr(entry, self._attr, value[i])
+            # not sure why that is here
+            if index.stop == maxsize:
+                index = slice(index.start, len(self))
+            if hasattr(value, "__getitem__"):
+                for i, entry in enumerate(self._list[index]):
+                    setattr(entry, self._attr, value[i])
+            else:
+                for i, entry in enumerate(self._list[index]):
+                    setattr(entry, self._attr, value)
         else:
             setattr(self._list[index], self._attr, value)
 
     def __setslice__(self, i, j, value):
-        ndarray.__setitem__(self, slice(i, j), value)
-        if j == maxsize:
-            j = len(self)
-        if hasattr(value, "__getitem__"):  # setting to a list
-            for index in range(i, j):
-                setattr(self._list[index], self._attr, value[index])
-        else:
-            for index in range(i, j):
-                setattr(self._list[index], self._attr, value)
+        self.__setitem__(self, slice(i, j), value)
 
     def _extend(self, other):
         old_size = len(self)

--- a/cobra/core/ArrayBasedModel.py
+++ b/cobra/core/ArrayBasedModel.py
@@ -333,7 +333,7 @@ class LinkedArray(ndarray):
             setattr(self._list[index], self._attr, value)
 
     def __setslice__(self, i, j, value):
-        self.__setitem__(self, slice(i, j), value)
+        self.__setitem__(slice(i, j), value)
 
     def _extend(self, other):
         old_size = len(self)

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -786,9 +786,12 @@ class TestCobraArrayModel(TestCobraModel):
         self.assertAlmostEqual(model.reactions[0].lower_bound, 0.0)
         model.upper_bounds[1] = 1234.0
         self.assertAlmostEqual(model.reactions[1].upper_bound, 1234.0)
-        model.upper_bounds[0:2] = [100.0, 200.0]
-        self.assertAlmostEqual(model.reactions[0].upper_bound, 100.0)
-        self.assertAlmostEqual(model.reactions[1].upper_bound, 200.0)
+        model.upper_bounds[9:11] = [100.0, 200.0]
+        self.assertAlmostEqual(model.reactions[9].upper_bound, 100.0)
+        self.assertAlmostEqual(model.reactions[10].upper_bound, 200.0)
+        model.upper_bounds[9:11] = 123.0
+        self.assertAlmostEqual(model.reactions[9].upper_bound, 123.0)
+        self.assertAlmostEqual(model.reactions[10].upper_bound, 123.0)
 
 
 # make a test suite to run all of the tests

--- a/cobra/test/unit_tests.py
+++ b/cobra/test/unit_tests.py
@@ -289,7 +289,6 @@ class TestReactions(CobraTestCase):
         model = self.model
         reaction = model.reactions.get_by_id("PGI")
         old_gene = list(reaction.genes)[0]
-        old_gene_reaction_rule = reaction.gene_reaction_rule
         new_gene = model.genes.get_by_id("s0001")
         # add an existing 'gene' to the gpr
         reaction.gene_reaction_rule = 's0001'
@@ -778,6 +777,18 @@ class TestCobraArrayModel(TestCobraModel):
         # mismatched dimensions should give an error
         with self.assertRaises(TypeError):
             model.reactions[[True, False]]
+
+    def test_array_based_bounds_setting(self):
+        model = self.model
+        bounds = [0.0] * len(model.reactions)
+        model.lower_bounds = bounds
+        self.assertEqual(type(model.reactions[0].lower_bound), float)
+        self.assertAlmostEqual(model.reactions[0].lower_bound, 0.0)
+        model.upper_bounds[1] = 1234.0
+        self.assertAlmostEqual(model.reactions[1].upper_bound, 1234.0)
+        model.upper_bounds[0:2] = [100.0, 200.0]
+        self.assertAlmostEqual(model.reactions[0].upper_bound, 100.0)
+        self.assertAlmostEqual(model.reactions[1].upper_bound, 200.0)
 
 
 # make a test suite to run all of the tests


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/cobra-pie/-Yfx7atjII8

This was a fun one.
Python 3 calls only `__setitem__` and not `__setslice__` as Python 2
and there was an error in the LinkedArray class in `__setitem__`
where it would assign all the values to each attribute in place
of assigning each value to the correct attribute.

Also added a unit test so that behavior is checked in the future and removed an 
unused assignment in the unit tests detected by Flake8.