### PR TITLE
Make FVA a bit faster.

### DIFF
--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -50,18 +50,17 @@ def flux_variability_analysis(cobra_model, reaction_list=None,
 def calculate_lp_variability(lp, solver, cobra_model, reaction_list,
                              **solver_args):
     """calculate max and min of selected variables in an LP"""
-    fva_results = {}
-    for r in reaction_list:
-        r_id = str(r)
-        i = cobra_model.reactions.index(r_id)
-        fva_results[r_id] = {}
-        solver.change_variable_objective(lp, i, 1.)
-        solver.solve_problem(lp, objective_sense="maximize", **solver_args)
-        fva_results[r_id]["maximum"] = solver.get_objective_value(lp)
-        solver.solve_problem(lp, objective_sense="minimize", **solver_args)
-        fva_results[r_id]["minimum"] = solver.get_objective_value(lp)
-        # revert the problem to how it was before
-        solver.change_variable_objective(lp, i, 0.)
+    fva_results = {str(r): {} for r in reaction_list}
+    for what in ("minimum", "maximum"):
+        sense = "minimize" if what == "minimum" else "maximize"
+        for r in reaction_list:
+            r_id = str(r)
+            i = cobra_model.reactions.index(r_id)
+            solver.change_variable_objective(lp, i, 1.)
+            solver.solve_problem(lp, objective_sense=sense, **solver_args)
+            fva_results[r_id][what] = solver.get_objective_value(lp)
+            # revert the problem to how it was before
+            solver.change_variable_objective(lp, i, 0.)
     return fva_results
 
 


### PR DESCRIPTION
The FVA in cobrapy alternated between optimizing via minimum and maximum, but the minimum solutions tend to be closer to each other than to the maximum solutions and vice versa. Thus, a better recycling strategy for the solution basis is to minimize all reactions first followed by maximizing them. This is also the algorithm described in the original publication.

## Benchmarks

Recon 2.2, more than 7500 reactions

```python
from cobra.flux_analysis import flux_variability_analysis

%time va = flux_variability_analysis(recon2)
%time va = flux_variability_analysis(recon2, solver="cplex")
%time va = flux_variability_analysis(recon2, solver="gurobi")
```

Old:

```
cglpk:
CPU times: user 2min 5s, sys: 4 ms, total: 2min 5s
Wall time: 2min 5s

cplex:
CPU times: user 59.4 s, sys: 4 ms, total: 59.4 s
Wall time: 59.4 s

gurobi:
CPU times: user 1min 28s, sys: 4 ms, total: 1min 28s
Wall time: 1min 28s

```

New:

```
cglpk:
CPU times: user 1min 30s, sys: 8 ms, total: 1min 30s
Wall time: 1min 30s

cplex:
CPU times: user 47.2 s, sys: 16 ms, total: 47.2 s
Wall time: 47.2 s

gurobi:
CPU times: user 1min 16s, sys: 24 ms, total: 1min 16s
Wall time: 1min 16s
```

More or less 25% speed up, mostly for cglpk which is a bit better in recycling previous solutions in general.