### PR TITLE
adding tabulate to the list of mock imports

### DIFF
--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -37,7 +37,7 @@ class Mock(object):
 
 MOCK_MODULES = ['numpy', 'scipy', 'scipy.sparse', 'scipy.io', 'scipy.stats',
                 'glpk', 'gurobipy', 'gurobipy.GRB', 'cplex', 'pp', 'libsbml',
-                'cplex.exceptions', 'pandas']
+                'cplex.exceptions', 'pandas', 'tabulate']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 


### PR DESCRIPTION
Quick fix to allow sphinx to access the `flux_analysis.summary` code, currently failing on RTD with:
```python
/home/docs/checkouts/readthedocs.org/user_builds/cobrapy/checkouts/latest/documentation_builder/cobra.flux_analysis.rst:90: WARNING: autodoc: failed to import module 'cobra.flux_analysis.summary'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cobrapy/envs/latest/lib/python3.4/site-packages/sphinx/ext/autodoc.py", line 385, in import_object
    __import__(self.modname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/cobrapy/checkouts/latest/cobra/flux_analysis/summary.py", line 5, in <module>
    from tabulate import tabulate
ImportError: No module named 'tabulate'
```

Assuming this should head to `master`, let me know if I should send it to `devel`?