### PR TITLE
Fix/enable inline pytest

### DIFF
--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -1,6 +1,7 @@
 from os.path import join, abspath, dirname
 from cobra.io import read_sbml_model
 import pytest
+
 try:
     from cPickle import load as _load
 except ImportError:
@@ -38,4 +39,5 @@ def create_test_model(model_name="salmonella"):
 def test_all():
     """ alias for running all unit-tests on installed cobra
     """
-    return pytest.main(['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs']) == 0
+    return pytest.main(
+        ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs']) == 0

--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -38,4 +38,4 @@ def create_test_model(model_name="salmonella"):
 def test_all():
     """ alias for running all unit-tests on installed cobra
     """
-    return pytest.main(['--pyargs', 'cobra']) == 0
+    return pytest.main(['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs']) == 0

--- a/cobra/test/test_design.py
+++ b/cobra/test/test_design.py
@@ -3,6 +3,7 @@ import pytest
 from cobra.design import *
 from cobra.design.design_algorithms import _add_decision_variable
 from cobra.solvers import get_solver_name
+from .conftest import model
 
 try:
     solver = get_solver_name(mip=True)

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -8,6 +8,7 @@ from cobra.core import Model, Reaction, Metabolite
 from cobra.solvers import solver_dict, get_solver_name
 from cobra.flux_analysis import *
 from cobra.solvers import SolverNotFound
+from .conftest import model, large_model, solved_model, fva_results
 
 try:
     import numpy

--- a/cobra/test/test_io.py
+++ b/cobra/test/test_io.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 from cobra import io
 from .conftest import data_directory
 
+
 def write_legacy_sbml_placeholder():
     pass
 

--- a/cobra/test/test_io.py
+++ b/cobra/test/test_io.py
@@ -8,7 +8,7 @@ from pickle import load, dump
 import pytest
 from collections import namedtuple
 from cobra import io
-
+from .conftest import data_directory
 
 def write_legacy_sbml_placeholder():
     pass

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -1,6 +1,7 @@
 from cobra.core import Metabolite, Model, Reaction
 from cobra.manipulation import *
 import pytest
+from .conftest import model, salmonella
 
 
 class TestManipulation:

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 from cobra.core import Model, Metabolite, Reaction
 from cobra.solvers import solver_dict
+from .conftest import model, array_model
 
 try:
     import scipy

--- a/cobra/test/test_solvers.py
+++ b/cobra/test/test_solvers.py
@@ -1,6 +1,7 @@
 import pytest
 from cobra.core import Model, Reaction, Metabolite
 from cobra import solvers
+from .conftest import model
 
 try:
     import scipy


### PR DESCRIPTION
without explicitly importing the fixtures, pytest don't find them when running outside the package repo