### PR TITLE
Fix/devel 2 broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   - (git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout ffe5995)
   # matplotlib non-compatible as testing runs in venv (non-framework)
   - TEST_DEPENDS="swiglpk optlang sympy decorator cython codecov coverage numpy scipy python-libsbml jsonschema six pytest pytest-cov pytest-benchmark pandas tabulate"
-  - BUILD_DEPENDS="cython numpy scipy"
+  - BUILD_DEPENDS="swiglpk optlang sympy decorator cython numpy scipy"
   - source multibuild/common_utils.sh
   - source multibuild/travis_steps.sh
   - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
   - (git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout ffe5995)
   # matplotlib non-compatible as testing runs in venv (non-framework)
   - TEST_DEPENDS="swiglpk optlang sympy decorator cython codecov coverage numpy scipy python-libsbml jsonschema six pytest pytest-cov pytest-benchmark pandas tabulate"
-  - BUILD_DEPENDS="swiglpk optlang sympy decorator cython numpy scipy"
+  - BUILD_DEPENDS="swiglpk optlang sympy cython numpy scipy"
   - source multibuild/common_utils.sh
   - source multibuild/travis_steps.sh
   - before_install

--- a/cobra/solvers/__init__.py
+++ b/cobra/solvers/__init__.py
@@ -39,7 +39,6 @@ def add_solver(solver_name, use_name=None):
             use_name = solver_name
     solver_dict[use_name] = eval(solver_name)
 
-import sys
 
 for i in listdir(path.dirname(path.abspath(__file__))):
     if i.startswith("_") or i.startswith(".") or i.startswith('legacy'):
@@ -48,7 +47,6 @@ for i in listdir(path.dirname(path.abspath(__file__))):
         continue
     if i.endswith(".py") or i.endswith(".so") or i.endswith(".pyc") \
             or i.endswith(".pyd"):
-        sys.stdout.write('to try: {}\n'.format(i))
         possible_solvers.add(i.split(".")[0])
 
 if "wrappers" in possible_solvers:
@@ -57,9 +55,7 @@ if "wrappers" in possible_solvers:
 for solver in possible_solvers:
     try:
         add_solver(solver)
-        sys.stdout.write("succeeded: {}\n".format(solver))
     except:
-        sys.stdout.write("failed: {}\n".format(solver))
         pass
     del solver
 

--- a/cobra/solvers/__init__.py
+++ b/cobra/solvers/__init__.py
@@ -39,7 +39,8 @@ def add_solver(solver_name, use_name=None):
             use_name = solver_name
     solver_dict[use_name] = eval(solver_name)
 
-    
+import sys
+
 for i in listdir(path.dirname(path.abspath(__file__))):
     if i.startswith("_") or i.startswith(".") or i.startswith('legacy'):
         continue
@@ -47,6 +48,7 @@ for i in listdir(path.dirname(path.abspath(__file__))):
         continue
     if i.endswith(".py") or i.endswith(".so") or i.endswith(".pyc") \
             or i.endswith(".pyd"):
+        sys.stdout.write('to try: {}\n'.format(i))
         possible_solvers.add(i.split(".")[0])
 
 if "wrappers" in possible_solvers:
@@ -56,6 +58,8 @@ for solver in possible_solvers:
     try:
         add_solver(solver)
     except:
+
+        sys.stdout.write("failed: {}\n".format(solver))
         pass
     del solver
 

--- a/cobra/solvers/__init__.py
+++ b/cobra/solvers/__init__.py
@@ -57,8 +57,8 @@ if "wrappers" in possible_solvers:
 for solver in possible_solvers:
     try:
         add_solver(solver)
+        sys.stdout.write("succeeded: {}\n".format(solver))
     except:
-
         sys.stdout.write("failed: {}\n".format(solver))
         pass
     del solver

--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -1,7 +1,6 @@
 from os.path import join, abspath, dirname
 from cobra.io import read_sbml_model
 import pytest
-
 try:
     from cPickle import load as _load
 except ImportError:
@@ -36,8 +35,11 @@ def create_test_model(model_name="salmonella"):
         return _load(infile)
 
 
-def test_all():
+def test_all(args=None):
     """ alias for running all unit-tests on installed cobra
     """
+    args = args if args else []
+
     return pytest.main(
-        ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs']) == 0
+        ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs'] + args
+        ) == 0

--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -42,4 +42,4 @@ def test_all(args=None):
 
     return pytest.main(
         ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs'] + args
-        ) == 0
+        ) != 0

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -464,8 +464,8 @@ class TestReaction:
                 already_included_metabolite.id].expression.has(
                 -1 * new_coefficient * reaction.reverse_variable)
 
+    @pytest.mark.xfail('non-deterministic test')
     def test_add_metabolites_combine_false(self, model):
-        pytest.skip('fix later')
         test_metabolite = Metabolite('test')
         for reaction in model.reactions:
             reaction.add_metabolites({test_metabolite: -66}, combine=False)

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -22,14 +22,6 @@ from cobra.exceptions import UndefinedSolution
 from cobra.util import TimeMachine
 import pytest
 
-slow = pytest.mark.skipif(
-    not pytest.config.getoption("--run-slow"),
-    reason="need --run-slow option to run"
-)
-non_deterministic = pytest.mark.skipif(
-    not pytest.config.getoption("--run-non-deterministic"),
-    reason="need --run-non-deterministic option to run"
-)
 
 solver_trials = ['glpk',
                  pytest.mark.skipif('cplex' not in config.solvers,
@@ -472,8 +464,8 @@ class TestReaction:
                 already_included_metabolite.id].expression.has(
                 -1 * new_coefficient * reaction.reverse_variable)
 
-    @non_deterministic
     def test_add_metabolites_combine_false(self, model):
+        pytest.skip('fix later')
         test_metabolite = Metabolite('test')
         for reaction in model.reactions:
             reaction.add_metabolites({test_metabolite: -66}, combine=False)

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -464,7 +464,7 @@ class TestReaction:
                 already_included_metabolite.id].expression.has(
                 -1 * new_coefficient * reaction.reverse_variable)
 
-    @pytest.mark.xfail('non-deterministic test')
+    @pytest.mark.xfail(reason='non-deterministic test')
     def test_add_metabolites_combine_false(self, model):
         test_metabolite = Metabolite('test')
         for reaction in model.reactions:

--- a/config.sh
+++ b/config.sh
@@ -19,13 +19,14 @@ function pre_build {
 			&& make install)
 	pip install cython
 	cython -a cobra/solvers/cglpk.pyx
-	pip install swiglpk
-	python -c 'import swiglpk'
 	export PATH="$PATH:/usr/local/bin"
+	echo "***** glpsol:" `which glpsol`
 }
 
 function build_wheel {
     # Set default building method to pip
+	python -c 'import swiglpk; print(swiglpk)'
+	python -c 'import cobra; print(cobra)'
     build_bdist_wheel $@
     # since swiglpk doesn't have wheels, we currently must keep glpk
     # installed for testing
@@ -49,7 +50,8 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
-	python -c 'import swiglpk'
+	python -c 'import cobra; print(cobra)'
+	python -c 'import swiglpk; print(swiglpk)'
 	echo "***** glpsol:" `which glpsol`
 	echo $PATH
 	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&

--- a/config.sh
+++ b/config.sh
@@ -50,7 +50,7 @@ function run_tests_in_repo {
 	COVERAGEXML=`python -c "import os,sys; print(os.path.realpath('coverage.xml'))"`
 	COVERAGERC=`python -c "import os,sys; print(os.path.realpath('../.coveragerc'))"`
 	echo -e "import cobra.test; import sys; sys.exit(cobra.test.test_all(['-rsx', '--cov=cobra', '--cov-report=xml:$COVERAGEXML', '--cov-config=$COVERAGERC']))" > run-tests.py
-	(python run-tests.py && mv coverage.xml ..)
+	(python run-tests.py && mv ${COVERAGEXML} ..)
 }
 
 function run_tests {

--- a/config.sh
+++ b/config.sh
@@ -7,26 +7,24 @@ function pre_build {
     if [ -n "$IS_OSX" ]; then
         export CC=clang
         export CXX=clang++
-		export CFLAGS="-fPIC -O3 -arch i386 -arch x86_64 -g -DNDEBUG -mmacosx-version-min=10.6"
-	else
-		yum install -y libxslt libxml2 libxml2-devel libxslt-devel
-	fi
-	curl -O http://ftp.gnu.org/gnu/glpk/glpk-4.60.tar.gz
-	tar xzf glpk-4.60.tar.gz
-	(cd glpk-4.60 \
-			&& ./configure \
-			&& make \
-			&& make install)
-	pip install cython
-	cython -a cobra/solvers/cglpk.pyx
-	export PATH="$PATH:/usr/local/bin"
-	echo "***** glpsol:" `which glpsol`
+        export CFLAGS="-fPIC -O3 -arch i386 -arch x86_64 -g -DNDEBUG -mmacosx-version-min=10.6"
+    else
+        yum install -y libxslt libxml2 libxml2-devel libxslt-devel
+    fi
+    curl -O http://ftp.gnu.org/gnu/glpk/glpk-4.60.tar.gz
+    tar xzf glpk-4.60.tar.gz
+    (cd glpk-4.60 \
+            && ./configure \
+            && make \
+            && make install)
+    pip install cython
+    cython -a cobra/solvers/cglpk.pyx
+    export PATH="$PATH:/usr/local/bin"
 }
 
 function build_wheel {
     # Set default building method to pip
     build_bdist_wheel $@
-	python -c 'import swiglpk; print(swiglpk)'
     # since swiglpk doesn't have wheels, we currently must keep glpk
     # installed for testing
 	# (cd glpk-4.60 && make uninstall)
@@ -49,14 +47,9 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
-	python -c 'import cobra; print(cobra)'
-	python -c 'import swiglpk; print(swiglpk)'
-	echo "***** glpsol:" `which glpsol`
-	echo $PATH
 	echo -e "import cobra.test; import sys; sys.exit(cobra.test.test_all(['-rsx', '--cov=cobra', '--cov-report=xml', '--cov-config=../.coveragerc']))" > run-tests.py
-	(python run-tests.py && mv coverage.xml ..)
-#	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
-#			mv coverage.xml ..)
+	python run-tests.py
+	mv coverage.xml ..
 }
 
 function run_tests {

--- a/config.sh
+++ b/config.sh
@@ -47,9 +47,10 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
-	echo -e "import cobra.test; import sys; sys.exit(cobra.test.test_all(['-rsx', '--cov=cobra', '--cov-report=xml', '--cov-config=../.coveragerc']))" > run-tests.py
-	python run-tests.py
-	mv coverage.xml ..
+	COVERAGEXML=`python -c "import os,sys; print(os.path.realpath('coverage.xml'))"`
+	COVERAGERC=`python -c "import os,sys; print(os.path.realpath('../.coveragerc'))"`
+	echo -e "import cobra.test; import sys; sys.exit(cobra.test.test_all(['-rsx', '--cov=cobra', '--cov-report=xml:$COVERAGEXML', '--cov-config=$COVERAGERC']))" > run-tests.py
+	(python run-tests.py && mv coverage.xml ..)
 }
 
 function run_tests {

--- a/config.sh
+++ b/config.sh
@@ -36,7 +36,6 @@ function run_tests_in_repo {
     # coverage run --source=cobra setup.py test
 	if [ -n "$IS_OSX" ]; then
 		echo -e " testing for mac... "
-		brew install glpk
 	else
 		wget --no-check-certificate \
 			 https://opencobra.github.io/pypi_cobrapy_travis/esolver.gz
@@ -48,8 +47,8 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
-	pip freeze
-	which glpsol
+	echo `which glpsol`
+	echo $PATH
 	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
 			mv coverage.xml ..)
 }

--- a/config.sh
+++ b/config.sh
@@ -19,6 +19,8 @@ function pre_build {
 			&& make install)
 	pip install cython
 	cython -a cobra/solvers/cglpk.pyx
+	pip install swiglpk
+	python -c 'import swiglpk'
 	export PATH="$PATH:/usr/local/bin"
 }
 
@@ -47,7 +49,8 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
-	echo `which glpsol`
+	python -c 'import swiglpk'
+	echo "***** glpsol:" `which glpsol`
 	echo $PATH
 	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
 			mv coverage.xml ..)

--- a/config.sh
+++ b/config.sh
@@ -25,9 +25,8 @@ function pre_build {
 
 function build_wheel {
     # Set default building method to pip
-	python -c 'import swiglpk; print(swiglpk)'
-	python -c 'import cobra; print(cobra)'
     build_bdist_wheel $@
+	python -c 'import swiglpk; print(swiglpk)'
     # since swiglpk doesn't have wheels, we currently must keep glpk
     # installed for testing
 	# (cd glpk-4.60 && make uninstall)

--- a/config.sh
+++ b/config.sh
@@ -25,7 +25,9 @@ function pre_build {
 function build_wheel {
     # Set default building method to pip
     build_bdist_wheel $@
-	(cd glpk-4.60 && make uninstall)
+    # since swiglpk doesn't have wheels, we currently must keep glpk
+    # installed for testing
+	# (cd glpk-4.60 && make uninstall)
 }
 
 function run_tests_in_repo {

--- a/config.sh
+++ b/config.sh
@@ -36,6 +36,7 @@ function run_tests_in_repo {
     # coverage run --source=cobra setup.py test
 	if [ -n "$IS_OSX" ]; then
 		echo -e " testing for mac... "
+		brew install glpk
 	else
 		wget --no-check-certificate \
 			 https://opencobra.github.io/pypi_cobrapy_travis/esolver.gz
@@ -47,6 +48,8 @@ function run_tests_in_repo {
 	fi
 	mkdir -p $HOME/.config/matplotlib
 	echo 'backend: Agg' >> $HOME/.config/matplotlib/matplotlibrc
+	pip freeze
+	which glpsol
 	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
 			mv coverage.xml ..)
 }

--- a/config.sh
+++ b/config.sh
@@ -53,8 +53,10 @@ function run_tests_in_repo {
 	python -c 'import swiglpk; print(swiglpk)'
 	echo "***** glpsol:" `which glpsol`
 	echo $PATH
-	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
-			mv coverage.xml ..)
+	echo -e "import cobra.test; import sys; sys.exit(cobra.test.test_all(['-rsx', '--cov=cobra', '--cov-report=xml', '--cov-config=../.coveragerc']))" > run-tests.py
+	(python run-tests.py && mv coverage.xml ..)
+#	(pytest --pyargs -v -rsx --cov=cobra --cov-report=xml --cov-config=../.coveragerc --benchmark-skip cobra &&
+#			mv coverage.xml ..)
 }
 
 function run_tests {

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,0 @@
-def pytest_addoption(parser):
-    parser.addoption("--run-slow", action="store_true",
-                     help="run slow tests")
-    parser.addoption("--run-non-deterministic", action="store_true",
-                     help="run tests that not always yield the same results")


### PR DESCRIPTION
several reasons why devel-2 failed:

- swiglpk depends on glpk so can't uninstall that prior to testing as is done in devel
- cmdline pytest --pyargs for some reason doesn't use the installed cobra resulting in not finding solver. this is now avoided. However, running pytest as now implemented extra args (e.g. --slow) don't directly work. Since this functionality currently is not critically important, it was removed
- previous reported status from cobra.test.test_all() was reported wrongly