### PR TITLE
Fix for failing test on Windows

### DIFF
--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -49,8 +49,10 @@ def solved_model(request, model):
 
 class TestLazySolution:
     def test_self_invalidation(self, solved_model):
+        from time import sleep
         solution, model = solved_model
         assert abs(solution.f - 0.873921506968431) < 0.000001
+        sleep(0.05)
         model.optimize()
         with pytest.raises(UndefinedSolution):
             getattr(solution, 'f')


### PR DESCRIPTION
`LazySolution` uses the current time stamp to judge whether a solution has changed. On windows `time.time` has lower resoultion than on Linux (officially 1/60 of a second). If resolving takes less than the solution gets the same timestamp. Introducing a sleep period > 1/60 s fixes the test, however for the future we might not want to rely on the time stamp for that. Maybe one could hash the solution and compare hashes rather than timestamps. 