### PR TITLE
fix: model copy and dict search

### DIFF
--- a/cobra/core/DictList.py
+++ b/cobra/core/DictList.py
@@ -79,7 +79,7 @@ class DictList(list):
                 return getattr(x, attribute)
 
         # if the search_function is a regular expression
-        if isinstance(search_function, str):
+        if isinstance(search_function, string_types):
             search_function = re.compile(search_function)
         if hasattr(search_function, "findall"):
             matches = (i for i in self

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -96,10 +96,13 @@ class Model(Object):
         than deepcopy
         """
         new = self.__class__()
-        do_not_copy = {"metabolites", "reactions", "genes"}
+        do_not_copy = {"metabolites", "reactions", "genes", "notes",
+                       "annotation"}
         for attr in self.__dict__:
             if attr not in do_not_copy:
                 new.__dict__[attr] = self.__dict__[attr]
+        new.notes = copy(self.notes)
+        new.annotation = copy(self.annotation)
 
         new.metabolites = DictList()
         do_not_copy = {"_reaction", "_model"}

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -96,20 +96,20 @@ class Model(Object):
         than deepcopy
         """
         new = self.__class__()
-        do_not_copy = {"metabolites", "reactions", "genes", "notes",
-                       "annotation"}
+        do_not_copy_by_ref = {"metabolites", "reactions", "genes", "notes",
+                              "annotation"}
         for attr in self.__dict__:
-            if attr not in do_not_copy:
+            if attr not in do_not_copy_by_ref:
                 new.__dict__[attr] = self.__dict__[attr]
-        new.notes = copy(self.notes)
-        new.annotation = copy(self.annotation)
+        new.notes = deepcopy(self.notes)
+        new.annotation = deepcopy(self.annotation)
 
         new.metabolites = DictList()
-        do_not_copy = {"_reaction", "_model"}
+        do_not_copy_by_ref = {"_reaction", "_model"}
         for metabolite in self.metabolites:
             new_met = metabolite.__class__()
             for attr, value in iteritems(metabolite.__dict__):
-                if attr not in do_not_copy:
+                if attr not in do_not_copy_by_ref:
                     new_met.__dict__[attr] = copy(
                         value) if attr == "formula" else value
             new_met._model = new
@@ -119,18 +119,18 @@ class Model(Object):
         for gene in self.genes:
             new_gene = gene.__class__(None)
             for attr, value in iteritems(gene.__dict__):
-                if attr not in do_not_copy:
+                if attr not in do_not_copy_by_ref:
                     new_gene.__dict__[attr] = copy(
                         value) if attr == "formula" else value
             new_gene._model = new
             new.genes.append(new_gene)
 
         new.reactions = DictList()
-        do_not_copy = {"_model", "_metabolites", "_genes"}
+        do_not_copy_by_ref = {"_model", "_metabolites", "_genes"}
         for reaction in self.reactions:
             new_reaction = reaction.__class__()
             for attr, value in iteritems(reaction.__dict__):
-                if attr not in do_not_copy:
+                if attr not in do_not_copy_by_ref:
                     new_reaction.__dict__[attr] = copy(value)
             new_reaction._model = new
             new.reactions.append(new_reaction)

--- a/cobra/test/test_dictlist.py
+++ b/cobra/test/test_dictlist.py
@@ -177,6 +177,8 @@ class TestDictList:
         test_list.append(obj2)
         result = test_list.query("test1")  # matches only test1
         assert len(result) == 1
+        result = test_list.query(u"test1")  # matches with unicode
+        assert len(result) == 1
         assert result[0] == obj
         result = test_list.query("foo", "name")  # matches only test2
         assert len(result) == 1

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -419,6 +419,8 @@ class TestCobraModel:
         # number of reactions in the original model
         model_copy = model.copy()
         old_reaction_count = len(model.reactions)
+        assert model_copy.notes is not model.notes
+        assert model_copy.annotation is not model.annotation
         assert len(model.reactions) == len(model_copy.reactions)
         assert len(model.metabolites) == len(model_copy.metabolites)
         model_copy.remove_reactions(model_copy.reactions[0:5])


### PR DESCRIPTION
model.notes and model.annotatation object were only copied by reference
which is unintuitive, let's copy those

querying dictlist with a unicode string triggered bug, use six