### PR TITLE
Fix/buildplans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ matrix:
         - MB_PYTHON_VERSION=3.5
 
 before_install:
-  - rvm get head
   - (git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout ffe5995)
   # matplotlib non-compatible as testing runs in venv (non-framework)
   - TEST_DEPENDS="cython codecov coverage numpy scipy python-libsbml jsonschema six pytest pytest-cov pytest-benchmark pandas tabulate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - build_wheel . $PLAT
 
 script:
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then pip install pip --upgrade; pip install rstcheck pep8; pep8 cobra --exclude=oven,solvers,sbml.py --show-source; rstcheck *.rst; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then pip install pip --upgrade; pip install 'sphinx>=1.5' rstcheck pep8; pep8 cobra --exclude=oven,solvers,sbml.py --show-source; rstcheck *.rst; fi
   - install_run $PLAT
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ cache:
 install:
   - "powershell appveyor\\install.ps1"
   - ps: Start-FileDownload 'https://bitbucket.org/gutworth/six/raw/default/six.py'
-  - "%PYTHON%/python -m pip install pip 'setuptools>=24.0' wheel --upgrade"
+  - "%PYTHON%/python -m pip install pip setuptools>=24.0 wheel --upgrade"
   - "%WITH_COMPILER% %PYTHON%/python appveyor/build_glpk.py"
   - "%PYTHON%/python -m pip install --upgrade pytest"
   - "%PYTHON%/python -m pip install pytest-cov pytest-benchmark"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,8 @@ cache:
 install:
   - "powershell appveyor\\install.ps1"
   - ps: Start-FileDownload 'https://bitbucket.org/gutworth/six/raw/default/six.py'
+  - "%PYTHON%/python -m pip install pip 'setuptools>=24.0' wheel --upgrade"
   - "%WITH_COMPILER% %PYTHON%/python appveyor/build_glpk.py"
-  - "%PYTHON%/python -m pip install pip setuptools wheel --upgrade"
   - "%PYTHON%/python -m pip install --upgrade pytest"
   - "%PYTHON%/python -m pip install pytest-cov pytest-benchmark"
   - "%PYTHON%/python -m pip install Cython jsonschema twine pypandoc==1.1.3"

--- a/appveyor/build_glpk.py
+++ b/appveyor/build_glpk.py
@@ -4,7 +4,7 @@ import hashlib
 import tarfile
 import struct
 import shutil
-import setuptools.msvc9_support
+import setuptools.msvc
 try:
     import urllib2
 except ImportError:  # python 3
@@ -35,7 +35,7 @@ def get_vcvarsall_cmd():
         vc_ver = 10
     else:
         vc_ver = 9
-    vc_path = setuptools.msvc9_support.find_vcvarsall(vc_ver)
+    vc_path = setuptools.msvc.msvc9_find_vcvarsall(vc_ver)
     assert vc_path is not None
     return '"%s" %s' % (vc_path, " amd64" if bitness == 64 else "")
 


### PR DESCRIPTION
- appveyor buildplans pin setuptools to recent version across python version
- travis remove redundant and broken `rvm get head`
- travis install recent sphinx for rstcheck