### PR TITLE
Add helper functions for optlang solvers that work with new context

### DIFF
--- a/cobra/config.py
+++ b/cobra/config.py
@@ -8,19 +8,3 @@ log = logging.getLogger(__name__)
 
 non_zero_flux_threshold = 1e-6
 ndecimals = 6
-
-# Determine available solver interfaces
-solvers = {}
-
-try:
-    from optlang import glpk_interface
-
-    solvers['glpk'] = glpk_interface
-except ImportError:
-    pass
-try:
-    from optlang import cplex_interface
-
-    solvers['cplex'] = cplex_interface
-except ImportError:
-    pass

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -17,13 +17,14 @@ except ImportError:
 import six
 
 from cobra import config
+from cobra.util.solver import solvers, SolverNotFound
 from cobra.core import Metabolite, Reaction, Model, LazySolution
 from cobra.exceptions import UndefinedSolution
 import pytest
 
 
 solver_trials = ['glpk',
-                 pytest.mark.skipif('cplex' not in config.solvers,
+                 pytest.mark.skipif('cplex' not in solvers,
                                     reason='no cplex')]
 
 
@@ -724,15 +725,15 @@ class TestSolverBasedModel:
                          7) == 0
 
     def test_invalid_solver_change_raises(self, model):
-        with pytest.raises(ValueError):
+        with pytest.raises(SolverNotFound):
             setattr(model, 'solver', [1, 2, 3])
-        with pytest.raises(ValueError):
+        with pytest.raises(SolverNotFound):
             setattr(model, 'solver',
                     'ThisIsDefinitelyNotAvalidSolver')
-        with pytest.raises(ValueError):
+        with pytest.raises(SolverNotFound):
             setattr(model, 'solver', os)
 
-    @pytest.mark.skipif('cplex' not in config.solvers, reason='no cplex')
+    @pytest.mark.skipif('optlang-cplex' not in solvers, reason='no cplex')
     def test_change_solver_to_cplex_and_check_copy_works(self, model):
         assert round(abs(model.optimize().f - 0.8739215069684306), 7) == 0
         model_copy = model.copy()

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -733,7 +733,7 @@ class TestSolverBasedModel:
         with pytest.raises(SolverNotFound):
             setattr(model, 'solver', os)
 
-    @pytest.mark.skipif('optlang-cplex' not in solvers, reason='no cplex')
+    @pytest.mark.skipif('cplex' not in solvers, reason='no cplex')
     def test_change_solver_to_cplex_and_check_copy_works(self, model):
         assert round(abs(model.optimize().f - 0.8739215069684306), 7) == 0
         model_copy = model.copy()

--- a/cobra/test/test_solver_utils.py
+++ b/cobra/test/test_solver_utils.py
@@ -1,0 +1,56 @@
+import cobra.util.solver as su
+from cobra.test.conftest import model
+
+
+class TestHelpers:
+    def test_solver_list(self):
+        assert len(su.solvers) >= 1
+        assert "glpk" in su.solvers
+
+    def test_interface_str(self):
+        assert su.interface_to_str("nonsense") == "nonsense"
+        assert su.interface_to_str("optlang.glpk_interface") == "glpk"
+        assert su.interface_to_str("optlang-cplex") == "cplex"
+
+    def test_solver_name(self):
+        assert su.get_solver_name() == "glpk"
+
+
+class TestSolverMods:
+    def test_add_remove(self, model):
+        v = model.solver.variables
+        new_var = model.solver.interface.Variable("test_var", lb=-10, ub=-10)
+        new_constraint = model.solver.interface.Constraint(
+            v.PGK - new_var, name="test_constraint", lb=0)
+
+        su.add_to_solver(model, [new_var, new_constraint])
+        assert "test_var" in model.solver.variables.keys()
+        assert "test_constraint" in model.solver.constraints.keys()
+
+        su.remove_from_solver(model, [new_var, new_constraint])
+        assert "test_var" not in model.solver.variables.keys()
+        assert "test_constraint" not in model.solver.constraints.keys()
+
+    def test_add_remove_in_context(self, model):
+        v = model.solver.variables
+        new_var = model.solver.interface.Variable("test_var", lb=-10, ub=-10)
+
+        with model:
+            su.add_to_solver(model, [new_var])
+            su.remove_from_solver(model, [v.PGM])
+            assert "test_var" in model.solver.variables.keys()
+            assert "PGM" not in model.solver.variables.keys()
+
+        assert "test_var" not in model.solver.variables.keys()
+        assert "PGM" in model.solver.variables.keys()
+
+    def test_absolute_expression(self, model):
+        v = model.solver.variables
+        with model:
+            su.add_absolute_expression(model, 2 * v.PGM, name="test", ub=100)
+            assert "test" in model.solver.variables.keys()
+            assert "abs_pos_test" in model.solver.constraints.keys()
+            assert "abs_neg_test" in model.solver.constraints.keys()
+        assert "test" not in model.solver.variables.keys()
+        assert "abs_pos_test" not in model.solver.constraints.keys()
+        assert "abs_neg_test" not in model.solver.constraints.keys()

--- a/cobra/util/__init__.py
+++ b/cobra/util/__init__.py
@@ -1,2 +1,3 @@
 from cobra.util.util import *
 from cobra.util.context import *
+from cobra.util.solver import *

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -1,0 +1,153 @@
+"""This module includes additional helper functions for the optlang
+solver object that integrate well with the context manager, meaning that
+all operations defined here work well with the model context manager.
+
+The functions defined here together with the existing model functions should
+allow you to implement custom flux analysis methods with ease."""
+
+from cobra.util.context import get_context
+from functools import partial
+import optlang
+
+
+class SolverNotFound(Exception):
+    None
+
+
+solvers = {match.split("_")[0]: getattr(optlang, match)
+           for match in dir(optlang) if "_interface" in match}
+
+
+def get_solver_name(mip=False, qp=False):
+    """Selects a solver for a given optimization problem in a reproducible
+    manner.
+
+    Parameters
+    ----------
+    mip: string
+    Does the solver require mixed integer linear programming capabilities?
+    qp: string
+    Does the solver require quadratic programming capabilities?
+
+    Returns
+    -------
+    name: string
+    The name of feasible solver.
+
+    Notes
+    -----
+    Raises SolverNotFound if a suitable solver is not found.
+    """
+    if len(solvers) == 0:
+        raise SolverNotFound("no solvers installed")
+    # glpk only does lp, not qp. Gurobi and cplex are better at mip
+    mip_order = ["gurobi", "cplex", "mosek", "glpk"]
+    lp_order = ["glpk", "cplex",  "gurobi", "mosek", "scipy"]
+    qp_order = ["gurobi", "cplex", "mosek"]
+
+    if mip is False and qp is False:
+        for solver_name in lp_order:
+            if solver_name in solvers:
+                return solver_name
+        # none of them are in the list order - so return the first one
+        return list(solvers)[0]
+    elif qp:  # mip does not yet matter for this determination
+        for solver_name in qp_order:
+            if solver_name in solvers:
+                return solver_name
+        raise SolverNotFound("no qp-capable solver found")
+    else:
+        for solver_name in mip_order:
+            if solver_name in solvers:
+                return solver_name
+    raise SolverNotFound("no mip-capable solver found")
+
+
+def add_to_solver(model, variables=[], constraints=[]):
+    """Adds variables and constraints to a Model's solver object.
+
+    Useful for variables and constraints that can not be expressed with
+    reactions and lower/upper bounds. Will integrate with the Model's context
+    manager in order to revert changes upon leaving the context.
+
+    Parameters
+    ----------
+    model: a cobra model
+    The model to which to add the variables and constraints.
+    variables: list or tuple of optlang variables.
+    The variables to add to the model. Must be of class
+    `model.solver.interface.Variable`.
+    constraints: list or tuple of optlang constraints
+    The constraints to add to the model. Must be of class
+    `model.solver.interface.Constraint`.
+    """
+    context = get_context(model)
+    both = variables + constraints
+
+    if len(both) > 0:
+        model.solver.add(both)
+        if context:
+            context(partial(model.solver.remove, both))
+
+
+def remove_from_solver(model, variables=[], constraints=[]):
+    """Removes variables and constraints from a Model's solver object.
+
+    Useful to temporarily remove variables and constraints from a Models's
+    solver object.
+
+    Parameters
+    ----------
+    model: a cobra model
+    The model from which to remove the variables and constraints.
+    variables: list or tuple of optlang variables.
+    The variables to remove from the model. Must be of class
+    `model.solver.interface.Variable`.
+    constraints: list or tuple of optlang constraints
+    The constraints to remove from the model. Must be of class
+    `model.solver.interface.Constraint`.
+    """
+    context = get_context(model)
+    both = variables + constraints
+
+    if len(both) > 0:
+        model.solver.remove(both)
+        if context:
+            context(partial(model.solver.add, both))
+
+
+def add_absolute_expression(model, expression, name="abs_var", ub=None):
+    """Adds the absolute value of an expression to the model and defines
+    a variable for the absolute value that can be used in other objectives or
+    constraints.
+
+    Parameters
+    ----------
+    model: a cobra model
+    The model to which to add the absolute expression.
+    expression: A sympy expression
+    Must be a valid expression within the Model's solver object. The absolute
+    value is applied automatically on the expression.
+    name: string
+    The name of the newly created variable.
+    ub: positive float
+    The upper bound for the variable.
+    """
+
+    context = get_context(model)
+    variable = model.solver.interface.Variable(name, lb=0, ub=ub)
+
+    # The following constraints enforce variable > expression and
+    # variable > - expression
+    constraints = [
+        # positive value constraint
+        model.solver.interface.Constraint(expression - variable, ub=0,
+                                          name="abs_pos_" + name),
+        # negative value constraint
+        model.solver.interface.Constraint(expression + variable, lb=0,
+                                          name="abs_neg_" + name)
+        ]
+    model.solver.add(constraints + [variable])
+
+    if context:
+        context(model.solver.remove(constraints + [variable]))

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -150,8 +150,6 @@ def add_absolute_expression(model, expression, name="abs_var", ub=None):
     ub: positive float
     The upper bound for the variable.
     """
-
-    context = get_context(model)
     variable = model.solver.interface.Variable(name, lb=0, ub=ub)
 
     # The following constraints enforce variable > expression and
@@ -164,7 +162,4 @@ def add_absolute_expression(model, expression, name="abs_var", ub=None):
         model.solver.interface.Constraint(expression + variable, lb=0,
                                           name="abs_neg_" + name)
         ]
-    model.solver.add(constraints + [variable])
-
-    if context:
-        context(partial(model.solver.remove, constraints + [variable]))
+    add_to_solver(model, constraints + [variable])


### PR DESCRIPTION
This is a proposal to pave the way for the optlang port of `flux_analysis.py`. The functions defined in `cobra.util.solver` help to temporarily add or remove variables and constraints to the solver. It also includes helpers to extract all available solver interfaces from `optlang`.

This implied some minor changes in `cobra.Model` in setting `Model.solver` and `Model.optimize`. 

The "solver" keyword is now respected in `Model.optimize` but requires a "optlang-" prefix for the optlang solvers.