### PR TITLE
Changing default query behavior

### DIFF
--- a/cobra/core/DictList.py
+++ b/cobra/core/DictList.py
@@ -54,7 +54,7 @@ class DictList(list):
         """
         return [getattr(i, attribute) for i in self]
 
-    def query(self, search_function, attribute="id"):
+    def query(self, search_function, attribute=None):
         """query the list
 
         search_function: used to select which objects to return
@@ -66,7 +66,7 @@ class DictList(list):
             * a function which takes one argument and returns True
               for desired values
 
-        attribute: the attribute to be searched for (default is 'id').
+        attribute: the attribute to be searched for (default is None).
                    If this is None, the object itself is used.
 
         returns: a list of objects which match the query

--- a/cobra/core/DictList.py
+++ b/cobra/core/DictList.py
@@ -55,21 +55,35 @@ class DictList(list):
         return [getattr(i, attribute) for i in self]
 
     def query(self, search_function, attribute=None):
-        """query the list
+        """Query the list
 
-        search_function: used to select which objects to return
-            * a string, in which case any object.attribute containing
-              the string will be returned
+        Parameters
+        ----------
+        search_function : a string, regular expression or function
+            used to find the matching elements in the list.
 
-            * a compiled regular expression
+            - a regular expression (possibly compiled), in which case the
+            given attribute of the object should match the regular expression.
 
-            * a function which takes one argument and returns True
-              for desired values
+            - a function which takes one argument and returns True for
+            desired values
+        attribute : string or None
+            the name attribute of the object to passed as argument to the
+            `search_function`. If this is None, the object itself is used.
 
-        attribute: the attribute to be searched for (default is None).
-                   If this is None, the object itself is used.
+        Returns
+        -------
+        DictList
+            a new list of objects which match the query
 
-        returns: a list of objects which match the query
+        Examples
+        --------
+        >>> import cobra.test
+        >>> model = cobra.test.create_test_model('textbook')
+        >>> model.reactions.query(lambda x: x.boundary)
+        >>> import re
+        >>> regex = re.compile('^g', flags=re.IGNORECASE)
+        >>> model.metabolites.query(regex, attribute='name')
         """
         def select_attribute(x):
             if attribute is None:

--- a/cobra/core/DictList.py
+++ b/cobra/core/DictList.py
@@ -71,22 +71,31 @@ class DictList(list):
 
         returns: a list of objects which match the query
         """
-        if attribute is None:
-            def select_attribute(x):
+        def select_attribute(x):
+            if attribute is None:
                 return x
-        else:
-            def select_attribute(x):
+            else:
                 return getattr(x, attribute)
 
-        # if the search_function is a regular expression
-        if isinstance(search_function, string_types):
-            search_function = re.compile(search_function)
-        if hasattr(search_function, "findall"):
-            matches = (i for i in self
-                       if search_function.findall(select_attribute(i)) != [])
-        else:
-            matches = (i for i in self
-                       if search_function(select_attribute(i)))
+        try:
+            # if the search_function is a regular expression
+            regex_searcher = re.compile(search_function)
+
+            if attribute is not None:
+                matches = (
+                    i for i in self if
+                    regex_searcher.findall(select_attribute(i)) != [])
+
+            else:
+                # Don't regex on objects
+                matches = (
+                    i for i in self if
+                    regex_searcher.findall(getattr(i, 'id')) != [])
+
+        except TypeError:
+            matches = (
+                i for i in self if search_function(select_attribute(i)))
+
         results = self.__class__()
         results._extend_nocheck(matches)
         return results

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -237,7 +237,7 @@ class TestManipulation:
         # if we remove the SBO term which marks the reaction as
         # mass balanced, then the reaction should be detected as
         # no longer mass balanced
-        EX_rxn = model.reactions.query("EX")[0]
+        EX_rxn = model.reactions.query(lambda r: r.boundary)[0]
         EX_rxn.annotation.pop("SBO")
         balance = check_mass_balance(model)
         assert len(balance) == 1

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -189,7 +189,7 @@ class TestDictList:
         obj2 = Object("test2")
         obj2.name = "foobar1"
         test_list.append(obj2)
-        result = test_list.query("test1", "id")  # matches only test1
+        result = test_list.query("test1")  # matches only test1
         assert len(result) == 1
         result = test_list.query(u"test1", "id")  # matches with unicode
         assert len(result) == 1

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -189,23 +189,26 @@ class TestDictList:
         obj2 = Object("test2")
         obj2.name = "foobar1"
         test_list.append(obj2)
-        result = test_list.query("test1")  # matches only test1
+        result = test_list.query("test1", "id")  # matches only test1
         assert len(result) == 1
-        result = test_list.query(u"test1")  # matches with unicode
+        result = test_list.query(u"test1", "id")  # matches with unicode
         assert len(result) == 1
         assert result[0] == obj
         result = test_list.query("foo", "name")  # matches only test2
         assert len(result) == 1
         assert result[0] == obj2
-        result = test_list.query("test")  # matches test1 and test2
+        result = test_list.query("test", "id")  # matches test1 and test2
         assert len(result) == 2
         # test with a regular expression
-        result = test_list.query(re.compile("test[0-9]"))
+        result = test_list.query(re.compile("test[0-9]"), "id")
         assert len(result) == 2
-        result = test_list.query(re.compile("test[29]"))
+        result = test_list.query(re.compile("test[29]"), "id")
         assert len(result) == 1
         # test query of name
         result = test_list.query(re.compile("foobar."), "name")
+        assert len(result) == 1
+        # test query with lambda function
+        result = test_list.query(lambda x: x.id == 'test1')
         assert len(result) == 1
 
     def test_removal(self):


### PR DESCRIPTION
I mentioned this a while back in the gitter, figured it was an easy enough change I'd just put the PR in to ask how other people feel about this.

I personally don't query on 'id' much, I'll usually use the query function to filter the reactions or metabolite list with a lambda function.

```python
>>> model.reactions.query(lambda r: len(r.reactants) > 1)
```

or 


```python
>>> model.metabolites.query(lambda m: m.charge)
```

Having to pass 'None' each time seems like a bit of a strange default behavior. Would anyone's code be significantly broken by a change like this?
