### PR TITLE
removing __repr_html__ from Solution

### DIFF
--- a/cobra/core/Solution.py
+++ b/cobra/core/Solution.py
@@ -162,9 +162,6 @@ class Solution(SolutionBase):
         fields.remove('y_dict')
         return fields
 
-    def _repr_html_(self):
-        return "%s: %f" % (self.model.solver.objective.expression, self.f)
-
 
 class LazySolution(SolutionBase):
     """This class implements a lazy evaluating version of the Solution class.


### PR DESCRIPTION
This might have been an oversight? I prefer knowing I have a 'Solution' object from the __repr__ methods. It seems to be the only remaining __repr_html__ method in cobrapy.