### PR TITLE
Deprecate ArrayBasedModel

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -8,11 +8,6 @@ from .core import Object, Metabolite, Gene, Reaction, Model, \
     DictList, Species
 from . import io, flux_analysis, design
 
-try:
-    from .core import ArrayBasedModel
-except ImportError:
-    None
-
 __version__ = get_version()
 del get_version
 

--- a/cobra/core/ArrayBasedModel.py
+++ b/cobra/core/ArrayBasedModel.py
@@ -27,6 +27,10 @@ class ArrayBasedModel(Model):
             Specifies which type of backend matrix to use for S.
 
         """
+        warn("ArrayBasedModel is deprecated, use "
+             "`cobra.util.array.create_stoichiometric_matrix` instead",
+             DeprecationWarning)
+
         if deepcopy_model and isinstance(description, Model):
             description = description.copy()
         Model.__init__(self, description)

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -369,18 +369,6 @@ class Model(Object):
         for constraint, terms in six.iteritems(constraint_terms):
             constraint.set_linear_coefficients(terms)
 
-    def to_array_based_model(self, deepcopy_model=False, **kwargs):
-        """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model
-        which may be used to perform linear algebra operations with the
-        stoichiomatric matrix.
-
-        deepcopy_model: Boolean.  If False then the ArrayBasedModel points
-        to the Model
-
-        """
-        from .ArrayBasedModel import ArrayBasedModel
-        return ArrayBasedModel(self, deepcopy_model=deepcopy_model, **kwargs)
-
     def optimize(self, objective_sense='maximize', solution_type=Solution,
                  **kwargs):
         """Optimize model using flux balance analysis

--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -369,6 +369,36 @@ class Model(Object):
         for constraint, terms in six.iteritems(constraint_terms):
             constraint.set_linear_coefficients(terms)
 
+    @property
+    def S(self):
+        """Return a stoichiometric array representation of the given model.
+
+        The the columns represent the reactions and rows represent
+        metabolites. S[i,j] therefore contains the quantity of metabolite `i`
+        produced (negative for consumed) by reaction `j`.
+
+        Returns a dense numpy array.
+        """
+
+        from cobra.util import create_stoichiometric_array
+        return create_stoichiometric_array(self)
+
+    def to_array_based_model(self, deepcopy_model=False, **kwargs):
+        """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model
+        which may be used to perform linear algebra operations with the
+        stoichiomatric matrix.
+
+        Deprecated (0.6). Use `~cobra.util.array.create_stoichiometric_array`
+        or `model.S` instead.
+
+        deepcopy_model: Boolean.  If False then the ArrayBasedModel points
+        to the Model
+
+        """
+
+        from .ArrayBasedModel import ArrayBasedModel
+        return ArrayBasedModel(self, deepcopy_model=deepcopy_model, **kwargs)
+
     def optimize(self, objective_sense='maximize', solution_type=Solution,
                  **kwargs):
         """Optimize model using flux balance analysis

--- a/cobra/core/__init__.py
+++ b/cobra/core/__init__.py
@@ -6,16 +6,3 @@ from .Reaction import Reaction
 from .Solution import Solution, LazySolution
 from .Model import Model
 from .Species import Species
-
-try:
-    import scipy
-except ImportError:
-    scipy = None
-
-if scipy:
-    from .ArrayBasedModel import ArrayBasedModel
-else:
-    from warnings import warn
-    warn("ArrayBasedModel requires scipy")
-    del warn
-del scipy

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -6,11 +6,13 @@ where possible to provide a uniform interface.
 
 from __future__ import division
 import numpy as np
-from ..solvers import solver_dict, get_solver_name
 from copy import deepcopy
 from multiprocessing import Pool, Array
 import ctypes
 from time import time
+
+from ..solvers import solver_dict, get_solver_name
+from cobra.util import create_stoichiometric_array
 
 BTOL = np.finfo(np.float32).eps
 """The tolerance used for checking bounds feasibility."""
@@ -122,7 +124,7 @@ class HRSampler(object):
         self.model = model
         self.thinning = thinning
         self.n_samples = 0
-        self.S = deepcopy(self.model).to_array_based_model().S.toarray()
+        self.S = create_stoichiometric_array(model, array_type='dense')
         self.NS = nullspace(self.S)
         self.bounds = np.array([[r.lower_bound, r.upper_bound]
                                for r in model.reactions]).T

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -143,7 +143,8 @@ def create_mat_dict(model):
     mat["rxns"] = _cell(rxns.list_attr("id"))
     mat["rxnNames"] = _cell(rxns.list_attr("name"))
     mat["subSystems"] = _cell(rxns.list_attr("subsystem"))
-    mat["csense"] = "".join(model._constraint_sense)
+    mat["csense"] = "".join((
+        met._constraint_sense for met in model.metabolites))
     stoich_mat = create_stoichiometric_array(model)
     mat["S"] = stoich_mat if stoich_mat is not None else [[]]
     # multiply by 1 to convert to float, working around scipy bug

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -7,6 +7,7 @@ from scipy.io import loadmat, savemat
 from scipy.sparse import coo_matrix, dok_matrix
 
 from .. import Model, Metabolite, Reaction
+from cobra.util import create_stoichiometric_array
 
 # try to use an ordered dict
 try:
@@ -118,7 +119,6 @@ def create_mat_metabolite_id(model):
 
 def create_mat_dict(model):
     """create a dict mapping model attributes to arrays"""
-    model = model.to_array_based_model(deepcopy_model=True)
     rxns = model.reactions
     mets = model.metabolites
     mat = DictClass()
@@ -144,7 +144,8 @@ def create_mat_dict(model):
     mat["rxnNames"] = _cell(rxns.list_attr("name"))
     mat["subSystems"] = _cell(rxns.list_attr("subsystem"))
     mat["csense"] = "".join(model._constraint_sense)
-    mat["S"] = model.S if model.S is not None else [[]]
+    stoich_mat = create_stoichiometric_array(model)
+    mat["S"] = stoich_mat if stoich_mat is not None else [[]]
     # multiply by 1 to convert to float, working around scipy bug
     # https://github.com/scipy/scipy/issues/4537
     mat["lb"] = array(rxns.list_attr("lower_bound")) * 1.

--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -35,11 +35,6 @@ def large_model():
 
 
 @pytest.fixture(scope="function")
-def array_model():
-    return create_test_model("textbook").to_array_based_model()
-
-
-@pytest.fixture(scope="function")
 def salmonella():
     return create_test_model("salmonella")
 

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     scipy = None
 
+
 class TestReactions:
     def test_gpr(self):
         model = Model()
@@ -511,7 +512,6 @@ class TestCobraModel:
         model.objective = [model.reactions.index(reaction) for
                            reaction in [atpm, biomass]]
         assert model.objective == {atpm: 1., biomass: 1.}
-
 
     def test_context_manager(self, model):
         bounds0 = model.reactions[0].bounds

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -556,7 +556,7 @@ class TestStoichiometricMatrix:
         fluxes = numpy.array(list(model.solution.fluxes.values()))
         for sparse_type in sparse_types:
             S = create_stoichiometric_array(model, array_type=sparse_type)
-            mass_balance = S @ fluxes
+            mass_balance = S.dot(fluxes)
             assert numpy.allclose(mass_balance, 0)
 
         # Is this really the best way to get a vector of fluxes?

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -542,7 +542,7 @@ class TestStoichiometricMatrix:
         S = create_stoichiometric_array(model, array_type='dense', dtype=float)
         model.optimize()
         # Is this really the best way to get a vector of fluxes?
-        mass_balance = S @ numpy.array(list(model.solution.fluxes.values()))
+        mass_balance = S.dot(numpy.array(list(model.solution.fluxes.values())))
         assert numpy.allclose(mass_balance, 0)
 
         # Test model property

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -543,8 +543,10 @@ class TestStoichiometricMatrix:
         model.optimize()
         # Is this really the best way to get a vector of fluxes?
         mass_balance = S @ numpy.array(list(model.solution.fluxes.values()))
-
         assert numpy.allclose(mass_balance, 0)
+
+        # Test model property
+        assert numpy.allclose(model.S, S)
 
     @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
     def test_sparse_matrix(self, model):

--- a/cobra/util/__init__.py
+++ b/cobra/util/__init__.py
@@ -1,3 +1,4 @@
 from cobra.util.util import *
 from cobra.util.context import *
 from cobra.util.solver import *
+from cobra.util.array import *

--- a/cobra/util/__init__.py
+++ b/cobra/util/__init__.py
@@ -1,4 +1,11 @@
 from cobra.util.util import *
 from cobra.util.context import *
 from cobra.util.solver import *
-from cobra.util.array import *
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
+if numpy:
+    from cobra.util.array import *

--- a/cobra/util/array.py
+++ b/cobra/util/array.py
@@ -1,0 +1,54 @@
+from warnings import warn
+from six import iteritems
+
+import numpy as np
+
+try:
+    import scipy
+except ImportError:
+    scipy = None
+
+
+def create_stoichiometric_array(model, array_type='dense', dtype=None):
+    """Return a stoichiometric array representation of the given model.
+
+    The the columns represent the reactions and rows represent
+    metabolites. S[i,j] therefore contains the quantity of metabolite `i`
+    produced (negative for consumed) by reaction `j`.
+
+    model: a :class:`~cobra.core.Model` object
+    array_type: string
+        The type of array to construct. if 'dense', return a standard
+        numpy.array. Otherwise, 'dok', or 'lil' will construct a sparse array
+        using scipy of the corresponding type.
+    dtype: data-type
+        The desired data-type for the array. If not given, defaults to float.
+
+    """
+    if array_type != 'dense' and not scipy:
+        warn('Sparse matrices require scipy')
+
+    if dtype is None:
+        dtype = np.float64
+
+    array_constructor = {
+        'dense': np.zeros,
+        'dok': scipy.sparse.dok_matrix,
+        'lil': scipy.sparse.lil_matrix
+    }
+
+    n_metabolites = len(model.metabolites)
+    n_reactions = len(model.reactions)
+    array = array_constructor[array_type](
+        (n_metabolites, n_reactions), dtype=dtype)
+
+    # Convenience functions to index metabolites and reactions
+    def m_ind(met): return model.metabolites.index(met)
+
+    def r_ind(rxn): return model.reactions.index(rxn)
+
+    for reaction in model.reactions:
+        for metabolite, stoich in iteritems(reaction.metabolites):
+            array[m_ind(metabolite), r_ind(reaction)] = stoich
+
+    return array


### PR DESCRIPTION
Deprecates ArrayBasedModel in favor of separate functions in
cobra.util.array. Still will likely need to implement similar functions
to get bounds arrays for cobra.io.mat

Would close #330 