### PR TITLE
Fix for multiple IDs in Matlab models

### DIFF
--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -174,7 +174,12 @@ def from_mat_struct(mat_struct, model_id=None, inf=inf):
         warn("objective vector 'c' not found")
     model = Model()
     if "description" in m.dtype.names:
-        model.id = m["description"][0, 0][0]
+        description = m["description"][0, 0][0]
+        if len(description) > 1:
+            model.id = description[0]
+            warn("Several IDs detected, only using the first.")
+        else:
+            model.id = description
     elif model_id is not None:
         model.id = model_id
     else:


### PR DESCRIPTION
ID setting is already fixed in `devel-2`. This addresses the loading of matlab models with multiple IDs.

Fixes #342 .