### PR TITLE
fix: avoid duplicated gene associations, fix #333

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -508,6 +508,8 @@ def get_libsbml_document(cobra_model,
         #If they are not identical, they are set to be identical
         note_dict = the_reaction.notes.copy()
         if the_reaction.gene_reaction_rule:
+            if 'GENE ASSOCIATION' in note_dict:
+                del note_dict['GENE ASSOCIATION']
             note_dict['GENE_ASSOCIATION'] = [str(the_reaction.gene_reaction_rule)]
         if the_reaction.subsystem:
             note_dict['SUBSYSTEM'] = [str(the_reaction.subsystem)]


### PR DESCRIPTION
parsing legacy sbml, underscores are dropped for keys, but were then
added back again to reactions notes dict.