### PR TITLE
Cleaning up reaction.boundary

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -630,11 +630,3 @@ class Model(Object):
         """Pop the top context manager and trigger the undo functions"""
         context = self._contexts.pop()
         context.reset()
-
-    def exchanges(self):
-        """Exchange reactions in model.
-
-        Reactions that either don't have products or substrates.
-        """
-        return [reaction for reaction in self.reactions if
-                len(reaction.reactants) == 0 or len(reaction.products) == 0]

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -375,15 +375,12 @@ class Reaction(Object):
 
     @property
     def boundary(self):
-        # single metabolite implies it must be a boundary
-        if len(self._metabolites) == 1:
-            return "system_boundary"
-        # if there is more than one metabolite, if it ONLY produces or ONLY
-        # consumes, it is also a boundary.
-        all_stoichiometry = self._metabolites.values()
-        if not min(all_stoichiometry) < 0 < max(all_stoichiometry):
-            return "system_boundary"
-        return None
+        """Whether or not this reaction is an exchange reaction.
+
+        Returns `True` if the reaction has either no products or reactants.
+        """
+
+        return (not self.reactants) or (not self.products)
 
     @property
     def model(self):


### PR DESCRIPTION
This simplifies the implementation of `reaction.boundary`, and removes the (imo) duplicated / undocumented `model.exchanges`. 

I would suggest users in the future to get exchange reactions with 
```python
model.reactions.query(lambda x: x.boundary)
```

Thoughts?