### PR TITLE
adding return statement to model context

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -644,6 +644,8 @@ class Model(Object):
         except AttributeError:
             self._contexts = [HistoryManager()]
 
+        return self
+
     def __exit__(self, type, value, traceback):
         """Pop the top context manager and trigger the undo functions"""
         context = self._contexts.pop()


### PR DESCRIPTION
one-liner, this just makes the context managers a bit more pythonic. If you wanted, you could now do something like

```python
with my_model as m:
    m.medium = xylose_medium
```

not necessarily recommending it, but its better than returning None.