### PR TITLE
Allow fixed random number seed in flux sampling

### DIFF
--- a/cobra/flux_analysis/__init__.py
+++ b/cobra/flux_analysis/__init__.py
@@ -3,11 +3,6 @@ try:
 except:
     numpy = None
 
-try:
-    import scipy
-except:
-    scipy = None
-
 from .essentiality import assess_medium_component_essentiality
 from .variability import flux_variability_analysis, find_blocked_reactions
 from .single_deletion import single_gene_deletion, single_reaction_deletion
@@ -18,15 +13,9 @@ from .gapfilling import growMatch
 if numpy:
     from .double_deletion import double_reaction_deletion, double_gene_deletion
     from .phenotype_phase_plane import calculate_phenotype_phase_plane
-else:
-    from warnings import warn
-    warn("double deletions and phase planes requires numpy")
-    del warn
-del numpy
-
-if scipy:
     from .sampling import sample
 else:
     from warnings import warn
-    warn("flux sampling requires numpy and scipy")
-del scipy
+    warn("double deletions, phase planes and flux sampling requires numpy")
+    del warn
+del numpy

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -13,11 +13,11 @@ from cobra.manipulation import convert_to_irreversible
 
 try:
     import numpy
+    from cobra.flux_analysis.sampling import ARCHSampler, OptGPSampler
 except ImportError:
     numpy = None
 try:
     import scipy
-    from cobra.flux_analysis.sampling import ARCHSampler, OptGPSampler
 except ImportError:
     scipy = None
 try:
@@ -456,7 +456,7 @@ class TestCobraFluxAnalysis:
             self.check_entries(out, desired_entries)
 
 
-@pytest.mark.skipif(scipy is None, reason="flux sampling requires numpy")
+@pytest.mark.skipif(numpy is None, reason="flux sampling requires numpy")
 class TestCobraFluxSampling:
     """Test and benchmark flux sampling"""
 
@@ -475,6 +475,10 @@ class TestCobraFluxSampling:
     def test_wrong_method(self, model):
         with pytest.raises(ValueError):
             sample(model, 1, method="schwupdiwupp")
+
+    def test_fixed_seed(Self, model):
+        s = sample(model, 1, seed=42)
+        assert numpy.allclose(s[0, 94], 8.38570846)
 
     def setup_class(self):
         from . import create_test_model


### PR DESCRIPTION
From E-mail request. 

This PR allows the random number seed to be specified explicitly thus allowing for reproducible sampling code. For ARCH it will use the given seed as is. OptGP will give each process a seed of `seed + idx` where `idx` is the index of the process ranging from `0 .. n_processes-1`.