### PR TITLE
Fix #363, improved error message

### DIFF
--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -46,4 +46,4 @@ def test_all():
         return pytest.main(
             ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs']) == 0
     else:
-        raise ImportError('missing package pytest required for testing')
+        raise ImportError('missing package pytest and pytest_benchmark required for testing')


### PR DESCRIPTION
This clears up which packages are required for testing.
```
try:
    import pytest
    import pytest_benchmark
except ImportError:
    pytest = None
```
can fail on import of `pytest` or `pytest_benchmark`.