### PR TITLE
Port single deletions to optlang

### DIFF
--- a/cobra/flux_analysis/moma.py
+++ b/cobra/flux_analysis/moma.py
@@ -5,8 +5,8 @@ import cobra.util.solver as sutil
 import sympy
 
 
-def moma_model(model):
-    """Changes a model's objective and bounds to represent a MOMA
+def add_moma(model):
+    """Add constraints and objective representing a MOMA
     (minimization of metabolic adjustment) model.
 
     Parameters:
@@ -38,7 +38,8 @@ def moma_model(model):
          lb_i <= v^d_i <= ub_i
 
     So basically we just re-center the flux space at the old solution and than
-    find the flux distribution closest to the new zero (center).
+    find the flux distribution closest to the new zero (center). This is the
+    same strategy as used in cameo.
 
     The former objective function is saved in the optlang solver interface as
     "moma_old_objective" and this can be used to immediately extract the value

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -88,11 +88,11 @@ def single_reaction_deletion_fba(cobra_model, reaction_list, solver=None,
             for reaction in reaction_list:
                 with m:
                     reaction.bounds = (0.0, 0.0)
-                    m.optimize()
+                    m.solver.optimize()
                     status = m.solver.status
                     status_dict[reaction.id] = status
-                    growth_rate_dict[reaction.id] = m.solution.f if \
-                        status == "optimal" else 0.
+                    growth_rate_dict[reaction.id] = m.solver.objective.value \
+                        if status == "optimal" else 0.
     else:
         # This entire block can be removed once the legacy solvers are
         # deprecated
@@ -147,7 +147,7 @@ def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
             for reaction in reaction_list:
                 with m:
                     reaction.bounds = (0.0, 0.0)
-                    m.optimize(objective_sense="minimize")
+                    m.solver.optimize()
                     status = m.solver.status
                     status_dict[reaction.id] = status
                     if status == "optimal":
@@ -215,10 +215,10 @@ def single_gene_deletion_fba(cobra_model, gene_list, solver=None,
                 with m:
                     for reaction in ko:
                         reaction.bounds = (0.0, 0.0)
-                    m.optimize()
+                    m.solver.optimize()
                     status = m.solver.status
                     status_dict[gene.id] = status
-                    growth_rate_dict[gene.id] = m.solution.f if \
+                    growth_rate_dict[gene.id] = m.solver.objective.value if \
                         status == "optimal" else 0.
     else:
         for gene in gene_list:
@@ -269,7 +269,7 @@ def single_gene_deletion_moma(cobra_model, gene_list, solver=None,
                 with m:
                     for reaction in ko:
                         reaction.bounds = (0.0, 0.0)
-                    m.optimize(objective_sense="minimize")
+                    m.solver.optimize()
                     status = m.solver.status
                     status_dict[gene.id] = status
                     if status == "optimal":

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -17,13 +17,31 @@ else:
 
 def single_reaction_deletion(cobra_model, reaction_list=None, solver=None,
                              method="fba", **solver_args):
-    """sequentially knocks out each reaction in a model
+    """Sequentially knocks out each reaction from a given reaction list.
 
-    reaction_list: list of reaction_ids or cobra.Reaction
+    Parameters
+    ----------
+    cobra_model : a cobra model
+        The model from which to delete the reactions. The model will not be
+        modified.
+    reaction_list : iterable
+        List of reaction IDs or cobra.Reaction. If None (default) will use all
+        reactions in the model.
+    method : str, optional
+        The method used to obtain fluxes. Must be one of "fba" or "moma".
+    solver : str, optional
+        Name of the solver to be used.
+    solver_args : optional
+        Additional arguments for the solver. Ignored for optlang solver, please
+        use `model.solver.configuration` instead.
 
-    method: "fba" or "moma"
-
-    returns ({reaction_id: growth_rate}, {reaction_id: status})"""
+    Returns
+    -------
+    tuple of 2 dictionaries
+        The first dictionary maps each reaction id to its growth rate after
+        the knockout. The second tuple reports the solutions status (for
+        instance "optimal" for each knockout).
+    """
     if reaction_list is None:
         reaction_list = cobra_model.reactions
     else:
@@ -42,14 +60,23 @@ def single_reaction_deletion(cobra_model, reaction_list=None, solver=None,
 
 def single_reaction_deletion_fba(cobra_model, reaction_list, solver=None,
                                  **solver_args):
-    """sequentially knocks out each reaction in a model using FBA
+    """Sequentially knocks out each reaction in a model using FBA.
 
-    reaction_list: list of reaction_ids or cobra.Reaction
+    Not supposed to be called directly use
+    `single_reactions_deletion(..., method="fba")` instead.
 
-    method: "fba" or "moma"
+    Parameters
+    ----------
+    reaction_list : iterable
+        List of reaction Ids or cobra.Reaction.
+    solver: str, optional
+        The name of the solver to be used.
 
-    returns ({reaction_id: growth_rate}, {reaction_id: status})"""
-
+    Returns
+    -------
+    tuple of dicts
+        A tuple ({reaction_id: growth_rate}, {reaction_id: status})
+    """
     legacy = False
     if solver is None:
         solver = cobra_model.solver
@@ -96,14 +123,26 @@ def single_reaction_deletion_fba(cobra_model, reaction_list, solver=None,
 
 def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
                                   **solver_args):
-    """sequentially knocks out each reaction in a model using MOMA
+    """Sequentially knocks out each reaction in a model using MOMA.
 
-    reaction_list: list of reaction_ids or cobra.Reaction
+    Not supposed to be called directly use
+    `single_reactions_deletion(..., method="moma")` instead.
 
+    Parameters
+    ----------
+    reaction_list : iterable
+        List of reaction IDs or cobra.Reaction.
+    solver: str, optional
+        The name of the solver to be used.
 
-    returns ({reaction_id: growth_rate}, {reaction_id: status})"""
+    Returns
+    -------
+    tuple of dicts
+        A tuple ({reaction_id: growth_rate}, {reaction_id: status})
+    """
     # The same function can not be used because MOMA can not re-use the
     # same LP object. Problem re-use leads to incorrect solutions.
+    # This is *not* true for optlang solvers!
     if moma is None:
         raise RuntimeError("scipy required for moma")
 
@@ -149,13 +188,31 @@ def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
 
 def single_gene_deletion(cobra_model, gene_list=None, solver=None,
                          method="fba", **solver_args):
-    """sequentially knocks out each gene in a model
+    """Sequentially knocks out each gene from a given gene list.
 
-    gene_list: list of gene_ids or cobra.Gene
+    Parameters
+    ----------
+    cobra_model : a cobra model
+        The model from which to delete the genes. The model will not be
+        modified.
+    gene_list : iterable
+        List of gene IDs or cobra.Gene. If None (default) will use all genes in
+        the model.
+    method : str, optional
+        The method used to obtain fluxes. Must be one of "fba" or "moma".
+    solver : str, optional
+        Name of the solver to be used.
+    solver_args : optional
+        Additional arguments for the solver. Ignored for optlang solver, please
+        use `model.solver.configuration` instead.
 
-    method: "fba" or "moma"
-
-    returns ({gene_id: growth_rate}, {gene_id: status})"""
+    Returns
+    -------
+    tuple of 2 dictionaries
+        The first dictionary maps each gene id to its growth rate after
+        the knockout. The second tuple reports the solutions status (for
+        instance "optimal" for each knockout).
+    """
     if gene_list is None:
         gene_list = cobra_model.genes
     else:
@@ -174,7 +231,23 @@ def single_gene_deletion(cobra_model, gene_list=None, solver=None,
 
 def single_gene_deletion_fba(cobra_model, gene_list, solver=None,
                              **solver_args):
+    """Sequentially knocks out each gene in a model using FBA.
 
+    Not supposed to be called directly use
+    `single_reactions_deletion(..., method="fba")` instead.
+
+    Parameters
+    ----------
+    gene_list : iterable
+        List of gene IDs or cobra.Reaction.
+    solver: str, optional
+        The name of the solver to be used.
+
+    Returns
+    -------
+    tuple of dicts
+        A tuple ({reaction_id: growth_rate}, {reaction_id: status})
+    """
     legacy = False
     if solver is None:
         solver = cobra_model.solver
@@ -224,6 +297,23 @@ def single_gene_deletion_fba(cobra_model, gene_list, solver=None,
 
 def single_gene_deletion_moma(cobra_model, gene_list, solver=None,
                               **solver_args):
+    """Sequentially knocks out each gene in a model using MOMA.
+
+    Not supposed to be called directly use
+    `single_reactions_deletion(..., method="moma")` instead.
+
+    Parameters
+    ----------
+    gene_list : iterable
+        List of gene IDs or cobra.Reaction.
+    solver: str, optional
+        The name of the solver to be used.
+
+    Returns
+    -------
+    tuple of dicts
+        A tuple ({reaction_id: growth_rate}, {reaction_id: status})
+    """
     if moma is None:
         raise RuntimeError("scipy required for moma")
 

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -1,5 +1,3 @@
-from warnings import warn
-
 from six import string_types, iteritems
 
 from ..manipulation import delete_model_genes, undelete_model_genes
@@ -10,27 +8,11 @@ import cobra.util.solver as solvers
 # this can be removed after deprecation of the old solver interface
 # since the optlang vrsion requires neither numpy nor scipy
 try:
-    import scipy
+    import scipy  # noqa
 except ImportError:
     moma = None
 else:
     from . import moma
-
-
-def single_deletion(cobra_model, element_list=None,
-                    element_type='gene', **kwargs):
-    """Wrapper for single_gene_deletion and single_reaction_deletion
-
-    .. deprecated :: 0.4
-        Use single_reaction_deletion and single_gene_deletion
-    """
-    warn("deprecated - use single_reaction_deletion and single_gene_deletion")
-    if element_type == "reaction":
-        return single_reaction_deletion(cobra_model, element_list, **kwargs)
-    elif element_type == "gene":
-        return single_gene_deletion(cobra_model, element_list, **kwargs)
-    else:
-        raise Exception("unknown element type")
 
 
 def single_reaction_deletion(cobra_model, reaction_list=None, solver=None,

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -143,7 +143,7 @@ def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
     if not legacy:
         with cobra_model as m:
             m.solver = solver
-            moma.moma_model(m)
+            moma.add_moma(m)
             for reaction in reaction_list:
                 with m:
                     reaction.bounds = (0.0, 0.0)
@@ -263,7 +263,7 @@ def single_gene_deletion_moma(cobra_model, gene_list, solver=None,
     if not legacy:
         with cobra_model as m:
             m.solver = solver
-            moma.moma_model(m)
+            moma.add_moma(m)
             for gene in gene_list:
                 ko = find_gene_knockout_reactions(cobra_model, [gene])
                 with m:

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -34,7 +34,11 @@ try:
 except ImportError:
     tabulate = None
 
-all_solvers = ["optlang-" + s for s in sutil.solvers] + list(solver_dict)
+# The scipt interface is currently unstable and may yield errors or infeasible
+# solutions
+stable_optlang = ["glpk", "cplex", "gurobi"]
+all_solvers = ["optlang-" + s for s in stable_optlang if s in sutil.solvers] +\
+              list(solver_dict)
 
 
 @contextmanager
@@ -118,8 +122,6 @@ class TestCobraFluxAnalysis:
 
     @pytest.mark.parametrize("solver", all_solvers)
     def test_single_gene_deletion_fba(self, model, solver):
-        if solver == "optlang-scipy":
-            pytest.skip("scipy LP solver is unstable")
         # expected knockouts for textbook model
         growth_dict = {"b0008": 0.87, "b0114": 0.80, "b0116": 0.78,
                        "b2276": 0.21, "b1779": 0.00}

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -136,7 +136,7 @@ class TestCobraFluxAnalysis:
     def test_single_gene_deletion_moma_benchmark(self, model, benchmark):
         try:
             sutil.get_solver_name(qp=True)
-        except SolverNotFound:
+        except sutil.SolverNotFound:
             pytest.skip("no qp support")
         genes = ['b0008', 'b0114', 'b2276', 'b1779']
         benchmark(single_gene_deletion, model, gene_list=genes,
@@ -145,7 +145,7 @@ class TestCobraFluxAnalysis:
     def test_single_gene_deletion_moma(self, model):
         try:
             sutil.get_solver_name(qp=True)
-        except SolverNotFound:
+        except sutil.SolverNotFound:
             pytest.skip("no qp support")
 
         # expected knockouts for textbook model

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -6,6 +6,7 @@ import re
 from six import iteritems, StringIO
 from cobra.core import Model, Reaction, Metabolite
 from cobra.solvers import solver_dict, get_solver_name
+import cobra.util.solver as sutil
 from cobra.flux_analysis import *
 from cobra.solvers import SolverNotFound
 from .conftest import model, large_model, solved_model, fva_results
@@ -32,6 +33,8 @@ try:
     import tabulate
 except ImportError:
     tabulate = None
+
+all_solvers = ["optlang-" + s for s in sutil.solvers] + list(solver_dict)
 
 
 @contextmanager
@@ -108,27 +111,32 @@ class TestCobraFluxAnalysis:
             optimize_minimal_flux(model, solver=solver)
         model.reactions.ATPM.lower_bound = atpm
 
-    def test_single_gene_deletion_fba_benchmark(self, large_model, benchmark):
+    @pytest.mark.parametrize("solver", all_solvers)
+    def test_single_gene_deletion_fba_benchmark(self, large_model, benchmark,
+                                                solver):
         genes = ['b0511', 'b2521', 'b0651', 'b2502', 'b3132', 'b1486', 'b3384',
                  'b4321', 'b3428', 'b2789', 'b0052', 'b0115',
                  'b2167', 'b0759', 'b3389', 'b4031', 'b3916', 'b2374', 'b0677',
                  'b2202']
-        benchmark(single_gene_deletion, large_model, gene_list=genes)
+        benchmark(single_gene_deletion, large_model, gene_list=genes,
+                  solver=solver)
 
-    def test_single_gene_deletion_fba(self, model):
+    @pytest.mark.parametrize("solver", all_solvers)
+    def test_single_gene_deletion_fba(self, model, solver):
         # expected knockouts for textbook model
         growth_dict = {"b0008": 0.87, "b0114": 0.80, "b0116": 0.78,
                        "b2276": 0.21, "b1779": 0.00}
         rates, statuses = single_gene_deletion(model,
                                                gene_list=growth_dict.keys(),
-                                               method="fba")
+                                               method="fba",
+                                               solver=solver)
         for gene, expected_value in iteritems(growth_dict):
             assert statuses[gene] == 'optimal'
             assert abs(rates[gene] - expected_value) < 0.01
 
     def test_single_gene_deletion_moma_benchmark(self, large_model, benchmark):
         try:
-            get_solver_name(qp=True)
+            sutil.get_solver_name(qp=True)
         except SolverNotFound:
             pytest.skip("no qp support")
         genes = ['b1764', 'b0463', 'b1779', 'b0417']
@@ -137,7 +145,7 @@ class TestCobraFluxAnalysis:
 
     def test_single_gene_deletion_moma(self, model):
         try:
-            get_solver_name(qp=True)
+            sutil.get_solver_name(qp=True)
         except SolverNotFound:
             pytest.skip("no qp support")
 
@@ -152,17 +160,20 @@ class TestCobraFluxAnalysis:
             assert statuses[gene] == 'optimal'
             assert abs(rates[gene] - expected_value) < 0.01
 
-    def test_single_gene_deletion_benchmark(self, large_model, benchmark):
+    @pytest.mark.parametrize("solver", all_solvers)
+    def test_single_gene_deletion_benchmark(self, large_model, benchmark,
+                                            solver):
         reactions = ['CDPMEK', 'PRATPP', 'HISTD', 'PPCDC']
         benchmark(single_reaction_deletion, large_model,
-                  reaction_list=reactions)
+                  reaction_list=reactions, solver=solver)
 
-    def test_single_reaction_deletion(self, model):
+    @pytest.mark.parametrize("solver", all_solvers)
+    def test_single_reaction_deletion(self, model, solver):
         expected_results = {'FBA': 0.70404, 'FBP': 0.87392, 'CS': 0,
                             'FUM': 0.81430, 'GAPD': 0, 'GLUDy': 0.85139}
 
         results, status = single_reaction_deletion(
-            model, reaction_list=expected_results.keys())
+            model, reaction_list=expected_results.keys(), solver=solver)
         assert len(results) == 6
         assert len(status) == 6
         for status_value in status.values():

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -704,38 +704,38 @@ class TestSolverBasedModel:
         with pytest.raises(TypeError):
             setattr(model, 'objective', 3.)
 
-    @pytest.mark.skipif(not scipy, reason='no scipy available')
+    @pytest.mark.skipif("cplex" not in solvers, reason="need cplex")
     def test_solver_change(self, model):
         solver_id = id(model.solver)
         problem_id = id(model.solver.problem)
         solution = model.optimize(solution_type=LazySolution).x_dict
-        model.solver == 'scipy'
+        model.solver = "cplex"
         assert id(model.solver) != solver_id
         assert id(model.solver.problem) != problem_id
-        new_solution = model.optimize(solution_type=LazySolution)
+        new_solution = model.optimize(solution_type=LazySolution).x_dict
         for key in list(solution.keys()):
-            assert round(abs(new_solution.x_dict[key] - solution[key]),
+            assert round(abs(new_solution[key] - solution[key]),
                          7) == 0
 
-    @pytest.mark.skipif(not scipy, reason='no scipy available')
+    @pytest.mark.skipif("cplex" not in solvers, reason="need cplex")
     def test_solver_change_with_optlang_interface(self, model):
         solver_id = id(model.solver)
         problem_id = id(model.solver.problem)
         solution = model.optimize(solution_type=LazySolution).x_dict
-        model.solver = optlang.scipy_interface
+        model.solver = optlang.cplex_interface
         assert id(model.solver) != solver_id
         assert id(model.solver.problem) != problem_id
-        new_solution = model.optimize(solution_type=LazySolution)
+        new_solution = model.optimize(solution_type=LazySolution).x_dict
         for key in list(solution.keys()):
-            assert round(abs(new_solution.x_dict[key] - solution[key]),
+            assert round(abs(new_solution[key] - solution[key]),
                          7) == 0
 
     def test_no_change_for_same_solver(self, model):
         solver_id = id(model.solver)
         problem_id = id(model.solver.problem)
         model.solver = "glpk"
-        assert id(model.solver) != solver_id
-        assert id(model.solver.problem) != problem_id
+        assert id(model.solver) == solver_id
+        assert id(model.solver.problem) == problem_id
 
     def test_invalid_solver_change_raises(self, model):
         with pytest.raises(SolverNotFound):

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -708,11 +708,11 @@ class TestSolverBasedModel:
     def test_solver_change(self, model):
         solver_id = id(model.solver)
         problem_id = id(model.solver.problem)
-        solution = model.optimize(solution_type=LazySolution).x_dict
+        solution = model.optimize(solution_type=LazySolution).fluxes
         model.solver = "cplex"
         assert id(model.solver) != solver_id
         assert id(model.solver.problem) != problem_id
-        new_solution = model.optimize(solution_type=LazySolution).x_dict
+        new_solution = model.optimize(solution_type=LazySolution).fluxes
         for key in list(solution.keys()):
             assert round(abs(new_solution[key] - solution[key]),
                          7) == 0
@@ -721,11 +721,11 @@ class TestSolverBasedModel:
     def test_solver_change_with_optlang_interface(self, model):
         solver_id = id(model.solver)
         problem_id = id(model.solver.problem)
-        solution = model.optimize(solution_type=LazySolution).x_dict
+        solution = model.optimize(solution_type=LazySolution).fluxes
         model.solver = optlang.cplex_interface
         assert id(model.solver) != solver_id
         assert id(model.solver.problem) != problem_id
-        new_solution = model.optimize(solution_type=LazySolution).x_dict
+        new_solution = model.optimize(solution_type=LazySolution).fluxes
         for key in list(solution.keys()):
             assert round(abs(new_solution[key] - solution[key]),
                          7) == 0


### PR DESCRIPTION
Sorry that this took awhile, there were a few hickups to sort out. Particularly there were quite some bugs in our initial optlang code and also small issues with optlang. Due to this there are also several changes in the Model code as well as tests. Also waiting for a new optlang release since optlang/devel includes a fix that helps our `Solution` class.

Single deletions are now fully working with optlang (FBA and MOMA). The FBA deletions are more or less twice as slow with optlang (see appended text file) whereas MOMA is as fast as before or even a little faster.

The new interfaces are much nicher in terms of customizability. For instance triple+ deletions with MOMA were impossible with the old interface. Now you can just use:

```Python
from cobra.flux_analysis.moma import moma_model

with model as m:
     add_moma(m)     # adds constraints and new objective
     m.reactions.r1.bounds = (0, 0)
     m.reactions.r2.bounds = (0, 0)
     m.reactions.r3.bounds = (0, 0)
     m.optimize(objective_sense=None)
     print("New growth rate: ", m.solution.f)
```

Test output
--------------- 
[test_output.txt](https://github.com/opencobra/cobrapy/files/749034/test_output.txt)

Some performance tips
-------------------------------

Currently creating the solution actually takes much longer than solving the model (since optlang.Model.primal_values is not that fast), thus it's a good strategy to avoid calling model.optimize() if you only need a few fluxes. Rather use:

```
model.solver.optimize()
model.solver.variables.my_reaction.primal
```

This is much faster.
