### PR TITLE
Better resets for objectives

### DIFF
--- a/cobra/core/Model.py
+++ b/cobra/core/Model.py
@@ -17,7 +17,7 @@ from sympy.core.singleton import S
 from cobra.util.util import AutoVivification
 from cobra.util.context import HistoryManager, resettable
 from cobra.util.solver import solvers, SolverNotFound, interface_to_str,\
-                              get_solver_name
+                              get_solver_name, reset_objective
 import optlang
 
 
@@ -650,7 +650,7 @@ class Model(Object):
         return self.objective_reactions
 
     @objective.setter
-    @resettable
+    @reset_objective
     def objective(self, value):
         if isinstance(value, six.string_types):
             try:

--- a/cobra/core/Reaction.py
+++ b/cobra/core/Reaction.py
@@ -13,6 +13,7 @@ import hashlib
 
 from cobra.util.util import Frozendict, _is_positive
 from cobra.util.context import resettable
+from cobra.util.solver import reset_objective
 
 
 # precompiled regular expressions
@@ -168,11 +169,13 @@ class Reaction(Object):
         return self._objective_coefficient
 
     @objective_coefficient.setter
+    @reset_objective
     def objective_coefficient(self, value):
         if self.model is not None:
-            coef_difference = value - self.objective_coefficient
-            self.model.solver.objective += \
-                coef_difference * self.flux_expression
+            if self.flux_expression is not None:
+                self.model.solver.objective.set_linear_coefficients(
+                    {self._forward_variable: value,
+                     self._reverse_variable: -value})
         self._objective_coefficient = value
 
     def __copy__(self):


### PR DESCRIPTION
This adds a working and much faster reset for objective manipulations. Basically it will reset the objective using `model.solver.objective` if it detects that the modification came from `Model` also correctly resetting former quadratic objectives (which was not the case before). When it detects that the change cam from `Reaction` it will rather use `set_linear_coefficients` to reset only coefs for that reaction.

This speeds up leaving the context by quite a bit. For example in a naive implementation of FVA I saw a difference of 3 orders of magnitude in performance for the "textbook" model.