### PR TITLE
Port FVA to optlang

### DIFF
--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -3,32 +3,67 @@ from warnings import warn
 from six import iteritems
 from cobra.solvers import solver_dict, get_solver_name
 import cobra.util.solver as sutil
-from sympy import Float
+from sympy.core.singleton import S
 
 
-def flux_variability_analysis(cobra_model, reaction_list=None,
+def flux_variability_analysis(model, reaction_list=None,
                               fraction_of_optimum=1.0, solver=None,
                               **solver_args):
-    legacy = False
-    if solver is None:
-        solver = cobra_model.solver
-    elif "optlang-" in solver:
-        solver = sutil.interface_to_str(solver)
-        solver = sutil.solvers[solver]
-    else:
-        legacy = True
-        solver = solver_dict[solver]
+    """Runs flux variability analysis to find the min/max flux values for each
+    each reaction in `reaction_list`.
+
+    Parameters
+    ----------
+    model : a cobra model
+        The model for which to run the analysis. It will *not* be modified.
+    reaction_list: list of cobra.Reaction or str, optional
+        The reactions for which to obtain min/max fluxes. If None will use
+        all reactions in the model.
+    fraction_of_optimum: float, optional
+        Must be <= 1.0. Requires that the objective value is at least
+        fraction * max_objective_value. A value of 0.85 for instance means that
+        the objective has to be at least at 95% percent of its maximum.
+    solver : str, optional
+        Name of the solver to be used. If None it will respect the solver set
+        in the model (model.solver).
+    **solver_args: additional arguments for legacy solver, optional
+        Additional arguments passed to the legacy solver. Ignored for
+        optlang solver (those can be configured using
+        model.solver.confguration).
+
+    Returns
+    -------
+    dict
+        A nested dictionary {reaction_id: {minimize/maximize: flux}} giving
+        the minimal and maximal flux for each reaction.
+
+    Notes
+    -----
+    This implements the fast version as described in [1]_. Please note that
+    the flux distribution containing all minimal/maximal fluxes does not have
+    to be a feasible solution for the model. Fluxes are minimized/maximized
+    individually and a single minimal flux might require all others to be
+    suboptimal.
+
+    References
+    ----------
+    .. [1] Computationally efficient flux variability analysis.
+       Gudmundsson S, Thiele I.
+       BMC Bioinformatics. 2010 Sep 29;11:489.
+       doi: 10.1186/1471-2105-11-489, PMID: 20920235
+    """
+    legacy, solver = sutil.choose_solver(model, solver)
 
     if reaction_list is None and "the_reactions" in solver_args:
         reaction_list = solver_args.pop("the_reactions")
         warn("the_reactions is deprecated. Please use reaction_list=")
     if reaction_list is None:
-        reaction_list = cobra_model.reactions
+        reaction_list = model.reactions
 
     if not legacy:
-        return _fva_optlang(cobra_model, reaction_list, fraction_of_optimum)
+        return _fva_optlang(model, reaction_list, fraction_of_optimum)
     else:
-        return _fva_legacy(cobra_model, reaction_list, fraction_of_optimum,
+        return _fva_legacy(model, reaction_list, fraction_of_optimum,
                            "maximize", solver, **solver_args)
 
 
@@ -114,7 +149,7 @@ def _fva_optlang(model, reaction_list, fraction):
             m.solver.objective.expression - v, lb=0.0, ub=0.0,
             name="fva_old_objective_constraint")
         sutil.add_to_solver(m, [v, c])
-        model.objective = Float(0.0)  # This will trigger the reset as well
+        model.objective = S.Zero  # This will trigger the reset as well
         for what in ("minimum", "maximum"):
             sense = "min" if what == "minimum" else "max"
             for r in reaction_list:

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -235,12 +235,12 @@ class TestCobraFluxAnalysis:
         assert solution["y"] == reactions
         self.compare_matrices(growth_list, solution["data"])
 
-    @pytest.mark.parametrize("solver", list(solver_dict))
+    @pytest.mark.parametrize("solver", all_solvers)
     def test_flux_variability_benchmark(self, large_model, benchmark, solver):
         benchmark(flux_variability_analysis, large_model, solver=solver,
                   reaction_list=large_model.reactions[1::3])
 
-    @pytest.mark.parametrize("solver", list(solver_dict))
+    @pytest.mark.parametrize("solver", all_solvers)
     def test_flux_variability(self, model, fva_results, solver):
         if solver == "esolver":
             pytest.skip("esolver too slow...")


### PR DESCRIPTION
PR to add optlang to FVA. This already includes several micro-optimizations to get decent speed. However, it gets an additional boost from setting coefs like in #368 or #374. The test output for a version that has #374 merged as well can be found [here](https://github.com/opencobra/cobrapy/files/764889/test_output.txt). Basically there is a difference of about 20% (still 5x faster than the cameo version) but profiling shows that this is mostly due to the Python object system...