### PR TITLE
Loopless solutions for optlang [fix #385]

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -641,7 +641,6 @@ class Model(Object):
         return self.solver.objective
 
     @objective.setter
-    @resettable
     def objective(self, value):
         if isinstance(value, sympy.Basic):
             value = self.solver.interface.Objective(value, sloppy=False)

--- a/cobra/flux_analysis/__init__.py
+++ b/cobra/flux_analysis/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 try:
     import numpy
 except:
@@ -10,7 +11,8 @@ except:
     scipy = None
 
 from cobra.flux_analysis.gapfilling import growMatch
-from cobra.flux_analysis.loopless import construct_loopless_model
+from cobra.flux_analysis.loopless import (
+    construct_loopless_model, loopless_solution)
 from cobra.flux_analysis.parsimonious import optimize_minimal_flux
 from cobra.flux_analysis.single_deletion import (
     single_gene_deletion, single_reaction_deletion)

--- a/cobra/flux_analysis/__init__.py
+++ b/cobra/flux_analysis/__init__.py
@@ -25,6 +25,7 @@ if numpy:
     from cobra.flux_analysis.phenotype_phase_plane import (
         calculate_phenotype_phase_plane,)
     from cobra.flux_analysis.sampling import sample
+    from cobra.flux_analysis.loopless import add_loopless
 else:
     from warnings import warn
     warn("double deletions, phase planes and flux sampling requires numpy")

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -2,12 +2,17 @@
 
 from __future__ import absolute_import
 
-from cobra.core import Metabolite, Reaction
-from cobra.manipulation.modify import convert_to_irreversible
-import numpy as np
 from six import iteritems
-from cobra.util import nullspace, add_to_solver
 from sympy.core.singleton import S
+from cobra.core import Metabolite, Reaction
+from cobra.util import add_to_solver
+from cobra.manipulation.modify import convert_to_irreversible
+
+try:
+    import numpy
+    from cobra.util import nullspace
+except:
+    numpy = None
 
 
 def add_loopless(model, zero_cutoff=1e-12):
@@ -37,7 +42,7 @@ def add_loopless(model, zero_cutoff=1e-12):
        Erratum in: Biophys J. 2011 Mar 2;100(5):1381.
     """
     internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
-    Sint = model.S[:, np.array(internal)]
+    Sint = model.S[:, numpy.array(internal)]
     Nint = nullspace(Sint).T
     max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
     prob = model.solver.interface

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -2,10 +2,74 @@
 
 from __future__ import absolute_import
 
-from six import iteritems
-
 from cobra.core import Metabolite, Reaction
 from cobra.manipulation.modify import convert_to_irreversible
+import numpy as np
+from six import iteritems
+from cobra.util import nullspace, add_to_solver
+from sympy.core.singleton import S
+
+
+def add_loopless(model, zero_cutoff=1e-12):
+    """Add variables and constraints to make a model thermodynamically
+    feasible. This removes flux loops. The used formulation is described
+    in [1]_.
+
+    Parameters
+    ----------
+    model : a cobra model
+        The model to which to add the constraints.
+    zero_cutoff : positive float, optional
+        Cutoff used for null space. Coefficients with an absolute value smaller
+        than `zero_cutoff` are considered to be zero.
+
+    Returns
+    -------
+    Nothing
+
+    References
+    ----------
+    .. [1] Elimination of thermodynamically infeasible loops in steady-state
+       metabolic models.
+       Schellenberger J, Lewis NE, Palsson BØ.
+       Biophys J. 2011 Feb 2;100(3):544-53.
+       doi: 10.1016/j.bpj.2010.12.3707.
+       Erratum in: Biophys J. 2011 Mar 2;100(5):1381.
+    """
+    internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
+    Sint = model.S[:, np.array(internal)]
+    Nint = nullspace(Sint).T
+    max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
+    prob = model.solver.interface
+
+    # Add indicator variables and new constraints
+    to_add = []
+    for i in internal:
+        rxn = model.reactions[i]
+        # indicator variable a_i
+        indicator = prob.Variable("indicator_" + rxn.id, type="binary")
+        # -M*(1 - a_i) <= v_i <= M*a_i
+        on_off_constraint = prob.Constraint(
+            rxn.flux_expression - max_bound * indicator,
+            lb=-max_bound, ub=0, name="on_off_" + rxn.id)
+        # -(max_bound + 1) * a_i + 1 <= G_i <= -(max_bound + 1) * a_i + 1000
+        delta_g = prob.Variable("delta_g_" + rxn.id)
+        delta_g_range = prob.Constraint(
+            delta_g + (max_bound + 1) * indicator,
+            lb=1, ub=max_bound, name="delta_g_range_" + rxn.id)
+        to_add.extend([indicator, on_off_constraint, delta_g, delta_g_range])
+
+    add_to_solver(model, to_add)
+
+    # Add nullspace constraints for G_i
+    for i, row in enumerate(Nint):
+        name = "nullspace_constraint_" + str(i)
+        nullspace_constraint = prob.Constraint(S.Zero, lb=0, ub=0, name=name)
+        add_to_solver(model, [nullspace_constraint])
+        coefs = {model.solver.variables[
+            "delta_g_" + model.reactions[ridx].id]: row[i]
+            for i, ridx in enumerate(internal) if abs(row[i]) > zero_cutoff}
+        model.solver.constraints[name].set_linear_coefficients(coefs)
 
 
 def construct_loopless_model(cobra_model):

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -31,7 +31,7 @@ def add_loopless(model, zero_cutoff=1e-12):
     ----------
     .. [1] Elimination of thermodynamically infeasible loops in steady-state
        metabolic models.
-       Schellenberger J, Lewis NE, Palsson BØ.
+       Schellenberger J, Lewis NE, Palsson BO.
        Biophys J. 2011 Feb 2;100(3):544-53.
        doi: 10.1016/j.bpj.2010.12.3707.
        Erratum in: Biophys J. 2011 Mar 2;100(5):1381.

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -117,8 +117,9 @@ def loopless_solution(model):
     """
     # Need to reoptimize otherwise spurious solution artifacts can cause
     # all kinds of havoc
-    model.solver.optimize()
-    obj_val = model.solver.objective.value
+    print(model.objective.expression)
+    model.optimize(objective_sense=None)
+    obj_val = model.solution.f
 
     prob = model.solver.interface
     with model:
@@ -142,7 +143,7 @@ def loopless_solution(model):
                 model.objective.set_linear_coefficients(
                     {rxn.forward_variable: -1, rxn.reverse_variable: 1})
         model.solver.objective.direction = "min"
-        model.optimize()
+        model.optimize(objective_sense=None)
         if model.solver.status == "optimal":
             fluxes = model.solution.fluxes
         else:
@@ -181,7 +182,8 @@ def loopless_fva_iter(model, reaction, all_fluxes=False, zero_cutoff=1e-12):
         all_fluxes == False (default). Otherwise returns a loopless flux
         solution containing the minimum/maximum flux for `reaction`.
     """
-    current = reaction.flux
+    current = model.solver.objective.value
+    print (reaction, current)
 
     # boundary reactions can not be part of cycles
     if reaction.boundary:

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -13,9 +13,8 @@ from multiprocessing import Array, Pool
 from time import time
 
 import numpy as np
-
 from cobra.solvers import get_solver_name, solver_dict
-from cobra.util import create_stoichiometric_array
+from cobra.util import create_stoichiometric_array, nullspace
 
 BTOL = np.finfo(np.float32).eps
 """The tolerance used for checking bounds feasibility."""
@@ -26,49 +25,6 @@ FTOL = BTOL
 bad_x = None
 bad_delta = None
 bad_alpha = None
-
-
-def nullspace(A, atol=1e-13, rtol=0):
-    """Compute an approximate basis for the nullspace of A.
-    The algorithm used by this function is based on the singular value
-    decomposition of `A`.
-
-    Parameters
-    ----------
-    A : numpy.ndarray
-        A should be at most 2-D.  A 1-D array with length k will be treated
-        as a 2-D with shape (1, k)
-    atol : float
-        The absolute tolerance for a zero singular value.  Singular values
-        smaller than `atol` are considered to be zero.
-    rtol : float
-        The relative tolerance.  Singular values less than rtol*smax are
-        considered to be zero, where smax is the largest singular value.
-
-    If both `atol` and `rtol` are positive, the combined tolerance is the
-    maximum of the two; that is::
-    tol = max(atol, rtol * smax)
-    Singular values smaller than `tol` are considered to be zero.
-
-    Returns
-    -------
-    ns : numpy.ndarray
-        If `A` is an array with shape (m, k), then `ns` will be an array
-        with shape (k, n), where n is the estimated dimension of the
-        nullspace of `A`.  The columns of `ns` are a basis for the
-        nullspace; each element in numpy.dot(A, ns) will be approximately
-        zero.
-
-    Notes
-    -----
-    Taken from the numpy cookbook.
-    """
-    A = np.atleast_2d(A)
-    u, s, vh = np.linalg.svd(A)
-    tol = max(atol, rtol * s[0])
-    nnz = (s >= tol).sum()
-    ns = vh[nnz:].conj().T
-    return ns
 
 
 # Has to be declared outside of class to be used for multiprocessing :(

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -163,7 +163,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
         fva_old_objective = prob.Variable(
             "fva_old_objective", lb=fraction * m.solver.objective.value)
         fva_old_obj_constraint = prob.Constraint(
-            m.solver.objective.expression - fva_old_objective, lb=0.0, ub=0.0,
+            m.solver.objective.expression - fva_old_objective, lb=0, ub=0,
             name="fva_old_objective_constraint")
         sutil.add_to_solver(m, [fva_old_objective, fva_old_obj_constraint])
         model.objective = S.Zero  # This will trigger the reset as well

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -180,6 +180,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
                     {rxn.forward_variable: 1, rxn.reverse_variable: -1})
                 m.solver.objective.direction = sense
                 m.solver.optimize()
+                print(m.solver.status)
                 if loopless:
                     value = loopless_fva_iter(m, rxn)
                 else:

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -180,7 +180,6 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
                     {rxn.forward_variable: 1, rxn.reverse_variable: -1})
                 m.solver.objective.direction = sense
                 m.solver.optimize()
-                print(m.solver.status)
                 if loopless:
                     value = loopless_fva_iter(m, rxn)
                 else:

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -355,6 +355,14 @@ class TestCobraFluxAnalysis:
         assert fluxes_feasible["v3"] == 0.0
         assert fluxes_infeasible["v3"] == 1.0
 
+    def test_loopless_solution_fluxes(self, model):
+        fluxes = model.optimize().fluxes
+        ll_fluxes = loopless_solution(model, fluxes=fluxes)
+        assert len(ll_fluxes) == len(model.reactions)
+        fluxes["Biomass_Ecoli_core"] = 1
+        ll_fluxes = loopless_solution(model, fluxes=fluxes)
+        assert ll_fluxes is None
+
     @pytest.mark.skipif(numpy is None, reason="null space requires numpy")
     def test_add_loopless(self):
         test_model = self.construct_ll_test_model()

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -331,13 +331,7 @@ class TestCobraFluxAnalysis:
         assert feasible_sol.status == "optimal"
         assert infeasible_sol.status == "infeasible"
 
-    def test_loopless(self):
-        try:
-            sutil.get_solver_name(mip=True)
-        except SolverNotFound:
-            pytest.skip("no MILP solver found")
-
-        # test with loopless_solution
+    def test_loopless_solution(self):
         test_model = self.construct_ll_test_model()
         fluxes_feasible = loopless_solution(test_model)
         test_model.reactions.v3.lower_bound = 1
@@ -346,7 +340,8 @@ class TestCobraFluxAnalysis:
         assert fluxes_feasible["v3"] == 0.0
         assert fluxes_infeasible["v3"] == 1.0
 
-        # test with add_loopless
+    @pytest.mark.skipif(numpy is None, reason="null space requires numpy")
+    def test_add_loopless(self):
         test_model = self.construct_ll_test_model()
         add_loopless(test_model)
         feasible_status = test_model.solver.optimize()

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -341,9 +341,10 @@ class TestCobraFluxAnalysis:
             solver="cglpk")
         test_model.reactions.v3.lower_bound = 1
         infeasible_mod = construct_loopless_model(test_model)
-        infeasible_sol = infeasible_mod.optimize(solver="cglpk")
         assert feasible_sol.status == "optimal"
-        assert infeasible_sol.status == "infeasible"
+
+        with pytest.raises(SolveError):
+            infeasible_mod.optimize(solver="cglpk")
 
     def test_loopless_solution(self):
         test_model = self.construct_ll_test_model()

--- a/cobra/util/array.py
+++ b/cobra/util/array.py
@@ -20,12 +20,12 @@ def create_stoichiometric_array(model, array_type='dense', dtype=None):
     metabolites. S[i,j] therefore contains the quantity of metabolite `i`
     produced (negative for consumed) by reaction `j`.
 
-    model: a :class:`~cobra.core.Model` object
-    array_type: string
+    model : cobra.Model
+    array_type : string
         The type of array to construct. if 'dense', return a standard
         numpy.array. Otherwise, 'dok', or 'lil' will construct a sparse array
         using scipy of the corresponding type.
-    dtype: data-type
+    dtype : data-type
         The desired data-type for the array. If not given, defaults to float.
 
     """
@@ -65,15 +65,15 @@ def nullspace(A, atol=1e-13, rtol=0):
 
     Parameters
     ----------
-    A : ndarray
-    A should be at most 2-D.  A 1-D array with length k will be treated
-    as a 2-D with shape (1, k)
+    A : numpy.ndarray
+        A should be at most 2-D.  A 1-D array with length k will be treated
+        as a 2-D with shape (1, k)
     atol : float
-    The absolute tolerance for a zero singular value.  Singular values
-    smaller than `atol` are considered to be zero.
+        The absolute tolerance for a zero singular value.  Singular values
+        smaller than `atol` are considered to be zero.
     rtol : float
-    The relative tolerance.  Singular values less than rtol*smax are
-    considered to be zero, where smax is the largest singular value.
+        The relative tolerance.  Singular values less than rtol*smax are
+        considered to be zero, where smax is the largest singular value.
 
     If both `atol` and `rtol` are positive, the combined tolerance is the
     maximum of the two; that is::
@@ -82,12 +82,12 @@ def nullspace(A, atol=1e-13, rtol=0):
 
     Returns
     -------
-    ns : ndarray
-    If `A` is an array with shape (m, k), then `ns` will be an array
-    with shape (k, n), where n is the estimated dimension of the
-    nullspace of `A`.  The columns of `ns` are a basis for the
-    nullspace; each element in numpy.dot(A, ns) will be approximately
-    zero.
+    numpy.ndarray
+        If `A` is an array with shape (m, k), then `ns` will be an array
+        with shape (k, n), where n is the estimated dimension of the
+        nullspace of `A`.  The columns of `ns` are a basis for the
+        nullspace; each element in numpy.dot(A, ns) will be approximately
+        zero.
 
     Notes
     -----

--- a/cobra/util/array.py
+++ b/cobra/util/array.py
@@ -56,3 +56,46 @@ def create_stoichiometric_array(model, array_type='dense', dtype=None):
             array[m_ind(metabolite), r_ind(reaction)] = stoich
 
     return array
+
+
+def nullspace(A, atol=1e-13, rtol=0):
+    """Compute an approximate basis for the nullspace of A.
+    The algorithm used by this function is based on the singular value
+    decomposition of `A`.
+
+    Parameters
+    ----------
+    A : ndarray
+    A should be at most 2-D.  A 1-D array with length k will be treated
+    as a 2-D with shape (1, k)
+    atol : float
+    The absolute tolerance for a zero singular value.  Singular values
+    smaller than `atol` are considered to be zero.
+    rtol : float
+    The relative tolerance.  Singular values less than rtol*smax are
+    considered to be zero, where smax is the largest singular value.
+
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is::
+    tol = max(atol, rtol * smax)
+    Singular values smaller than `tol` are considered to be zero.
+
+    Returns
+    -------
+    ns : ndarray
+    If `A` is an array with shape (m, k), then `ns` will be an array
+    with shape (k, n), where n is the estimated dimension of the
+    nullspace of `A`.  The columns of `ns` are a basis for the
+    nullspace; each element in numpy.dot(A, ns) will be approximately
+    zero.
+
+    Notes
+    -----
+    Taken from the numpy cookbook.
+    """
+    A = np.atleast_2d(A)
+    u, s, vh = np.linalg.svd(A)
+    tol = max(atol, rtol * s[0])
+    nnz = (s >= tol).sum()
+    ns = vh[nnz:].conj().T
+    return ns

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -117,29 +117,27 @@ def set_objective(model, value, additive=False):
         an empty objective.
     """
     interface = model.solver.interface
+    reverse_value = model.solver.objective.expression
+    reverse_value = interface.Objective(
+        reverse_value, direction=model.solver.objective.direction,
+        sloppy=True)
+
     if isinstance(value, dict):
         if not model.objective.is_Linear:
             raise ValueError('can only update non-linear objectives '
                              'additively using object of class '
                              'model.solver.interface.Objective, not %s' %
                              type(value))
+
         if not additive:
             model.solver.objective = interface.Objective(
                 sympy.S.Zero, direction=model.solver.objective.direction)
-        reverse_value = {}
         for reaction, coef in value.items():
-            reverse_value[reaction.forward_variable] = \
-                reaction.objective_coefficient
-            reverse_value[reaction.reverse_variable] = \
-                -reaction.objective_coefficient
             model.solver.objective.set_linear_coefficients(
                 {reaction.forward_variable: coef,
                  reaction.reverse_variable: -coef})
 
     elif isinstance(value, (sympy.Basic, model.solver.interface.Objective)):
-        reverse_value = interface.Objective(
-            model.solver.objective.expression,
-            direction=model.solver.objective.direction, sloppy=True)
         if isinstance(value, sympy.Basic):
             value = interface.Objective(
                 value, direction=model.solver.objective.direction,
@@ -148,6 +146,7 @@ def set_objective(model, value, additive=False):
         # clone the objective if not, faster than cloning without checking
         if not _valid_atoms(model, value.expression):
             value = interface.Objective.clone(value, model=model.solver)
+
         if not additive:
             model.solver.objective = value
         else:
@@ -158,15 +157,11 @@ def set_objective(model, value, additive=False):
 
     context = get_context(model)
     if context:
-        if isinstance(reverse_value, dict):
-            context(partial(model.solver.objective.set_linear_coefficients,
-                            reverse_value))
-        else:
-            def reset():
-                model.solver.objective = reverse_value
-                model.solver.objective.direction = reverse_value.direction
+        def reset():
+            model.solver.objective = reverse_value
+            model.solver.objective.direction = reverse_value.direction
 
-            context(reset)
+        context(reset)
 
 
 def interface_to_str(interface):

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -91,7 +91,7 @@ def _valid_atoms(model, expression):
         True if all referenced variables are contained in model, False
         otherwise.
     """
-    atoms = expression.atoms(optlang.Variable)
+    atoms = expression.atoms(optlang.interface.Variable)
     return all(a.problem is model.solver for a in atoms)
 
 


### PR DESCRIPTION
Up to now only implements the original method from Schellenberger. First time the optlang interface really shines. I could basically implement the original method as is. This requires less constraints than the prior version in cobrapy and brings a speed up (twice as fast).

### Missing:

- [x] a posteriori version (should be much faster)
- [x] faster loopless FVA using the method from CycleFreeFlux (semi a posteriori) 

As expected *a posteriori* methods are faster. For FVA the loopless version is still slower than the non-loopless one for large problems (kind of expected). However it is much faster than using `add_loopless` or `construct_loopless_model` followed by calling "normal" FVA. Faster meaning 2 seconds vs 2 minutes for textbook and a much larger gap (~1000x) for ecoli.

### API

This one I am still not sure about. So fire away with your comments

A priori:
```Python
with model:
    add_loopless(model)
    model.optimize()
    single_gene_deletion(model)
```

A posteriori:
```Python
with model:
    model.optimize()
    fluxes = loopless_solution(model)
```

Maybe that one should take a flux distribution as argument alongside with the model? That way you could use it to convert flux samples or saved flux distributions to loopless ones as well...

### Benchmarks

[test_output.txt](https://github.com/opencobra/cobrapy/files/778088/test_output.txt)
