### PR TITLE
Context management for Reactions and Metabolites [fix #389]

### DIFF
--- a/cobra/core/dictlist.py
+++ b/cobra/core/dictlist.py
@@ -220,9 +220,10 @@ class DictList(list):
     def __sub__(self, other):
         """x.__sub__(y) <==> x - y
 
-        other: iterable
+        Parameters
+        ----------
+        other : iterable
             other must contain only unique id's present in the list
-
         """
         total = DictList()
         total.extend(self)
@@ -233,9 +234,10 @@ class DictList(list):
     def __isub__(self, other):
         """x.__sub__(y) <==> x -= y
 
-        other: iterable
+        Parameters
+        ----------
+        other : iterable
             other must contain only unique id's present in the list
-
         """
 
         for item in other:

--- a/cobra/core/dictlist.py
+++ b/cobra/core/dictlist.py
@@ -217,6 +217,31 @@ class DictList(list):
                                 current_length):
             _dict[obj.id] = i
 
+    def __sub__(self, other):
+        """x.__sub__(y) <==> x - y
+
+        other: iterable
+            other must contain only unique id's present in the list
+
+        """
+        total = DictList()
+        total.extend(self)
+        for item in other:
+            total.remove(item)
+        return total
+
+    def __isub__(self, other):
+        """x.__sub__(y) <==> x -= y
+
+        other: iterable
+            other must contain only unique id's present in the list
+
+        """
+
+        for item in other:
+            self.remove(item)
+        return self
+
     def __add__(self, other):
         """x.__add__(y) <==> x + y
 

--- a/cobra/core/dictlist.py
+++ b/cobra/core/dictlist.py
@@ -354,6 +354,10 @@ class DictList(list):
                 _dict[i] = j - 1
         return value
 
+    def add(self, x):
+        """Opposite of `remove`. Mirrors set.add"""
+        self.extend([x])
+
     def remove(self, x):
         """.. warning :: Internal use only"""
         # Each item is unique in the list which allows this

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -171,6 +171,8 @@ class Metabolite(Species):
     def remove_from_model(self, destructive=False):
         """Removes the association from self.model
 
+        The change is reverted upon exit when using the model as a context.
+
         Parameters
         ----------
         destructive : bool

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -168,7 +168,7 @@ class Metabolite(Species):
                 raise Exception("model solution was not optimal")
             raise e
 
-    def remove_from_model(self, method='subtractive', **kwargs):
+    def remove_from_model(self, method='subtractive'):
         """Removes the association from self.model
 
         Parameters
@@ -181,21 +181,7 @@ class Metabolite(Species):
         # why is model being taken in as a parameter? This plays
         # back to the question of allowing a Metabolite to be associated
         # with multiple Models
-        if "model" in kwargs:
-            warn("model argument deprecated")
-        model = self._model
-        self._model.metabolites.remove(self)
-        self._model = None
-        if method.lower() == 'subtractive':
-            for the_reaction in list(self._reaction):
-                the_coefficient = the_reaction._metabolites[self]
-                the_reaction.subtract_metabolites({self: the_coefficient})
-        elif method.lower() == 'destructive':
-            for x in self._reaction:
-                x.remove_from_model()
-        else:
-            raise Exception(method + " is not 'subtractive' or 'destructive'")
-        model.solver.remove(model.solver.constraints[self.id])
+        self._model.remove_metabolites(self, method)
 
     def summary(self, threshold=0.01, fva=False, floatfmt='.3g', **kwargs):
         """Print a summary of the reactions which produce and consume this

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -168,20 +168,17 @@ class Metabolite(Species):
                 raise Exception("model solution was not optimal")
             raise e
 
-    def remove_from_model(self, method='subtractive'):
+    def remove_from_model(self, destructive=False):
         """Removes the association from self.model
 
         Parameters
         ----------
-        method : 'subtractive' or 'destructive'.
-            If 'subtractive' then the metabolite is removed from all
-            associated reactions.  If 'destructive' then all associated
+        destructive : bool
+            If False then the metabolite is removed from all
+            associated reactions.  If True then all associated
             reactions are removed from the Model.
         """
-        # why is model being taken in as a parameter? This plays
-        # back to the question of allowing a Metabolite to be associated
-        # with multiple Models
-        self._model.remove_metabolites(self, method)
+        self._model.remove_metabolites(self, destructive)
 
     def summary(self, threshold=0.01, fva=False, floatfmt='.3g', **kwargs):
         """Print a summary of the reactions which produce and consume this

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -528,30 +528,6 @@ class Model(Object):
                 reaction._metabolites = {}
                 reaction._genes = set()
 
-    def repair(self, rebuild_index=True, rebuild_relationships=True):
-        """Update all indexes and pointers in a model"""
-        if rebuild_index:  # DictList indexes
-            self.reactions._generate_index()
-            self.metabolites._generate_index()
-            self.genes._generate_index()
-        if rebuild_relationships:
-            for met in self.metabolites:
-                met._reaction.clear()
-            for gene in self.genes:
-                gene._reaction.clear()
-            for rxn in self.reactions:
-                for met in rxn._metabolites:
-                    met._reaction.add(rxn)
-                for gene in rxn._genes:
-                    gene._reaction.add(rxn)
-        # point _model to self
-        for l in (self.reactions, self.genes, self.metabolites):
-            for e in l:
-                e._model = self
-        if self.solution is None:
-            self.solution = Solution(None)
-        return
-
     def _populate_solver(self, reaction_list, metabolite_list=None):
         """Populate attached solver with constraints and variables that
         model the provided reactions.
@@ -692,6 +668,37 @@ class Model(Object):
             #     'returned solution status is "%s"' % (
             #         self, solution.status))
         return solution
+
+    def repair(self, rebuild_index=True, rebuild_relationships=True):
+        """Update all indexes and pointers in a model
+        Parameters
+        ----------
+        rebuild_index : bool
+            rebuild the indices kept in reactions, metabolites and genes
+        rebuild_relationships : bool
+             reset all associations between genes, metabolites, model and
+             then re-add them.
+        """
+        if rebuild_index:  # DictList indexes
+            self.reactions._generate_index()
+            self.metabolites._generate_index()
+            self.genes._generate_index()
+        if rebuild_relationships:
+            for met in self.metabolites:
+                met._reaction.clear()
+            for gene in self.genes:
+                gene._reaction.clear()
+            for rxn in self.reactions:
+                for met in rxn._metabolites:
+                    met._reaction.add(rxn)
+                for gene in rxn._genes:
+                    gene._reaction.add(rxn)
+        # point _model to self
+        for l in (self.reactions, self.genes, self.metabolites):
+            for e in l:
+                e._model = self
+        if self.solution is None:
+            self.solution = Solution(None)
 
     @property
     def objective(self):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -315,6 +315,8 @@ class Model(Object):
         """Will add a list of metabolites to the model object and add new
         constraints accordingly.
 
+        The change is reverted upon exit when using the model as a context.
+
         Parameters
         ----------
         metabolite_list : A list of `cobra.core.Metabolite` objects
@@ -347,9 +349,14 @@ class Model(Object):
                 context(partial(setattr, x, '_model', None))
 
     def remove_metabolites(self, metabolite_list, destructive=False):
-        """Will remove a list of metabolites from the the object
+        """Remove a list of metabolites from the the object.
 
-        metabolite_list : A list of :class:`~cobra.core.Metabolite` objects
+        The change is reverted upon exit when using the model as a context.
+
+        Parameters
+        ----------
+        metabolite_list : list
+            A list with `cobra.Metabolite` objects as elements.
 
         destructive : bool
             If False then the metabolite is removed from all
@@ -376,7 +383,6 @@ class Model(Object):
 
         self.metabolites -= metabolite_list
 
-        # from cameo ...
         to_remove = [self.solver.constraints[m.id] for m in metabolite_list]
         remove_from_solver(self, to_remove)
 
@@ -392,10 +398,10 @@ class Model(Object):
 
         Parameters
         ----------
-        reaction : A `cobra.core.Reaction` object
+        reaction : cobra.Reaction
+            The reaction to add
 
         Deprecated (0.6). Use `~cobra.Model.add_reactions` instead
-
         """
         warn("add_reaction deprecated. Use add_reactions instead",
              DeprecationWarning)
@@ -406,9 +412,12 @@ class Model(Object):
         """Will add a cobra.Reaction object to the model, if
         reaction.id is not in self.reactions.
 
+        The change is reverted upon exit when using the model as a context.
+
         Parameters
         ----------
-        reaction_list : A list of `cobra.core.Reaction` objects
+        reaction_list : list
+            A list of `cobra.Reaction` objects
 
         """
 
@@ -479,17 +488,21 @@ class Model(Object):
 
     def remove_reactions(self, reactions, delete=True,
                          remove_orphans=False):
-        """remove reactions from the model
+        """Remove reactions from the model.
 
-        reactions: [:class:`~cobra.core.Reaction.Reaction`] or [str]
-            The reactions (or their id's) to remove
+        The change is reverted upon exit when using the model as a context.
 
-        delete: Boolean
+        Parameters
+        ----------
+        reactions : list
+            A list with reactions (`cobra.Reaction`), or their id's, to remove
+
+        delete : bool
             Whether or not the reactions should be deleted after removal.
             If the reactions are not deleted, those objects will be
             recreated with new metabolite and gene objects.
 
-        remove_orphans: Boolean
+        remove_orphans : bool
             Remove orphaned genes and metabolites from the model as well
 
         """
@@ -680,6 +693,7 @@ class Model(Object):
 
     def repair(self, rebuild_index=True, rebuild_relationships=True):
         """Update all indexes and pointers in a model
+
         Parameters
         ----------
         rebuild_index : bool

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -346,16 +346,15 @@ class Model(Object):
                 # Do we care?
                 context(partial(setattr, x, '_model', None))
 
-    def remove_metabolites(self, metabolite_list, method='subtractive'):
+    def remove_metabolites(self, metabolite_list, destructive=False):
         """Will remove a list of metabolites from the the object
 
         metabolite_list : A list of :class:`~cobra.core.Metabolite` objects
 
-        method : 'subtractive' or 'destructive'.
-            If 'subtractive' then the metabolite is removed from all
-            associated reactions.  If 'destructive' then all associated
-            reactions are removed from the Model
-            ** Need to do this.
+        destructive : bool
+            If False then the metabolite is removed from all
+            associated reactions.  If True then all associated
+            reactions are removed from the Model.
 
         """
         if not hasattr(metabolite_list, '__iter__'):
@@ -366,18 +365,14 @@ class Model(Object):
         for x in metabolite_list:
             x._model = None
 
-            if method == 'subtractive':
+            if not destructive:
                 for the_reaction in list(x._reaction):
                     the_coefficient = the_reaction._metabolites[x]
                     the_reaction.subtract_metabolites({x: the_coefficient})
 
-            elif method == 'destructive':
+            else:
                 for x in list(x._reaction):
                     x.remove_from_model()
-
-            else:
-                raise TypeError(
-                    method + " is not 'subtractive' or 'destructive'")
 
         self.metabolites -= metabolite_list
 

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -365,6 +365,20 @@ class Model(Object):
                            if x.id in self.metabolites]
         for x in metabolite_list:
             x._model = None
+
+            if method == 'subtractive':
+                for the_reaction in list(x._reaction):
+                    the_coefficient = the_reaction._metabolites[x]
+                    the_reaction.subtract_metabolites({x: the_coefficient})
+
+            elif method == 'destructive':
+                for x in list(x._reaction):
+                    x.remove_from_model()
+
+            else:
+                raise TypeError(
+                    method + " is not 'subtractive' or 'destructive'")
+
         self.metabolites -= metabolite_list
 
         # from cameo ...

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -297,7 +297,7 @@ class Reaction(Object):
 
         # TODO: Do this :)
         if get_context(self):
-            warn("Context management not implemeneted for "
+            warn("Context management not implemented for "
                  "gene reaction rules")
 
         self._gene_reaction_rule = new_rule.strip()
@@ -409,6 +409,8 @@ class Reaction(Object):
     def remove_from_model(self, model=None, remove_orphans=False):
         """Removes the reaction from the model while keeping it intact
 
+        The change is reverted upon exit when using the model as a context.
+
         Parameters
         ----------
         remove_orphans : bool
@@ -433,6 +435,8 @@ class Reaction(Object):
         This removes all associations between a reaction the associated
         model, metabolites and genes (unlike remove_from_model which only
         dissociates the reaction from the model).
+
+        The change is reverted upon exit when using the model as a context.
 
         Parameters
         ----------
@@ -586,6 +590,8 @@ class Reaction(Object):
         If the final coefficient for a metabolite is 0 then it is removed
         from the reaction.
 
+        The change is reverted upon exit when using the model as a context.
+
         Parameters
         ----------
         metabolites_to_add : dict
@@ -674,6 +680,8 @@ class Reaction(Object):
         """This function will 'subtract' metabolites from a reaction, which
         means add the metabolites with -1*coefficient. If the final coefficient
         for a metabolite is 0 then the metabolite is removed from the reaction.
+
+        The change is reverted upon exit when using the model as a context.
 
         Parameters
         ----------
@@ -792,6 +800,9 @@ class Reaction(Object):
         arguments infers a set of metabolites, metabolite compartments and
         stoichiometries for the reaction.  It also infers the reversibility
         of the reaction from the reaction arrow.
+
+        Changes to the associated model are reverted upon exit when using
+        the model as a context.
 
         Parameters
         ----------

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -6,6 +6,7 @@ import hashlib
 import re
 from collections import defaultdict
 from copy import copy, deepcopy
+from functools import partial
 from warnings import warn
 
 from six import iteritems, string_types
@@ -13,7 +14,7 @@ from six import iteritems, string_types
 from cobra.core.gene import Gene, ast2str, parse_gpr
 from cobra.core.metabolite import Metabolite
 from cobra.core.object import Object
-from cobra.util.context import resettable
+from cobra.util.context import resettable, get_context
 from cobra.util.solver import linear_reaction_coefficients, set_objective
 from cobra.util.util import Frozendict, _is_positive
 
@@ -293,6 +294,12 @@ class Reaction(Object):
 
     @gene_reaction_rule.setter
     def gene_reaction_rule(self, new_rule):
+
+        # TODO: Do this :)
+        if get_context(self):
+            warn("Context management not implemeneted for "
+                 "gene reaction rules")
+
         self._gene_reaction_rule = new_rule.strip()
         try:
             _, gene_names = parse_gpr(self._gene_reaction_rule)
@@ -486,39 +493,6 @@ class Reaction(Object):
             i._model = model
         return new_reaction
 
-    def pop(self, metabolite_id):
-        """Remove a metabolite from the reaction and return the
-        stoichiometric coefficient.
-
-        Parameters
-        ----------
-        metabolite_id : str or cobra.core.Metabolite.Metabolite
-            The metabolite to remove
-        """
-        if self.model is None:
-            the_metabolite = metabolite_id
-            if isinstance(the_metabolite, string_types):
-                found_match = None
-                for possible_match in self._metabolites:
-                    if possible_match.id == the_metabolite:
-                        found_match = possible_match
-                        break
-                if found_match is None:
-                    raise KeyError("No metabolite named %s in the reaction" %
-                                   the_metabolite)
-                else:
-                    the_metabolite = found_match
-            the_coefficient = self._metabolites.pop(the_metabolite)
-            the_metabolite._reaction.remove(self)
-        else:
-            if isinstance(metabolite_id, string_types):
-                met = self.model.metabolites.get_by_id(metabolite_id)
-            else:
-                met = metabolite_id
-            the_coefficient = self.metabolites[met]
-            self.add_metabolites({met: -the_coefficient}, combine=True)
-        return the_coefficient
-
     def __add__(self, other):
         """Add two reactions
 
@@ -607,35 +581,27 @@ class Reaction(Object):
         """
         return map(self.get_coefficient, metabolite_ids)
 
-    def add_metabolites(self, metabolites, combine=True,
-                        add_to_container_model=True):
+    def add_metabolites(self, metabolites_to_add, combine=True):
         """Add metabolites and stoichiometric coefficients to the reaction.
         If the final coefficient for a metabolite is 0 then it is removed
         from the reaction.
 
         Parameters
         ----------
-        metabolites : dict
+        metabolites_to_add : dict
             {str or :class:`~cobra.core.Metabolite.Metabolite`: coefficient}
 
         combine : bool
             Describes behavior a metabolite already exists in the reaction.
             True causes the coefficients to be added.
             False causes the coefficient to be replaced.
-            True and a metabolite already exists in the
-
-        add_to_container_model : bool
-            Add the metabolite to the :class:`~cobra.core.Model.Model`
-            the reaction is associated with (i.e. self.model)
 
         """
-        # from cameo ...
-        old_coefficients = self.metabolites if combine else {}
-        # ...
-
-        _id_to_metabolites = {str(x): x for x in self._metabolites}
+        old_coefficients = self.metabolites
         new_metabolites = []
-        for metabolite, coefficient in iteritems(metabolites):
+        _id_to_metabolites = dict([(x.id, x) for x in self._metabolites])
+
+        for metabolite, coefficient in iteritems(metabolites_to_add):
             met_id = str(metabolite)
             # If a metabolite already exists in the reaction then
             # just add them.
@@ -666,19 +632,20 @@ class Reaction(Object):
                 # make the metabolite aware that it is involved in this
                 # reaction
                 metabolite._reaction.add(self)
+
         for metabolite, the_coefficient in list(self._metabolites.items()):
             if the_coefficient == 0:
                 # make the metabolite aware that it no longer participates
                 # in this reaction
                 metabolite._reaction.remove(self)
                 self._metabolites.pop(metabolite)
-        if add_to_container_model and hasattr(self._model, 'add_metabolites'):
-            self._model.add_metabolites(new_metabolites)
 
         # from cameo ...
         model = self.model
         if model is not None:
-            for metabolite, coefficient in metabolites.items():
+            model.add_metabolites(new_metabolites)
+
+            for metabolite, coefficient in metabolites_to_add.items():
 
                 if isinstance(metabolite,
                               str):  # support metabolites added as strings.
@@ -697,6 +664,12 @@ class Reaction(Object):
                      self.reverse_variable: -coefficient
                      })
 
+        context = get_context(self)
+        if context:
+            # Just subtact the metabolites that were added
+            context(partial(
+                self.subtract_metabolites, metabolites_to_add, combine=True))
+
     def subtract_metabolites(self, metabolites, combine=True):
         """This function will 'subtract' metabolites from a reaction, which
         means add the metabolites with -1*coefficient. If the final coefficient
@@ -709,16 +682,16 @@ class Reaction(Object):
             are the coefficients. These metabolites will be added to the
             reaction.
 
+        combine : bool
+            Describes behavior a metabolite already exists in the reaction.
+            True causes the coefficients to be added.
+            False causes the coefficient to be replaced.
+
         .. note:: A final coefficient < 0 implies a reactant.
 
         """
         self.add_metabolites({k: -v for k, v in iteritems(metabolites)},
                              combine=combine)
-
-    def clear_metabolites(self):
-        """Remove all metabolites from the reaction"""
-        for metabolite in list(self._metabolites.keys()):
-            self.pop(metabolite)
 
     @property
     def reaction(self):
@@ -879,7 +852,7 @@ class Reaction(Object):
         reactant_str = reaction_str[:arrow_match.start()].strip()
         product_str = reaction_str[arrow_match.end():].strip()
 
-        self.clear_metabolites()
+        self.subtract_metabolites(self.metabolites, combine=True)
 
         for substr, factor in ((reactant_str, -1), (product_str, 1)):
             if len(substr) == 0:

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -292,17 +292,37 @@ class TestCobraModel:
         assert new_metabolite not in model.metabolites
         assert new_metabolite.id not in model.solver.constraints
 
-    def test_remove_metabolite(self, model):
+    def test_remove_metabolite_subtractive(self, model):
         test_metabolite = model.metabolites[4]
+        test_reactions = test_metabolite.reactions
         with model:
-            model.remove_metabolites(test_metabolite)
+            model.remove_metabolites(test_metabolite, method='subtractive')
             assert test_metabolite._model is None
             assert test_metabolite not in model.metabolites
             assert test_metabolite.id not in model.solver.constraints
+            for reaction in test_reactions:
+                assert reaction in model.reactions
 
         assert test_metabolite._model is model
         assert test_metabolite in model.metabolites
         assert test_metabolite.id in model.solver.constraints
+
+    def test_remove_metabolite_destructive(self, model):
+        test_metabolite = model.metabolites[4]
+        test_reactions = test_metabolite.reactions
+        with model:
+            model.remove_metabolites(test_metabolite, method='destructive')
+            assert test_metabolite._model is None
+            assert test_metabolite not in model.metabolites
+            assert test_metabolite.id not in model.solver.constraints
+            for reaction in test_reactions:
+                assert reaction not in model.reactions
+
+        assert test_metabolite._model is model
+        assert test_metabolite in model.metabolites
+        assert test_metabolite.id in model.solver.constraints
+        for reaction in test_reactions:
+            assert reaction in model.reactions
 
     def test_add_reaction(self, model):
         old_reaction_count = len(model.reactions)

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -312,7 +312,7 @@ class TestCobraModel:
         test_metabolite = model.metabolites[4]
         test_reactions = test_metabolite.reactions
         with model:
-            model.remove_metabolites(test_metabolite, method='subtractive')
+            model.remove_metabolites(test_metabolite, destructive=False)
             assert test_metabolite._model is None
             assert test_metabolite not in model.metabolites
             assert test_metabolite.id not in model.solver.constraints
@@ -327,7 +327,7 @@ class TestCobraModel:
         test_metabolite = model.metabolites[4]
         test_reactions = test_metabolite.reactions
         with model:
-            model.remove_metabolites(test_metabolite, method='destructive')
+            model.remove_metabolites(test_metabolite, destructive=True)
             assert test_metabolite._model is None
             assert test_metabolite not in model.metabolites
             assert test_metabolite.id not in model.solver.constraints

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -488,27 +488,27 @@ class TestReaction:
                 already_included_metabolite.id].expression.has(
                 -10 * reaction.reverse_variable)
 
-    def test_pop(self, model):
-        pgi = model.reactions.PGI
-        g6p = model.metabolites.get_by_id("g6p_c")
-        f6p = model.metabolites.get_by_id("f6p_c")
-        g6p_expr = model.solver.constraints["g6p_c"].expression
-        g6p_coef = pgi.pop("g6p_c")
-        assert g6p not in pgi.metabolites
-        actual = model.solver.constraints[
-            "g6p_c"].expression.as_coefficients_dict()
-        expected = (g6p_expr - g6p_coef * pgi.flux_expression
-                    ).as_coefficients_dict()
-        assert actual == expected
-        assert pgi.metabolites[f6p] == 1
-
-        f6p_expr = model.solver.constraints["f6p_c"].expression
-        f6p_coef = pgi.pop(f6p)
-        assert f6p not in pgi.metabolites
-        assert model.solver.constraints[
-                   "f6p_c"].expression.as_coefficients_dict() == (
-                   f6p_expr - f6p_coef * pgi.flux_expression
-               ).as_coefficients_dict()
+    # def test_pop(self, model):
+    #     pgi = model.reactions.PGI
+    #     g6p = model.metabolites.get_by_id("g6p_c")
+    #     f6p = model.metabolites.get_by_id("f6p_c")
+    #     g6p_expr = model.solver.constraints["g6p_c"].expression
+    #     g6p_coef = pgi.pop("g6p_c")
+    #     assert g6p not in pgi.metabolites
+    #     actual = model.solver.constraints[
+    #         "g6p_c"].expression.as_coefficients_dict()
+    #     expected = (g6p_expr - g6p_coef * pgi.flux_expression
+    #                 ).as_coefficients_dict()
+    #     assert actual == expected
+    #     assert pgi.metabolites[f6p] == 1
+    #
+    #     f6p_expr = model.solver.constraints["f6p_c"].expression
+    #     f6p_coef = pgi.pop(f6p)
+    #     assert f6p not in pgi.metabolites
+    #     assert model.solver.constraints[
+    #                "f6p_c"].expression.as_coefficients_dict() == (
+    #                f6p_expr - f6p_coef * pgi.flux_expression
+    #            ).as_coefficients_dict()
 
     def test_remove_from_model(self, model):
         pgi = model.reactions.PGI

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -129,6 +129,25 @@ class TestDictList:
         assert len(test_list) == 1
         assert len(sum) == 9
 
+    def test_sub(self, dict_list):
+        obj, test_list = dict_list
+        obj_list = [Object("test%d" % (i)) for i in range(2, 10)]
+        sum = test_list + obj_list
+        sub = sum - test_list
+        assert test_list[0].id == "test1"
+        assert sub[0].id == "test2"
+        assert len(sub) == 8
+        assert sum - obj_list == test_list
+
+    def test_isub(self, dict_list):
+        obj, test_list = dict_list
+        obj_list = [Object("test%d" % (i)) for i in range(2, 10)]
+        sum = test_list + obj_list
+        sum -= obj_list[2:4]
+        assert len(sum) == 7
+        with pytest.raises(ValueError):
+            sum -= [Object('bogus')]
+
     def test_init_copy(self, dict_list):
         obj, test_list = dict_list
         test_list.append(Object("test2"))

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -131,7 +131,7 @@ class TestDictList:
 
     def test_sub(self, dict_list):
         obj, test_list = dict_list
-        obj_list = [Object("test%d" % (i)) for i in range(2, 10)]
+        obj_list = [Object("test%d" % i) for i in range(2, 10)]
         sum = test_list + obj_list
         sub = sum - test_list
         assert test_list[0].id == "test1"
@@ -141,7 +141,7 @@ class TestDictList:
 
     def test_isub(self, dict_list):
         obj, test_list = dict_list
-        obj_list = [Object("test%d" % (i)) for i in range(2, 10)]
+        obj_list = [Object("test%d" % i) for i in range(2, 10)]
         sum = test_list + obj_list
         sum -= obj_list[2:4]
         assert len(sum) == 7

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -276,12 +276,14 @@ def choose_solver(model, solver=None, qp=False):
     return legacy, solver
 
 
-def add_to_solver(model, what):
+def add_to_solver(model, what, **kwargs):
     """Add variables and constraints to a Model's solver object.
 
     Useful for variables and constraints that can not be expressed with
     reactions and lower/upper bounds. Will integrate with the Model's context
     manager in order to revert changes upon leaving the context.
+
+    kwargs are passed to solver.add()
 
     Parameters
     ----------
@@ -294,7 +296,7 @@ def add_to_solver(model, what):
     """
     context = get_context(model)
 
-    model.solver.add(what)
+    model.solver.add(what, **kwargs)
     if context:
         context(partial(model.solver.remove, what))
 

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -283,8 +283,6 @@ def add_to_solver(model, what, **kwargs):
     reactions and lower/upper bounds. Will integrate with the Model's context
     manager in order to revert changes upon leaving the context.
 
-    kwargs are passed to solver.add()
-
     Parameters
     ----------
     model : a cobra model
@@ -293,6 +291,8 @@ def add_to_solver(model, what, **kwargs):
        The variables or constraints to add to the model. Must be of class
        `model.solver.interface.Variable` or
        `model.solver.interface.Constraint`.
+    **kwargs : keyword arguments
+        passed to solver.add()
     """
     context = get_context(model)
 


### PR DESCRIPTION
Got some decent progress.. 

Still todo:

- [x] `Model.remove_reactions`
- [x] Implement `Model.remove_metabolites(method)` kwarg.. (will call `Model.remove_reactions`?)
- [x] `Reaction.metabolites`
- [ ] `Reaction.gene_reaction_rule`?


definitely running into the issue of wanting to call other context-managed methods, but not wanting to trigger the issue seen in #393...

@cdiener, I'll probably ask how you do those benchmarks 😄 , we should also make sure we're not torpedoing performance.