### PR TITLE
Revise solver lists for optlang

### DIFF
--- a/cobra/test/test_solver_utils.py
+++ b/cobra/test/test_solver_utils.py
@@ -31,8 +31,9 @@ class TestHelpers:
         assert su.choose_solver(model, "cglpk")[0]
 
         if any(s in su.solvers for s in su.qp_solvers):
-            qp_choice = su.interface_to_str(su.choose_solver(model, qp=True))
-            assert qp_choice in su.qp_solvers
+            legacy, qp_choice = su.choose_solver(model, qp=True)
+            assert not legacy
+            assert su.interface_to_str(qp_choice) in su.qp_solvers
         else:
             with pytest.raises(su.SolverNotFound):
                 su.choose_solver(model, qp=True)

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -179,10 +179,10 @@ def get_solver_name(mip=False, qp=False):
     """
     if len(solvers) == 0:
         raise SolverNotFound("no solvers installed")
-    # glpk only does lp, not qp. Gurobi and cplex are better at mip
-    mip_order = ["gurobi", "cplex", "mosek", "glpk"]
-    lp_order = ["glpk", "cplex", "gurobi", "mosek", "scipy"]
-    qp_order = ["gurobi", "cplex", "mosek"]
+    # Those lists need to be update as optlang implements more solvers
+    mip_order = ["gurobi", "cplex", "glpk"]
+    lp_order = ["glpk", "cplex", "gurobi"]
+    qp_order = ["cplex"]
 
     if mip is False and qp is False:
         for solver_name in lp_order:

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -179,7 +179,7 @@ def get_solver_name(mip=False, qp=False):
     """
     if len(solvers) == 0:
         raise SolverNotFound("no solvers installed")
-    # Those lists need to be update as optlang implements more solvers
+    # Those lists need to be updated as optlang implements more solvers
     mip_order = ["gurobi", "cplex", "glpk"]
     lp_order = ["glpk", "cplex", "gurobi"]
     qp_order = ["cplex"]


### PR DESCRIPTION
Removes unsupported/incomplete solver implementations in optlang from `cobra.util.solver.get_solver_name`.

Should fix #408.