### PR TITLE
Make objectives transferible

### DIFF
--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -567,6 +567,15 @@ class TestSolverBasedModel:
         assert coef_dict[biomass_r.forward_variable] == 1
         assert coef_dict[biomass_r.reverse_variable] == -1
 
+    def test_transfer_objective(self, model):
+        new_mod = Model("new model")
+        new_mod.add_reactions(model.reactions)
+        new_mod.objective = model.objective
+        assert (str(new_mod.objective.expression) ==
+                str(model.objective.expression))
+        new_mod.solver.optimize()
+        assert (new_mod.objective.value - 0.874) < 0.001
+
     def test_model_from_other_model(self, model):
         model = Model(id_or_model=model)
         for reaction in model.reactions:

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -574,7 +574,7 @@ class TestSolverBasedModel:
         assert (str(new_mod.objective.expression) ==
                 str(model.objective.expression))
         new_mod.solver.optimize()
-        assert (new_mod.objective.value - 0.874) < 0.001
+        assert abs(new_mod.objective.value - 0.874) < 0.001
 
     def test_model_from_other_model(self, model):
         model = Model(id_or_model=model)


### PR DESCRIPTION
This fixes variables so objectives are transferible between models. Also some linting of docstrings.

Before (current devel-2):

```Python
In [1]: from cobra.test import create_test_model

In [2]: import cobra

In [3]: mod = create_test_model("textbook")

In [4]: mod2 = cobra.Model("test")

In [5]: mod2.add_reactions(mod.reactions)

In [6]: mod2.objective = mod.objective

In [7]: mod.objective.expression
Out[7]: 0

In [8]: mod2.objective.expression
Out[8]: 0

In [9]: mod.optimize()
Out[9]: <Solution 0 at 0x7f56f3b4e4e0>

In [10]: mod2.optimize()
Out[10]: <Solution 0 at 0x7f56f4e00b70>
```

No error, but breaks both objectives at once :sob:

After:

```Python
In [1]: from cobra.test import create_test_model

In [2]: import cobra

In [3]: mod = create_test_model("textbook")

In [4]: mod2 = cobra.Model("test")

In [5]: mod2.add_reactions(mod.reactions)

In [6]: mod2.objective = mod.objective

In [7]: mod2.objective.expression
Out[7]: -1.0*Biomass_Ecoli_core_reverse_2cdba + 1.0*Biomass_Ecoli_core

In [8]: mod.objective.expression
Out[8]: -1.0*Biomass_Ecoli_core_reverse_2cdba + 1.0*Biomass_Ecoli_core

In [9]: mod2.optimize()
Out[9]: <Solution 0.874 at 0x7f7494986518>

In [10]: mod.optimize()
Out[10]: <Solution 0.874 at 0x7f749497b7b8>
``` 

All ok :sparkles: 