### PR TITLE
make travis stop testing after first failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - UNICODE_WIDTH=32
 
 matrix:
+  fast_finish: true
   exclude:
       - python: 3.5
   include:


### PR DESCRIPTION
Basically enable AppVeyor like behavior. It should speed up testing and the Mac tests are stable now. So I think it's worth using.