### PR TITLE
Fix instance checking for Objective

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -644,7 +644,7 @@ class Model(Object):
     def objective(self, value):
         if isinstance(value, sympy.Basic):
             value = self.solver.interface.Objective(value, sloppy=False)
-        if not isinstance(value, (dict, self.solver.interface.Objective)):
+        if not isinstance(value, (dict, optlang.interface.Objective)):
             value = {rxn: 1 for rxn in self.reactions.get_by_any(value)}
         set_objective(self, value, additive=False)
 

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -137,7 +137,7 @@ def set_objective(model, value, additive=False):
                 {reaction.forward_variable: coef,
                  reaction.reverse_variable: -coef})
 
-    elif isinstance(value, (sympy.Basic, model.solver.interface.Objective)):
+    elif isinstance(value, (sympy.Basic, optlang.interface.Objective)):
         if isinstance(value, sympy.Basic):
             value = interface.Objective(
                 value, direction=model.solver.objective.direction,


### PR DESCRIPTION
Checking the instance for Objective should be done with `optlang.interface.Objective` and not `model.solver.interface.Objective`. This introduced the following bug which is fixed by this PR:

```Python
In [1]: from cobra.test import create_test_model

In [2]: mod = create_test_model("textbook")

In [3]: o = mod.objective

In [4]: mod.solver = "cplex"

In [5]: mod.objective = o
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-a1035cc6dd94> in <module>()
----> 1 mod.objective = o

/home/cdiener/code/cobrapy/cobra/core/model.py in objective(self, value)
    646             value = self.solver.interface.Objective(value, sloppy=False)
    647         if not isinstance(value, (dict, self.solver.interface.Objective)):
--> 648             value = {rxn: 1 for rxn in self.reactions.get_by_any(value)}
    649         set_objective(self, value, additive=False)
    650 

/home/cdiener/code/cobrapy/cobra/core/dictlist.py in get_by_any(self, iterable)
     89         if not isinstance(iterable, list):
     90             iterable = [iterable]
---> 91         return [get_item(item) for item in iterable]
     92 
     93     def query(self, search_function, attribute=None):

/home/cdiener/code/cobrapy/cobra/core/dictlist.py in <listcomp>(.0)
     89         if not isinstance(iterable, list):
     90             iterable = [iterable]
---> 91         return [get_item(item) for item in iterable]
     92 
     93     def query(self, search_function, attribute=None):

/home/cdiener/code/cobrapy/cobra/core/dictlist.py in get_item(item)
     82                 except KeyError:
     83                     raise ValueError('%s not a member' % item)
---> 84             elif item in self:
     85                 return item
     86             else:

/home/cdiener/code/cobrapy/cobra/core/dictlist.py in __contains__(self, object)
    297         else:
    298             the_id = object
--> 299         return the_id in self._dict
    300 
    301     def __copy__(self):

TypeError: unhashable type: 'Objective'
```