### PR TITLE
fix: array model is deprecated but not defunct - remove model.S

### DIFF
--- a/cobra/core/arraybasedmodel.py
+++ b/cobra/core/arraybasedmodel.py
@@ -368,7 +368,8 @@ class SMatrix_dok(dok_matrix):
             else:  # setting 0 means metabolites should be removed
                 metabolite = self._model.metabolites[index[0]]
                 if metabolite in reaction._metabolites:
-                    reaction.pop(metabolite)
+                    reaction.subtract_metabolites(
+                        {metabolite: reaction.get_coefficient(metabolite)})
 
     def tolil(self):
         new = SMatrix_lil(dok_matrix.tolil(self), model=self._model)
@@ -400,7 +401,8 @@ class SMatrix_lil(lil_matrix):
             for reaction in reactions:
                 to_remove = met_set.intersection(reaction._metabolites)
                 for i in to_remove:
-                    reaction.pop(i)
+                    reaction.subtract_metabolites(
+                        {i: reaction.get_coefficient(i)})
         else:  # add metabolites
             met_dict = {met: value for met in metabolites}
             for reaction in reactions:

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -686,19 +686,21 @@ class Model(Object):
         return create_stoichiometric_array(self)
 
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
-        """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model
+        """Makes a `cobra.core.ArrayBasedModel` from a cobra.Model
         which may be used to perform linear algebra operations with the
         stoichiometric matrix.
 
-        Deprecated (0.6). Use `~cobra.util.array.create_stoichiometric_array`
+        Deprecated (0.6). Use `cobra.util.array.create_stoichiometric_array`
         or `model.S` instead.
 
         deepcopy_model: Boolean.  If False then the ArrayBasedModel points
         to the Model
 
         """
-
-        from .ArrayBasedModel import ArrayBasedModel
+        warn("to_array_based_model is deprecated. "
+             "use cobra.util.array.create_stoichiometric_array instead",
+             DeprecationWarning)
+        from cobra.core.arraybasedmodel import ArrayBasedModel
         return ArrayBasedModel(self, deepcopy_model=deepcopy_model, **kwargs)
 
     def optimize(self, objective_sense=None, **kwargs):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -671,30 +671,18 @@ class Model(Object):
         for constraint, terms in six.iteritems(constraint_terms):
             constraint.set_linear_coefficients(terms)
 
-    @property
-    def S(self):
-        """Return a stoichiometric array representation of the given model.
-
-        The the columns represent the reactions and rows represent
-        metabolites. S[i,j] therefore contains the quantity of metabolite `i`
-        produced (negative for consumed) by reaction `j`.
-
-        Returns a dense numpy array.
-        """
-
-        from cobra.util import create_stoichiometric_array
-        return create_stoichiometric_array(self)
-
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
         """Makes a `cobra.core.ArrayBasedModel` from a cobra.Model
         which may be used to perform linear algebra operations with the
         stoichiometric matrix.
 
         Deprecated (0.6). Use `cobra.util.array.create_stoichiometric_array`
-        or `model.S` instead.
+        instead.
 
-        deepcopy_model: Boolean.  If False then the ArrayBasedModel points
-        to the Model
+        Parameters
+        ----------
+        deepcopy_model : bool
+            If False then the ArrayBasedModel points to the Model
 
         """
         warn("to_array_based_model is deprecated. "

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -9,7 +9,8 @@ from six import iteritems
 from sympy.core.singleton import S
 
 from cobra.core import Metabolite, Reaction, get_solution
-from cobra.util import linear_reaction_coefficients
+from cobra.util import (linear_reaction_coefficients,
+                        create_stoichiometric_array)
 from cobra.manipulation.modify import convert_to_irreversible
 from cobra.util import nullspace
 
@@ -45,7 +46,7 @@ def add_loopless(model, zero_cutoff=1e-12):
        in: Biophys J. 2011 Mar 2;100(5):1381.
     """
     internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
-    s_int = model.S[:, numpy.array(internal)]
+    s_int = create_stoichiometric_array(model)[:, numpy.array(internal)]
     n_int = nullspace(s_int).T
     max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
     prob = model.problem

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -85,7 +85,8 @@ class TestReactions:
                 solver_dict[solver].create_problem(model)
             for m, c in many_metabolites.items():
                 try:
-                    reaction.pop(m.id)
+                    reaction.subtract_metabolites(
+                        {m: reaction.get_coefficient(m)})
                 except KeyError:
                     pass
 
@@ -806,9 +807,6 @@ class TestStoichiometricMatrix:
         solution = model.optimize()
         mass_balance = S.dot(solution.fluxes)
         assert numpy.allclose(mass_balance, 0)
-
-        # Test model property
-        assert numpy.allclose(model.S, S)
 
     @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
     def test_sparse_matrix(self, model):

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -722,6 +722,74 @@ class TestCobraModel:
 class TestStoichiometricMatrix:
     """Test the simple replacement for ArrayBasedModel"""
 
+    def test_array_model(self, model):
+        """ legacy test """
+        for matrix_type in ["scipy.dok_matrix", "scipy.lil_matrix"]:
+            array_model = model.to_array_based_model(matrix_type=matrix_type)
+            assert array_model.S[7, 0] == -1
+            assert array_model.S[43, 0] == 0
+            array_model.S[43, 0] = 1
+            assert array_model.S[43, 0] == 1
+            assert array_model.reactions[0]._metabolites[
+                       array_model.metabolites[43]] == 1
+            array_model.S[43, 0] = 0
+            assert array_model.lower_bounds[0] == array_model.reactions[
+                0].lower_bound
+            assert array_model.lower_bounds[5] == array_model.reactions[
+                5].lower_bound
+            assert array_model.upper_bounds[0] == array_model.reactions[
+                0].upper_bound
+            assert array_model.upper_bounds[5] == array_model.reactions[
+                5].upper_bound
+            array_model.lower_bounds[6] = 2
+            assert array_model.lower_bounds[6] == 2
+            assert array_model.reactions[6].lower_bound == 2
+            # this should fail because it is the wrong size
+            with pytest.raises(Exception):
+                array_model.upper_bounds = [0, 1]
+            array_model.upper_bounds = [0] * len(array_model.reactions)
+            assert max(array_model.upper_bounds) == 0
+            # test something for all the attributes
+            array_model.lower_bounds[2] = -1
+            assert array_model.reactions[2].lower_bound == -1
+            assert array_model.lower_bounds[2] == -1
+            array_model.objective_coefficients[2] = 1
+            assert array_model.reactions[2].objective_coefficient == 1
+            assert array_model.objective_coefficients[2] == 1
+            array_model.b[2] = 1
+            assert array_model.metabolites[2]._bound == 1
+            assert array_model.b[2] == 1
+            array_model.constraint_sense[2] = "L"
+            assert array_model.metabolites[2]._constraint_sense == "L"
+            assert array_model.constraint_sense[2] == "L"
+            # test resize matrix on reaction removal
+            m, n = array_model.S.shape
+            array_model.remove_reactions([array_model.reactions[2]],
+                                         remove_orphans=False)
+            assert len(array_model.metabolites) == array_model.S.shape[0]
+            assert len(array_model.reactions) == array_model.S.shape[1]
+            assert array_model.S.shape == (m, n - 1)
+
+    def test_array_based_model_add(self, model):
+        """ legacy test """
+        array_model = model.to_array_based_model()
+        m = len(array_model.metabolites)
+        n = len(array_model.reactions)
+        for matrix_type in ["scipy.dok_matrix", "scipy.lil_matrix"]:
+            test_model = model.copy().to_array_based_model(
+                matrix_type=matrix_type)
+            test_reaction = Reaction("test")
+            test_reaction.add_metabolites({test_model.metabolites[0]: 4})
+            test_reaction.lower_bound = -3.14
+            test_model.add_reaction(test_reaction)
+            assert len(test_model.reactions) == n + 1
+            assert test_model.S.shape == (m, n + 1)
+            assert len(test_model.lower_bounds) == n + 1
+            assert len(test_model.upper_bounds) == n + 1
+            assert test_model.S[0, n] == 4
+            assert test_model.S[7, 0] == -1
+            assert test_model.lower_bounds[n] == -3.14
+
     def test_dense_matrix(self, model):
         S = create_stoichiometric_array(model, array_type='dense', dtype=int)
         assert S.dtype == int

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -722,6 +722,7 @@ class TestCobraModel:
 class TestStoichiometricMatrix:
     """Test the simple replacement for ArrayBasedModel"""
 
+    @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
     def test_array_model(self, model):
         """ legacy test """
         for matrix_type in ["scipy.dok_matrix", "scipy.lil_matrix"]:
@@ -770,6 +771,7 @@ class TestStoichiometricMatrix:
             assert len(array_model.reactions) == array_model.S.shape[1]
             assert array_model.S.shape == (m, n - 1)
 
+    @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
     def test_array_based_model_add(self, model):
         """ legacy test """
         array_model = model.to_array_based_model()


### PR DESCRIPTION
so let's keep the tests there and fix module renaming mistake