### PR TITLE
fix: don't throw warnings on import

### DIFF
--- a/cobra/io/__init__.py
+++ b/cobra/io/__init__.py
@@ -2,30 +2,9 @@
 
 from __future__ import absolute_import
 
-from warnings import warn
-
 from cobra.io.json import load_json_model, save_json_model, to_json
 from cobra.io.sbml3 import read_sbml_model, write_sbml_model
-
-# These functions have other dependencies
-try:
-    import libsbml
-    from cobra.io.sbml import read_legacy_sbml
-    from cobra.io.sbml import write_cobra_model_to_sbml_file as\
-        write_legacy_sbml
-except ImportError:
-    warn("cobra.io.sbml requires libsbml")
-    libsbml = None
-    read_legacy_sbml = None
-    write_legacy_sbml = None
-
-try:
-    import scipy
-    from cobra.io.mat import load_matlab_model, save_matlab_model
-except ImportError:
-    warn("cobra.io.mat requires scipy")
-    scipy = None
-    load_matlab_model = None
-    save_matlab_model = None
-
-del libsbml, scipy, warn
+from cobra.io.sbml import read_legacy_sbml
+from cobra.io.sbml import write_cobra_model_to_sbml_file as \
+    write_legacy_sbml
+from cobra.io.mat import load_matlab_model, save_matlab_model

--- a/cobra/test/test_io.py
+++ b/cobra/test/test_io.py
@@ -103,6 +103,28 @@ trials = [IOTrial('fbc2', 'mini.pickle', 'mini_fbc2.xml',
 trial_names = [node.name for node in trials]
 
 
+@pytest.mark.skipif(scipy is not None, reason='scipy available')
+def raise_scipy_errors():
+    with pytest.raises(ImportError):
+        io.save_matlab_model(None, 'test')
+    with pytest.raises(ImportError):
+        io.load_matlab_model('test')
+
+
+@pytest.mark.skipif(libsbml is not None, reason='libsbml available')
+def raise_libsbml_errors():
+    with pytest.raises(ImportError):
+        io.read_sbml_model('test')
+    with pytest.raises(ImportError):
+        io.write_sbml_model(None, 'test')
+    with pytest.raises(ImportError):
+        io.load_matlab_model('test')
+    with pytest.raises(ImportError):
+        io.write_legacy_sbml(None, 'test')
+    with pytest.raises(ImportError):
+        io.read_legacy_sbml(None, 'test')
+
+
 @pytest.fixture(scope="module", params=trials, ids=trial_names)
 def io_trial(request, data_directory):
     with open(join(data_directory, request.param.reference_file),


### PR DESCRIPTION
warnings makes the package look broken even though the lacking functionality is normal and not a concern unless the affected features are actually needed.

Let's raises errors when relevant.