### PR TITLE
feat: add constraint or variable

### DIFF
--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -179,7 +179,7 @@ class Metabolite(Species):
         """
         try:
             check_solver_status(self._model.solver.status)
-            return self._model.solver.constraints[self.id].dual
+            return self._model.constraints[self.id].dual
         except AttributeError:
             raise RuntimeError(
                 "metabolite '{}' is not part of a model".format(self.id))

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -53,7 +53,7 @@ class Metabolite(Species):
         if value in self.model.metabolites:
             raise ValueError("The model already contains a metabolite with "
                              "the id:", value)
-        self.model.solver.constraints[self.id].name = value
+        self.model.constraints[self.id].name = value
         self._id = value
         self.model.metabolites._generate_index()
 
@@ -67,7 +67,7 @@ class Metabolite(Species):
             the optlang constraint for this metabolite
         """
         if self.model is not None:
-            return self.model.solver.constraints[self.id]
+            return self.model.constraints[self.id]
 
     @property
     def elements(self):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -649,7 +649,7 @@ class Model(Object):
             forward_variable = self.problem.Variable(
                 reaction.id, lb=forward_lb, ub=forward_ub)
             reverse_variable = self.problem.Variable(
-                reaction._get_reverse_id(), lb=reverse_lb, ub=reverse_ub)
+                reaction.reverse_id, lb=reverse_lb, ub=reverse_ub)
 
             self.add_cons_vars([forward_variable, reverse_variable])
             self.solver.update()

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -21,7 +21,8 @@ from cobra.solvers import optimize
 from cobra.util.context import HistoryManager, resettable, get_context
 from cobra.util.solver import (
     SolverNotFound, get_solver_name, interface_to_str, set_objective, solvers,
-    add_to_solver, remove_from_solver, choose_solver, check_solver_status)
+    add_cons_vars_to_problem, remove_cons_vars_from_problem, choose_solver,
+    check_solver_status)
 from cobra.util.util import AutoVivification
 
 
@@ -107,7 +108,7 @@ class Model(Object):
         --------
         >>> import cobra.test
         >>> model = cobra.test.create_test_model("textbook")
-        >>> new = model.solver.interface.Constraint(model.objective.expression,
+        >>> new = model.problem.Constraint(model.objective.expression,
         >>> lb=0.99)
         >>> model.solver.add(new)
         """
@@ -133,7 +134,7 @@ class Model(Object):
             raise not_valid_interface
 
         # Do nothing if the solver did not change
-        if self.solver.interface == interface:
+        if self.problem == interface:
             return
 
         for reaction in self.reactions:
@@ -301,7 +302,6 @@ class Model(Object):
         except Exception:  # pragma: no cover
             new._solver = copy(self.solver)  # pragma: no cover
 
-        # No use in copying it, also circular dependencies
         return new
 
     def add_metabolites(self, metabolite_list):
@@ -327,12 +327,12 @@ class Model(Object):
         # from cameo ...
         to_add = []
         for met in metabolite_list:
-            if met.id not in self.solver.constraints:
-                constraint = self.solver.interface.Constraint(
+            if met.id not in self.constraints:
+                constraint = self.problem.Constraint(
                     S.Zero, name=met.id, lb=0, ub=0)
                 to_add += [constraint]
 
-        add_to_solver(self, to_add)
+        self.add_cons_vars(to_add)
 
         context = get_context(self)
         if context:
@@ -377,7 +377,7 @@ class Model(Object):
         self.metabolites -= metabolite_list
 
         to_remove = [self.solver.constraints[m.id] for m in metabolite_list]
-        remove_from_solver(self, to_remove)
+        self.remove_cons_vars(to_remove)
 
         context = get_context(self)
         if context:
@@ -513,7 +513,7 @@ class Model(Object):
             else:
                 forward = reaction.forward_variable
                 reverse = reaction.reverse_variable
-                remove_from_solver(self, [forward, reverse])
+                self.remove_cons_vars([forward, reverse])
                 self.reactions.remove(reaction)
                 reaction._model = None
 
@@ -543,6 +543,92 @@ class Model(Object):
                 reaction._metabolites = {}
                 reaction._genes = set()
 
+    def add_cons_vars(self, what, **kwargs):
+        """Add constraints and variables to the model's mathematical problem.
+
+        Useful for variables and constraints that can not be expressed with
+        reactions and simple lower and upper bounds.
+
+        Additions are reversed upon exit if the model itself is used as
+        context.
+
+        Parameters
+        ----------
+        what : list or tuple of optlang variables or constraints.
+           The variables or constraints to add to the model. Must be of
+           class `optlang.interface.Variable` or
+           `optlang.interface.Constraint`.
+        **kwargs : keyword arguments
+           Passed to solver.add()
+        """
+        add_cons_vars_to_problem(self, what, **kwargs)
+
+    def remove_cons_vars(self, what):
+        """Remove variables and constraints from the model's mathematical
+        problem.
+
+        Remove variables and constraints that were added directly to the
+        model's underlying mathematical problem. Removals are reversed
+        upon exit if the model itself is used as context.
+
+        Parameters
+        ----------
+        what : list or tuple of optlang variables or constraints.
+           The variables or constraints to add to the model. Must be of
+           class `optlang.interface.Variable` or
+           `optlang.interface.Constraint`.
+        """
+        remove_cons_vars_from_problem(self, what)
+
+    @property
+    def problem(self):
+        """The interface to the model's underlying mathematical problem.
+
+        Solutions to cobra models are obtained by formulating a mathematical
+        problem and solving it. Cobrapy uses the optlang package to
+        accomplish that and with this property you can get access to the
+        problem interface directly.
+
+        Returns
+        -------
+        optlang.interface
+            The problem interface that defines methods for interacting with
+            the problem and associated solver directly.
+        """
+        return self.solver.interface
+
+    @property
+    def variables(self):
+        """The mathematical variables in the cobra model.
+
+        In a cobra model, most variables are reactions. However,
+        for specific use cases, it may also be useful to have other types of
+        variables. This property defines all variables currently associated
+        with the model's problem.
+
+        Returns
+        -------
+        optlang.container.Container
+            A container with all associated variables.
+        """
+        return self.solver.variables
+
+    @property
+    def constraints(self):
+        """The constraints in the cobra model.
+
+        In a cobra model, most constraints are metabolites and their
+        stoichiometries. However, for specific use cases, it may also be
+        useful to have other types of constraints. This property defines all
+        constraints currently associated with the model's problem.
+
+        Returns
+        -------
+        optlang.container.Container
+            A container with all associated constraints.
+        """
+        return self.solver.constraints
+
     def _populate_solver(self, reaction_list, metabolite_list=None):
         """Populate attached solver with constraints and variables that
         model the provided reactions.
@@ -551,32 +637,32 @@ class Model(Object):
         to_add = []
         if metabolite_list is not None:
             for met in metabolite_list:
-                to_add += [self.solver.interface.Constraint(
+                to_add += [self.problem.Constraint(
                     S.Zero, name=met.id, lb=0, ub=0)]
-        add_to_solver(self, to_add)
+        self.add_cons_vars(to_add)
 
         for reaction in reaction_list:
 
             reverse_lb, reverse_ub, forward_lb, forward_ub = \
                 separate_forward_and_reverse_bounds(*reaction.bounds)
 
-            forward_variable = self.solver.interface.Variable(
+            forward_variable = self.problem.Variable(
                 reaction.id, lb=forward_lb, ub=forward_ub)
-            reverse_variable = self.solver.interface.Variable(
+            reverse_variable = self.problem.Variable(
                 reaction._get_reverse_id(), lb=reverse_lb, ub=reverse_ub)
 
-            add_to_solver(self, [forward_variable, reverse_variable])
+            self.add_cons_vars([forward_variable, reverse_variable])
             self.solver.update()
 
             for metabolite, coeff in six.iteritems(reaction.metabolites):
-                if metabolite.id in self.solver.constraints:
-                    constraint = self.solver.constraints[metabolite.id]
+                if metabolite.id in self.constraints:
+                    constraint = self.constraints[metabolite.id]
                 else:
-                    constraint = self.solver.interface.Constraint(
+                    constraint = self.problem.Constraint(
                         S.Zero,
                         name=metabolite.id,
                         lb=0, ub=0)
-                    add_to_solver(self, constraint, sloppy=True)
+                    self.add_cons_vars(constraint, sloppy=True)
 
                 constraint_terms[constraint][forward_variable] = coeff
                 constraint_terms[constraint][reverse_variable] = -coeff
@@ -602,7 +688,7 @@ class Model(Object):
     def to_array_based_model(self, deepcopy_model=False, **kwargs):
         """Makes a :class:`~cobra.core.ArrayBasedModel` from a cobra.Model
         which may be used to perform linear algebra operations with the
-        stoichiomatric matrix.
+        stoichiometric matrix.
 
         Deprecated (0.6). Use `~cobra.util.array.create_stoichiometric_array`
         or `model.S` instead.
@@ -648,7 +734,7 @@ class Model(Object):
 
         """
         legacy, solver = choose_solver(self, solver=kwargs.get("solver"))
-        original_direction = self.solver.objective.direction
+        original_direction = self.objective.direction
 
         if legacy:
             if objective_sense is None:
@@ -660,12 +746,12 @@ class Model(Object):
             return solution
 
         self.solver = solver
-        self.solver.objective.direction = \
+        self.objective.direction = \
             {"maximize": "max", "minimize": "min"}.get(
                 objective_sense, original_direction)
         self.solver.optimize()
         solution = get_solution(self)
-        self.solver.objective.direction = original_direction
+        self.objective.direction = original_direction
         return solution
 
     def repair(self, rebuild_index=True, rebuild_relationships=True):
@@ -702,7 +788,7 @@ class Model(Object):
     def objective(self):
         """Get or set the solver objective
 
-        Before introduction of the optlang based solver interfaces,
+        Before introduction of the optlang based problems,
         this function returned the objective reactions as a list. With
         optlang, the objective is not limited a simple linear summation of
         individual reaction fluxes, making that return value ambiguous.
@@ -712,7 +798,7 @@ class Model(Object):
 
         The set value can be dictionary (reactions as keys, linear
         coefficients as values), string (reaction identifier), int (reaction
-        index), Reaction or solver.interface.Objective or sympy expression
+        index), Reaction or problem.Objective or sympy expression
         directly interpreted as objectives.
 
         When using a `HistoryManager` context, this attribute can be set
@@ -723,7 +809,7 @@ class Model(Object):
     @objective.setter
     def objective(self, value):
         if isinstance(value, sympy.Basic):
-            value = self.solver.interface.Objective(value, sloppy=False)
+            value = self.problem.Objective(value, sloppy=False)
         if not isinstance(value, (dict, optlang.interface.Objective)):
             value = {rxn: 1 for rxn in self.reactions.get_by_any(value)}
         set_objective(self, value, additive=False)

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -97,18 +97,15 @@ class Reaction(Object):
         reverse_variable = self.reverse_variable
         self._id = value
         self.model.reactions._generate_index()
-        forward_variable.name = self._get_forward_id()
-        reverse_variable.name = self._get_reverse_id()
+        forward_variable.name = self.id
+        reverse_variable.name = self.reverse_id
 
-    def _get_reverse_id(self):
+    @property
+    def reverse_id(self):
         """Generate the id of reverse_variable from the reaction's id."""
         return '_'.join((self.id, 'reverse',
                          hashlib.md5(
                              self.id.encode('utf-8')).hexdigest()[0:5]))
-
-    def _get_forward_id(self):
-        """Generate the id of forward_variable from the reaction's id."""
-        return self.id
 
     @property
     def flux_expression(self):
@@ -139,7 +136,7 @@ class Reaction(Object):
         if self.model is not None:
             if self._forward_variable is None:
                 self._forward_variable = self.model.variables[
-                    self._get_forward_id()]
+                    self.id]
             assert self._forward_variable.problem is self.model.solver
             return self._forward_variable
         else:
@@ -159,7 +156,7 @@ class Reaction(Object):
         if model is not None:
             if self._reverse_variable is None:
                 self._reverse_variable = model.variables[
-                    self._get_reverse_id()]
+                    self.reverse_id]
             assert self._reverse_variable.problem is self.model.solver
             return self._reverse_variable
         else:
@@ -295,7 +292,6 @@ class Reaction(Object):
 
         Examples
         --------
-        >>> import cobra
         >>> import cobra.test
         >>> model = cobra.test.create_test_model("textbook")
         >>> solution = model.optimize()

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -138,7 +138,7 @@ class Reaction(Object):
         """
         if self.model is not None:
             if self._forward_variable is None:
-                self._forward_variable = self.model.solver.variables[
+                self._forward_variable = self.model.variables[
                     self._get_forward_id()]
             assert self._forward_variable.problem is self.model.solver
             return self._forward_variable
@@ -158,7 +158,7 @@ class Reaction(Object):
         model = self.model
         if model is not None:
             if self._reverse_variable is None:
-                self._reverse_variable = model.solver.variables[
+                self._reverse_variable = model.variables[
                     self._get_reverse_id()]
             assert self._reverse_variable.problem is self.model.solver
             return self._reverse_variable
@@ -766,7 +766,7 @@ class Reaction(Object):
                     else:
                         coefficient = coefficient + old_coefficient
 
-                model.solver.constraints[
+                model.constraints[
                     metabolite.id].set_linear_coefficients(
                     {self.forward_variable: coefficient,
                      self.reverse_variable: -coefficient

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -7,14 +7,12 @@ from __future__ import absolute_import
 import numpy
 from six import iteritems
 from sympy.core.singleton import S
+
 from cobra.core import Metabolite, Reaction, get_solution
+from cobra.exceptions import SolveError
 from cobra.util import add_to_solver, linear_reaction_coefficients
 from cobra.manipulation.modify import convert_to_irreversible
-
-try:
-    from cobra.util import nullspace
-except ImportError:
-    nullspace = None
+from cobra.util import nullspace
 
 
 def add_loopless(model, zero_cutoff=1e-12):
@@ -51,7 +49,7 @@ def add_loopless(model, zero_cutoff=1e-12):
     s_int = model.S[:, numpy.array(internal)]
     n_int = nullspace(s_int).T
     max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
-    prob = model.solver.interface
+    prob = model.problem
 
     # Add indicator variables and new constraints
     to_add = []
@@ -70,18 +68,18 @@ def add_loopless(model, zero_cutoff=1e-12):
             lb=1, ub=max_bound, name="delta_g_range_" + rxn.id)
         to_add.extend([indicator, on_off_constraint, delta_g, delta_g_range])
 
-    add_to_solver(model, to_add)
+    model.add_cons_vars(to_add)
 
     # Add nullspace constraints for G_i
     for i, row in enumerate(n_int):
         name = "nullspace_constraint_" + str(i)
         nullspace_constraint = prob.Constraint(S.Zero, lb=0, ub=0, name=name)
-        add_to_solver(model, [nullspace_constraint])
-        coefs = {model.solver.variables[
+        model.add_cons_vars([nullspace_constraint])
+        coefs = {model.variables[
                  "delta_g_" + model.reactions[ridx].id]: row[i]
                  for i, ridx in enumerate(internal) if
                  abs(row[i]) > zero_cutoff}
-        model.solver.constraints[name].set_linear_coefficients(coefs)
+        model.constraints[name].set_linear_coefficients(coefs)
 
 
 def loopless_solution(model, fluxes=None):
@@ -142,14 +140,14 @@ def loopless_solution(model, fluxes=None):
         coefs = linear_reaction_coefficients(model)
         obj_val = sum(coefs[rxn] * fluxes[rxn.id] for rxn in coefs)
 
-    prob = model.solver.interface
+    prob = model.problem
     with model:
         loopless_old_obj = prob.Variable("loopless_old_objective",
                                          lb=obj_val, ub=obj_val)
         loopless_obj_constraint = prob.Constraint(
             model.solver.objective.expression - loopless_old_obj,
             lb=0, ub=0, name="loopless_obj_constraint")
-        add_to_solver(model, [loopless_old_obj, loopless_obj_constraint])
+        model.add_cons_vars([loopless_old_obj, loopless_obj_constraint])
         model.objective = S.Zero
         for rxn in model.reactions:
             flux = fluxes[rxn.id]
@@ -214,7 +212,7 @@ def loopless_fva_iter(model, reaction, all_fluxes=False, zero_cutoff=1e-9):
 
     # Reset objective to original one and get a loopless solution
     model.solver.objective.set_linear_coefficients(
-        {model.solver.variables.fva_old_objective: 1,
+        {model.variables.fva_old_objective: 1,
          reaction.forward_variable: 0, reaction.reverse_variable: 0})
 
     loopless = loopless_solution(model)
@@ -225,7 +223,7 @@ def loopless_fva_iter(model, reaction, all_fluxes=False, zero_cutoff=1e-9):
         # Reset the objective to the one used in the iteration, walk around
         # the context manager for speed
         model.solver.objective.set_linear_coefficients(
-            {model.solver.variables.fva_old_objective: 0,
+            {model.variables.fva_old_objective: 0,
              reaction.forward_variable: 1, reaction.reverse_variable: -1})
         if all_fluxes:
             current = loopless
@@ -246,7 +244,7 @@ def loopless_fva_iter(model, reaction, all_fluxes=False, zero_cutoff=1e-9):
 
         # Globally reset the objective to the one used in the FVA iteration
         model.solver.objective.set_linear_coefficients(
-            {model.solver.variables.fva_old_objective: 0,
+            {model.variables.fva_old_objective: 0,
              reaction.forward_variable: 1, reaction.reverse_variable: -1})
 
     solution = model.optimize(objective_sense=None)

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -9,8 +9,7 @@ from six import iteritems
 from sympy.core.singleton import S
 
 from cobra.core import Metabolite, Reaction, get_solution
-from cobra.exceptions import SolveError
-from cobra.util import add_to_solver, linear_reaction_coefficients
+from cobra.util import linear_reaction_coefficients
 from cobra.manipulation.modify import convert_to_irreversible
 from cobra.util import nullspace
 

--- a/cobra/flux_analysis/moma.py
+++ b/cobra/flux_analysis/moma.py
@@ -54,7 +54,7 @@ def add_moma(model):
     model.solver = sutil.choose_solver(model, qp=True)[1]
 
     solution = model.optimize()
-    prob = model.solver.interface
+    prob = model.problem
     v = prob.Variable("moma_old_objective")
     c = prob.Constraint(model.solver.objective.expression - v,
                         lb=0.0, ub=0.0, name="moma_old_objective_constraint")
@@ -67,7 +67,7 @@ def add_moma(model):
                                 name="moma_constraint_" + r.id)
         to_add.extend([dist, const])
         new_obj += dist**2
-    sutil.add_to_solver(model, to_add)
+    model.add_cons_vars(to_add)
     model.objective = prob.Objective(new_obj, direction='min')
 
 

--- a/cobra/flux_analysis/parsimonious.py
+++ b/cobra/flux_analysis/parsimonious.py
@@ -51,7 +51,7 @@ def optimize_minimal_flux(model, already_irreversible=False,
         initial optimization result. Ignored for optlang solvers, instead,
         define your objective separately and pass using the `objective`
         argument.
-    objective : dict or model.solver.interface.Objective
+    objective : dict or model.problem.Objective
         A desired objective to use during optimization in addition to the
         pFBA objective. Dictionaries (reaction as key, coefficient as value)
         can be used for linear objectives. Not used for non-optlang solvers.
@@ -120,7 +120,7 @@ def add_pfba(model, objective=None, fraction_of_optimum=1.0):
     reaction_variables = ((rxn.forward_variable, rxn.reverse_variable)
                           for rxn in model.reactions)
     variables = chain(*reaction_variables)
-    pfba_objective = model.solver.interface.Objective(add(
+    pfba_objective = model.problem.Objective(add(
         [mul((sympy.singleton.S.One, variable))
          for variable in variables]), direction='min', sloppy=True)
     set_objective(model, pfba_objective)

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -179,7 +179,7 @@ def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
                     status = m.solver.status
                     status_dict[reaction.id] = status
                     if status == "optimal":
-                        growth = m.solver.variables.moma_old_objective.primal
+                        growth = m.variables.moma_old_objective.primal
                     else:
                         growth = 0.0
                     growth_rate_dict[reaction.id] = growth
@@ -354,7 +354,7 @@ def single_gene_deletion_moma(cobra_model, gene_list, solver=None,
                     status = m.solver.status
                     status_dict[gene.id] = status
                     if status == "optimal":
-                        growth = m.solver.variables.moma_old_objective.primal
+                        growth = m.variables.moma_old_objective.primal
                     else:
                         growth = 0.0
                     growth_rate_dict[gene.id] = growth

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -156,7 +156,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
         A dictionary containing the results.
     """
     fva_results = {str(rxn): {} for rxn in reaction_list}
-    prob = model.solver.interface
+    prob = model.problem
     with model as m:
         m.solver.optimize()
         if m.solver.status != "optimal":
@@ -170,7 +170,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
         fva_old_obj_constraint = prob.Constraint(
             m.solver.objective.expression - fva_old_objective, lb=0, ub=0,
             name="fva_old_objective_constraint")
-        sutil.add_to_solver(m, [fva_old_objective, fva_old_obj_constraint])
+        m.add_cons_vars([fva_old_objective, fva_old_obj_constraint])
         model.objective = S.Zero  # This will trigger the reset as well
         for what in ("minimum", "maximum"):
             sense = "min" if what == "minimum" else "max"

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -71,7 +71,7 @@ class TestCobraFluxAnalysis:
         if solver in optlang_solvers:
             model.solver = solver
         expression = model.objective.expression
-        n_constraints = len(model.solver.constraints)
+        n_constraints = len(model.constraints)
         solution = optimize_minimal_flux(model, solver=solver)
         assert solution.status == "optimal"
         assert numpy.isclose(solution.x_dict["Biomass_Ecoli_core"],
@@ -80,7 +80,7 @@ class TestCobraFluxAnalysis:
         assert numpy.isclose(sum(abs_x), 518.4221, atol=1e-4, rtol=0.0)
         # test changes to model reverted
         assert expression == model.objective.expression
-        assert len(model.solver.constraints) == n_constraints
+        assert len(model.constraints) == n_constraints
 
         # needed?
         # Test desired_objective_value

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 import numpy
 import pytest
+from sympy import S
 
 import cobra.util.solver as su
 from cobra.core import Metabolite, Model, Reaction
@@ -649,6 +650,17 @@ class TestCobraModel:
                            reaction in [atpm, biomass]]
         assert su.linear_reaction_coefficients(model) == {atpm: 1.,
                                                           biomass: 1.}
+
+    def test_problem_properties(self, model):
+        new_variable = model.problem.Variable("test_variable")
+        new_constraint = model.problem.Constraint(S.Zero,
+                                                  name="test_constraint")
+        model.add_cons_vars([new_variable, new_constraint])
+        assert "test_variable" in model.variables.keys()
+        assert "test_constraint" in model.constraints.keys()
+        model.remove_cons_vars([new_constraint, new_variable])
+        assert "test_variable" not in model.variables.keys()
+        assert "test_constraint" not in model.variables.keys()
 
     def test_model_medium(self, model):
         # Add a dummy 'malformed' import reaction

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -541,7 +541,7 @@ class TestSolverBasedModel:
         biomass_r = model.reactions.get_by_id('Biomass_Ecoli_core')
         pgi = model.reactions.PGI
         pgi.objective_coefficient = 2
-        coef_dict = model.solver.objective.expression.as_coefficients_dict()
+        coef_dict = model.objective.expression.as_coefficients_dict()
         # Check that objective has been updated
         assert coef_dict[pgi.forward_variable] == 2
         assert coef_dict[pgi.reverse_variable] == -2
@@ -578,7 +578,7 @@ class TestSolverBasedModel:
         assert model.reactions[-1] == r2
         assert isinstance(model.reactions[-2].reverse_variable,
                           model.problem.Variable)
-        coefficients_dict = model.solver.objective.expression. \
+        coefficients_dict = model.objective.expression. \
             as_coefficients_dict()
         biomass_r = model.reactions.get_by_id('Biomass_Ecoli_core')
         assert coefficients_dict[biomass_r.forward_variable] == 1.
@@ -653,7 +653,7 @@ class TestSolverBasedModel:
             assert reaction in model.reactions
 
     def test_objective(self, model):
-        obj = model.solver.objective
+        obj = model.objective
         assert {var.name: coef for var, coef in
                 obj.expression.as_coefficients_dict().items()} == {
                    'Biomass_Ecoli_core_reverse_2cdba': -1,
@@ -663,55 +663,55 @@ class TestSolverBasedModel:
     def test_change_objective(self, model):
         expression = 1.0 * model.variables['ENO'] + \
                      1.0 * model.variables['PFK']
-        model.solver.objective = model.problem.Objective(
+        model.objective = model.problem.Objective(
             expression)
-        assert model.solver.objective.expression == expression
+        assert model.objective.expression == expression
         model.objective = "ENO"
         eno_obj = model.problem.Objective(
             model.reactions.ENO.flux_expression, direction="max")
         pfk_obj = model.problem.Objective(
             model.reactions.PFK.flux_expression, direction="max")
-        assert model.solver.objective == eno_obj
+        assert model.objective == eno_obj
 
         with model:
             model.objective = "PFK"
-            assert model.solver.objective == pfk_obj
-        assert model.solver.objective == eno_obj
-        expression = model.solver.objective.expression
+            assert model.objective == pfk_obj
+        assert model.objective == eno_obj
+        expression = model.objective.expression
         atpm = model.reactions.get_by_id("ATPM")
         biomass = model.reactions.get_by_id("Biomass_Ecoli_core")
         with model:
             model.objective = atpm
-        assert model.solver.objective.expression == expression
+        assert model.objective.expression == expression
         with model:
             atpm.objective_coefficient = 1
             biomass.objective_coefficient = 2
-        assert model.solver.objective.expression == expression
+        assert model.objective.expression == expression
 
         with model:
             set_objective(model, model.problem.Objective(
                 atpm.flux_expression))
-            assert model.solver.objective.expression == atpm.flux_expression
-        assert model.solver.objective.expression == expression
+            assert model.objective.expression == atpm.flux_expression
+        assert model.objective.expression == expression
 
-        expression = model.solver.objective.expression
+        expression = model.objective.expression
         with model:
             with model:  # Test to make sure nested contexts are OK
                 set_objective(model, atpm.flux_expression,
                               additive=True)
-                assert (model.solver.objective.expression ==
+                assert (model.objective.expression ==
                         expression + atpm.flux_expression)
-        assert model.solver.objective.expression == expression
+        assert model.objective.expression == expression
 
     def test_set_reaction_objective(self, model):
         model.objective = model.reactions.ACALD
-        assert str(model.solver.objective.expression) == str(
+        assert str(model.objective.expression) == str(
             1.0 * model.reactions.ACALD.forward_variable -
             1.0 * model.reactions.ACALD.reverse_variable)
 
     def test_set_reaction_objective_str(self, model):
         model.objective = model.reactions.ACALD.id
-        assert str(model.solver.objective.expression) == str(
+        assert str(model.objective.expression) == str(
             1.0 * model.reactions.ACALD.forward_variable -
             1.0 * model.reactions.ACALD.reverse_variable)
 

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -502,16 +502,16 @@ class TestReaction:
         pgi.remove_from_model()
         assert pgi.model is None
         assert not ("PGI" in model.reactions)
-        assert not (pgi._get_forward_id() in model.variables)
-        assert not (pgi._get_reverse_id() in model.variables)
+        assert not (pgi.id in model.variables)
+        assert not (pgi.reverse_id in model.variables)
 
     def test_delete(self, model):
         pgi = model.reactions.PGI
         pgi.delete()
         assert pgi.model is None
         assert not ("PGI" in model.reactions)
-        assert not (pgi._get_forward_id() in model.variables)
-        assert not (pgi._get_reverse_id() in model.variables)
+        assert not (pgi.id in model.variables)
+        assert not (pgi.reverse_id in model.variables)
 
     def test_change_id_is_reflected_in_solver(self, model):
         for i, reaction in enumerate(model.reactions):
@@ -523,10 +523,10 @@ class TestReaction:
             reaction.id = new_reaction_id
             assert reaction.id == new_reaction_id
             assert not (old_reaction_id in model.variables)
-            assert reaction._get_forward_id() in model.variables
-            assert reaction._get_reverse_id() in model.variables
-            name = model.variables[reaction._get_forward_id()].name
-            assert name == reaction._get_forward_id()
+            assert reaction.id in model.variables
+            assert reaction.reverse_id in model.variables
+            name = model.variables[reaction.id].name
+            assert name == reaction.id
 
 
 class TestSolverBasedModel:

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -68,29 +68,29 @@ class TestReaction:
         test_met = model.metabolites[0]
         pgi_reaction.add_metabolites({test_met: 42}, combine=False)
         assert pgi_reaction.metabolites[test_met] == 42
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.forward_variable] == 42
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.reverse_variable] == -42
 
         pgi_reaction.add_metabolites({test_met: -10}, combine=True)
         assert pgi_reaction.metabolites[test_met] == 32
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.forward_variable] == 32
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.reverse_variable] == -32
 
         pgi_reaction.add_metabolites({test_met: 0}, combine=False)
         with pytest.raises(KeyError):
             pgi_reaction.metabolites[test_met]
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.forward_variable] == 0
-        assert model.solver.constraints[
+        assert model.constraints[
                    test_met.id].expression.as_coefficients_dict()[
                    pgi_reaction.reverse_variable] == 0
 
@@ -433,9 +433,9 @@ class TestReaction:
         for reaction in model.reactions:
             reaction.add_metabolites({test_metabolite: -66}, combine=True)
             assert reaction.metabolites[test_metabolite] == -66
-            assert model.solver.constraints['test'].expression.has(
+            assert model.constraints['test'].expression.has(
                 -66. * reaction.forward_variable)
-            assert model.solver.constraints['test'].expression.has(
+            assert model.constraints['test'].expression.has(
                 66. * reaction.reverse_variable)
             already_included_metabolite = \
                 list(reaction.metabolites.keys())[0]
@@ -446,10 +446,10 @@ class TestReaction:
             new_coefficient = previous_coefficient + 10
             assert reaction.metabolites[
                        already_included_metabolite] == new_coefficient
-            assert model.solver.constraints[
+            assert model.constraints[
                 already_included_metabolite.id].expression.has(
                 new_coefficient * reaction.forward_variable)
-            assert model.solver.constraints[
+            assert model.constraints[
                 already_included_metabolite.id].expression.has(
                 -1 * new_coefficient * reaction.reverse_variable)
 
@@ -459,19 +459,19 @@ class TestReaction:
         for reaction in model.reactions:
             reaction.add_metabolites({test_metabolite: -66}, combine=False)
             assert reaction.metabolites[test_metabolite] == -66
-            assert model.solver.constraints['test'].expression.has(
+            assert model.constraints['test'].expression.has(
                 -66. * reaction.forward_variable)
-            assert model.solver.constraints['test'].expression.has(
+            assert model.constraints['test'].expression.has(
                 66. * reaction.reverse_variable)
             already_included_metabolite = \
                 list(reaction.metabolites.keys())[0]
             reaction.add_metabolites({already_included_metabolite: 10},
                                      combine=False)
             assert reaction.metabolites[already_included_metabolite] == 10
-            assert model.solver.constraints[
+            assert model.constraints[
                 already_included_metabolite.id].expression.has(
                 10 * reaction.forward_variable)
-            assert model.solver.constraints[
+            assert model.constraints[
                 already_included_metabolite.id].expression.has(
                 -10 * reaction.reverse_variable)
 
@@ -502,30 +502,30 @@ class TestReaction:
         pgi.remove_from_model()
         assert pgi.model is None
         assert not ("PGI" in model.reactions)
-        assert not (pgi._get_forward_id() in model.solver.variables)
-        assert not (pgi._get_reverse_id() in model.solver.variables)
+        assert not (pgi._get_forward_id() in model.variables)
+        assert not (pgi._get_reverse_id() in model.variables)
 
     def test_delete(self, model):
         pgi = model.reactions.PGI
         pgi.delete()
         assert pgi.model is None
         assert not ("PGI" in model.reactions)
-        assert not (pgi._get_forward_id() in model.solver.variables)
-        assert not (pgi._get_reverse_id() in model.solver.variables)
+        assert not (pgi._get_forward_id() in model.variables)
+        assert not (pgi._get_reverse_id() in model.variables)
 
     def test_change_id_is_reflected_in_solver(self, model):
         for i, reaction in enumerate(model.reactions):
             old_reaction_id = reaction.id
-            assert model.solver.variables[
+            assert model.variables[
                        old_reaction_id].name == old_reaction_id
-            assert old_reaction_id in model.solver.variables
+            assert old_reaction_id in model.variables
             new_reaction_id = reaction.id + '_' + str(i)
             reaction.id = new_reaction_id
             assert reaction.id == new_reaction_id
-            assert not (old_reaction_id in model.solver.variables)
-            assert reaction._get_forward_id() in model.solver.variables
-            assert reaction._get_reverse_id() in model.solver.variables
-            name = model.solver.variables[reaction._get_forward_id()].name
+            assert not (old_reaction_id in model.variables)
+            assert reaction._get_forward_id() in model.variables
+            assert reaction._get_reverse_id() in model.variables
+            name = model.variables[reaction._get_forward_id()].name
             assert name == reaction._get_forward_id()
 
 
@@ -577,7 +577,7 @@ class TestSolverBasedModel:
         assert model.reactions[-2] == r1
         assert model.reactions[-1] == r2
         assert isinstance(model.reactions[-2].reverse_variable,
-                          model.solver.interface.Variable)
+                          model.problem.Variable)
         coefficients_dict = model.solver.objective.expression. \
             as_coefficients_dict()
         biomass_r = model.reactions.get_by_id('Biomass_Ecoli_core')
@@ -646,7 +646,7 @@ class TestSolverBasedModel:
             [reaction.model is None for reaction in reactions_to_remove])
         for reaction in reactions_to_remove:
             assert reaction.id not in list(
-                model.solver.variables.keys())
+                model.variables.keys())
 
         model.add_reactions(reactions_to_remove)
         for reaction in reactions_to_remove:
@@ -661,15 +661,15 @@ class TestSolverBasedModel:
         assert obj.direction == "max"
 
     def test_change_objective(self, model):
-        expression = 1.0 * model.solver.variables['ENO'] + \
-                     1.0 * model.solver.variables['PFK']
-        model.solver.objective = model.solver.interface.Objective(
+        expression = 1.0 * model.variables['ENO'] + \
+                     1.0 * model.variables['PFK']
+        model.solver.objective = model.problem.Objective(
             expression)
         assert model.solver.objective.expression == expression
         model.objective = "ENO"
-        eno_obj = model.solver.interface.Objective(
+        eno_obj = model.problem.Objective(
             model.reactions.ENO.flux_expression, direction="max")
-        pfk_obj = model.solver.interface.Objective(
+        pfk_obj = model.problem.Objective(
             model.reactions.PFK.flux_expression, direction="max")
         assert model.solver.objective == eno_obj
 
@@ -689,7 +689,7 @@ class TestSolverBasedModel:
         assert model.solver.objective.expression == expression
 
         with model:
-            set_objective(model, model.solver.interface.Objective(
+            set_objective(model, model.problem.Objective(
                 atpm.flux_expression))
             assert model.solver.objective.expression == atpm.flux_expression
         assert model.solver.objective.expression == expression
@@ -781,9 +781,9 @@ class TestSolverBasedModel:
         solution, model = solved_model
         model_cp = copy.copy(model)
         primals_original = [variable.primal for variable in
-                            model.solver.variables]
+                            model.variables]
         primals_copy = [variable.primal for variable in
-                        model_cp.solver.variables]
+                        model_cp.variables]
         abs_diff = abs(
             numpy.array(primals_copy) - numpy.array(primals_original))
         assert not any(abs_diff > 1e-6)
@@ -807,4 +807,4 @@ class TestMetabolite:
         met = model.metabolites.get_by_id("g6p_c")
         met.remove_from_model()
         assert not (met.id in model.metabolites)
-        assert not (met.id in model.solver.constraints)
+        assert not (met.id in model.constraints)


### PR DESCRIPTION
Whilst updating the notebooks I find the `add_to_solver` utility to be confusing because while we have some (currently unavoidable) convolution between the `Model` and the `Model.solver`, it doesn't feel necessary to explain this to the casual user, and so I would like a `Model.add_constraint_or_variable` (long name though..) as a wrapper to `add_to_solver`.
