### PR TITLE
Some changes to stoichiometric matrix

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -687,7 +687,7 @@ class Model(Object):
         which may be used to perform linear algebra operations with the
         stoichiometric matrix.
 
-        Deprecated (0.6). Use `cobra.util.array.create_stoichiometric_array`
+        Deprecated (0.6). Use `cobra.util.array.create_stoichiometric_matrix`
         instead.
 
         Parameters
@@ -697,7 +697,7 @@ class Model(Object):
 
         """
         warn("to_array_based_model is deprecated. "
-             "use cobra.util.array.create_stoichiometric_array instead",
+             "use cobra.util.array.create_stoichiometric_matrix instead",
              DeprecationWarning)
         from cobra.core.arraybasedmodel import ArrayBasedModel
         return ArrayBasedModel(self, deepcopy_model=deepcopy_model, **kwargs)

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -10,7 +10,7 @@ from sympy.core.singleton import S
 
 from cobra.core import Metabolite, Reaction, get_solution
 from cobra.util import (linear_reaction_coefficients,
-                        create_stoichiometric_array)
+                        create_stoichiometric_matrix)
 from cobra.manipulation.modify import convert_to_irreversible
 from cobra.util import nullspace
 
@@ -46,7 +46,7 @@ def add_loopless(model, zero_cutoff=1e-12):
        in: Biophys J. 2011 Mar 2;100(5):1381.
     """
     internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
-    s_int = create_stoichiometric_array(model)[:, numpy.array(internal)]
+    s_int = create_stoichiometric_matrix(model)[:, numpy.array(internal)]
     n_int = nullspace(s_int).T
     max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
     prob = model.problem

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -15,7 +15,7 @@ from time import time
 import numpy as np
 import pandas
 from cobra.solvers import get_solver_name, solver_dict
-from cobra.util import create_stoichiometric_array, nullspace
+from cobra.util import create_stoichiometric_matrix, nullspace
 
 BTOL = np.finfo(np.float32).eps
 """The tolerance used for checking bounds feasibility."""
@@ -87,7 +87,7 @@ class HRSampler(object):
         self.model = model
         self.thinning = thinning
         self.n_samples = 0
-        self.S = create_stoichiometric_array(model, array_type='dense')
+        self.S = create_stoichiometric_matrix(model, array_type='dense')
         self.NS = nullspace(self.S)
         self.bounds = np.array([[r.lower_bound, r.upper_bound]
                                for r in model.reactions]).T

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -11,7 +11,7 @@ from numpy import object as np_object
 from numpy import array, inf, isinf
 
 from cobra.core import Metabolite, Model, Reaction
-from cobra.util import create_stoichiometric_array
+from cobra.util import create_stoichiometric_matrix
 from cobra.util.solver import set_objective
 
 try:
@@ -153,7 +153,7 @@ def create_mat_dict(model):
     mat["subSystems"] = _cell(rxns.list_attr("subsystem"))
     mat["csense"] = "".join((
         met._constraint_sense for met in model.metabolites))
-    stoich_mat = create_stoichiometric_array(model)
+    stoich_mat = create_stoichiometric_matrix(model)
     mat["S"] = stoich_mat if stoich_mat is not None else [[]]
     # multiply by 1 to convert to float, working around scipy bug
     # https://github.com/scipy/scipy/issues/4537

--- a/cobra/util/array.py
+++ b/cobra/util/array.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-from itertools import product
 import numpy as np
 import pandas as pd
 from six import iteritems
@@ -13,7 +12,7 @@ except ImportError:
     dok_matrix, lil_matrix = None, None
 
 
-def create_stoichiometric_array(model, array_type='dense', dtype=None):
+def create_stoichiometric_matrix(model, array_type='dense', dtype=None):
     """Return a stoichiometric array representation of the given model.
 
     The the columns represent the reactions and rows represent
@@ -27,8 +26,8 @@ def create_stoichiometric_array(model, array_type='dense', dtype=None):
     array_type : string
         The type of array to construct. if 'dense', return a standard
         numpy.array, 'dok', or 'lil' will construct a sparse array using
-        scipy of the corresponding type and 'data_frame' will give a
-        pandas `DataFrame` with metabolite and reaction identifiers as indices.
+        scipy of the corresponding type and 'DataFrame' will give a
+        pandas `DataFrame` with metabolite indices and reaction columns
     dtype : data-type
         The desired data-type for the array. If not given, defaults to float.
 
@@ -37,23 +36,15 @@ def create_stoichiometric_array(model, array_type='dense', dtype=None):
     matrix of class `dtype`
         The stoichiometric matrix for the given model.
     """
-    if array_type not in ('data_frame', 'dense') and not dok_matrix:
+    if array_type not in ('DataFrame', 'dense') and not dok_matrix:
         raise ValueError('Sparse matrices require scipy')
 
     if dtype is None:
         dtype = np.float64
 
-    def data_frame(_, dtype):
-        metabolite_ids = [met.id for met in model.metabolites]
-        reaction_ids = [rxn.id for rxn in model.reactions]
-        index = pd.MultiIndex.from_tuples(
-            list(product(metabolite_ids, reaction_ids)))
-        return pd.DataFrame(data=0, index=index, columns=['stoichiometry'],
-                            dtype=dtype)
-
     array_constructor = {
         'dense': np.zeros, 'dok': dok_matrix, 'lil': lil_matrix,
-        'data_frame': data_frame
+        'DataFrame': np.zeros,
     }
 
     n_metabolites = len(model.metabolites)
@@ -66,13 +57,15 @@ def create_stoichiometric_array(model, array_type='dense', dtype=None):
 
     for reaction in model.reactions:
         for metabolite, stoich in iteritems(reaction.metabolites):
-            if array_type == 'data_frame':
-                array.set_value((metabolite.id, reaction.id),
-                                'stoichiometry', stoich)
-            else:
-                array[m_ind(metabolite), r_ind(reaction)] = stoich
+            array[m_ind(metabolite), r_ind(reaction)] = stoich
 
-    return array
+    if array_type == 'DataFrame':
+        metabolite_ids = [met.id for met in model.metabolites]
+        reaction_ids = [rxn.id for rxn in model.reactions]
+        return pd.DataFrame(array, index=metabolite_ids, columns=reaction_ids)
+
+    else:
+        return array
 
 
 def nullspace(A, atol=1e-13, rtol=0):

--- a/release-notes/0.6.0.md
+++ b/release-notes/0.6.0.md
@@ -108,9 +108,9 @@ and [simulating](http://cobrapy.readthedocs.io/en/latest/simulating.html)
 
 ## DataFrames as return values
 
-`flux_variability_analysis`, `single_{gene,rection}_deletion`,
+`flux_variability_analysis`, `single_{gene,reaction}_deletion`,
 `cobra.flux_analysis.sampling` and
-`cobra.util.create_stoichiometry_array` now return a pandas data frame
+`cobra.util.create_stoichiometric_matrix` now return pandas data frames
 instead of nested dicts as these are more convenient and fun to work
 with. Pandas (and numpy) are therefore now hard requirements for
 cobrapy, which should not be a problem for neither linux, windows or
@@ -142,7 +142,7 @@ the next major cobrapy release.
 - `ArrayBasedModel` / `Model.to_array_based_model` are
   deprecated. This formulation makes little sense when handing over
   the matrix algebra to optlang, for the stoichiometry matrix (aka S),
-  see `cobra.util.array.create_stoichiometry_array`.
+  see `cobra.util.array.create_stoichiometric_matrix`.
 - `Metabolite.y` in favor of `Metabolite.shadow_price`
 - `Model.add_reaction` in favor of `Model.add_reactions`
 - `Reaction.x` in favor of `Reaction.flux`


### PR DESCRIPTION
Renames `create_stochiometric_array` to `create_stoichiometric_matrix`, as suggested in #442.

Also, I wasn't paying too close attention to #417, was this really the behavior we want for pandas DataFrames? I would assume that the dataframe returned should be consistent with the other returned values, and have metabolites and rows and reactions as columns.

This PR also implements that change, such that the dataframe return will look like

```
         ACALD  ACALDt  ACKr  ACONTa  ACONTb  ACt2r  ADK1  AKGDH  AKGt2r  \
13dpg_c    0.0     0.0   0.0     0.0     0.0    0.0   0.0    0.0     0.0
2pg_c      0.0     0.0   0.0     0.0     0.0    0.0   0.0    0.0     0.0
3pg_c      0.0     0.0   0.0     0.0     0.0    0.0   0.0    0.0     0.0
6pgc_c     0.0     0.0   0.0     0.0     0.0    0.0   0.0    0.0     0.0
6pgl_c     0.0     0.0   0.0     0.0     0.0    0.0   0.0    0.0     0.0

         ALCD2x ...   RPI  SUCCt2_2  SUCCt3  SUCDi  SUCOAS  TALA  THD2  TKT1  \
13dpg_c     0.0 ...   0.0       0.0     0.0    0.0     0.0   0.0   0.0   0.0
2pg_c       0.0 ...   0.0       0.0     0.0    0.0     0.0   0.0   0.0   0.0
3pg_c       0.0 ...   0.0       0.0     0.0    0.0     0.0   0.0   0.0   0.0
6pgc_c      0.0 ...   0.0       0.0     0.0    0.0     0.0   0.0   0.0   0.0
6pgl_c      0.0 ...   0.0       0.0     0.0    0.0     0.0   0.0   0.0   0.0

         TKT2  TPI
13dpg_c   0.0  0.0
2pg_c     0.0  0.0
3pg_c     0.0  0.0
6pgc_c    0.0  0.0
6pgl_c    0.0  0.0

[5 rows x 95 columns]
```