### PR TITLE
fix: enable pickling an model with context

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -54,8 +54,11 @@ class Model(Object):
     """
 
     def __setstate__(self, state):
-        """Make sure all cobra.Objects in the model point to the model"""
+        """Make sure all cobra.Objects in the model point to the model.
+        Current contexts are not saved (or reset).
+        """
         self.__dict__.update(state)
+        self._contexts = []
         for y in ['reactions', 'genes', 'metabolites']:
             for x in getattr(self, y):
                 x._model = self


### PR DESCRIPTION
contexts cannot (and arguably shouldn't) be saved, but one may want to
save a model object that has a context.

(currently trying to pickle a model with an active context will result in uncaught exception)