### PR TITLE
fix: enable pickling an model with context

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -54,7 +54,8 @@ class Model(Object):
     """
 
     def __setstate__(self, state):
-        """Make sure all cobra.Objects in the model point to the model"""
+        """Make sure all cobra.Objects in the model point to the model.
+        """
         self.__dict__.update(state)
         for y in ['reactions', 'genes', 'metabolites']:
             for x in getattr(self, y):
@@ -63,6 +64,16 @@ class Model(Object):
                     x._reset_var_cache()
         if not hasattr(self, "name"):
             self.name = None
+
+    def __getstate__(self):
+        """Get state for serialization.
+
+        Ensures that the context stack is cleared prior to serialization,
+        since partial functions cannot be pickled reliably.
+        """
+        odict = self.__dict__.copy()
+        odict['_contexts'] = []
+        return odict
 
     def __init__(self, id_or_model=None, name=None):
         if isinstance(id_or_model, Model):

--- a/cobra/test/test_io.py
+++ b/cobra/test/test_io.py
@@ -134,7 +134,10 @@ def io_trial(request, data_directory):
                                                   request.param.test_file))
     test_output_filename = join(gettempdir(),
                                 split(request.param.test_file)[-1])
-    request.param.write_function(test_model, test_output_filename)
+    # test writing the model within a context with a non-empty stack
+    with test_model:
+        test_model.objective = test_model.objective
+        request.param.write_function(test_model, test_output_filename)
     reread_model = request.param.read_function(test_output_filename)
     unlink(test_output_filename)
     return request.param.name, reference_model, test_model, reread_model


### PR DESCRIPTION
Contexts cannot (and shouldn't) be saved, but one may want to save a
model object that has a context (e.g. when using multiprocessing.) This 
was not possible as partial functions cannot be pickled. Fix this by deleting 
the context in model's `__getstate__`. Adjust the IO tests to write the model 
within a context.

Pickling and unpickling a model does not touch the model's own context, 
only the saved copy.