### PR TITLE
fix: add metabolites in nested contexts

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -331,6 +331,9 @@ class Model(Object):
         """
         if not hasattr(metabolite_list, '__iter__'):
             metabolite_list = [metabolite_list]
+        if len(metabolite_list) == 0:
+            return None
+
         # First check whether the metabolites exist in the model
         metabolite_list = [x for x in metabolite_list
                            if x.id not in self.metabolites]

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -92,16 +92,17 @@ class TestReactions:
         benchmark(add_remove_metabolite)
 
     def test_add_metabolite(self, model):
-
         with model:
-            reaction = model.reactions.get_by_id("PGI")
-            reaction.add_metabolites({model.metabolites[0]: 1})
-            assert model.metabolites[0] in reaction._metabolites
-            fake_metabolite = Metabolite("fake")
-            reaction.add_metabolites({fake_metabolite: 1})
-            assert fake_metabolite in reaction._metabolites
-            assert model.metabolites.has_id("fake")
-            assert model.metabolites.get_by_id("fake") is fake_metabolite
+            with model:
+                reaction = model.reactions.get_by_id("PGI")
+                reaction.add_metabolites({model.metabolites[0]: 1})
+                assert model.metabolites[0] in reaction._metabolites
+                fake_metabolite = Metabolite("fake")
+                reaction.add_metabolites({fake_metabolite: 1})
+                assert fake_metabolite in reaction._metabolites
+                assert model.metabolites.has_id("fake")
+                assert model.metabolites.get_by_id("fake") is fake_metabolite
+            assert len(model._contexts[0]._history) == 0
 
         assert fake_metabolite._model is None
         assert fake_metabolite not in reaction._metabolites


### PR DESCRIPTION
With model as context, `reaction.add_metabolites` would make an
addition of a partial call to `reaction.subtract_metabolites`, which in
turn called `reaction.add_metabolites` thus adding the revert itself back
to the history stack. Avoid this by adding a flag to avoid this addition
from happening. Shame on the ugly extra parameter but saw no good alternatives as the `reaction.add_metabolites` function is quite complex.

Also add small performance boost to make
`model.add_metabolites` on empty list a noop (can happen fairly often when
manipulating many reactions).