### PR TITLE
fix: catch cplex error for milp (#467)

### DIFF
--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -44,6 +44,36 @@ optlang_solvers = ["optlang-" + s for s in stable_optlang if s in
 all_solvers = optlang_solvers + list(solver_dict)
 
 
+def construct_ll_test_model():
+    test_model = Model()
+    test_model.add_metabolites(Metabolite("A"))
+    test_model.add_metabolites(Metabolite("B"))
+    test_model.add_metabolites(Metabolite("C"))
+    EX_A = Reaction("EX_A")
+    EX_A.add_metabolites({test_model.metabolites.A: 1})
+    DM_C = Reaction("DM_C")
+    DM_C.add_metabolites({test_model.metabolites.C: -1})
+    v1 = Reaction("v1")
+    v1.add_metabolites({test_model.metabolites.A: -1,
+                        test_model.metabolites.B: 1})
+    v2 = Reaction("v2")
+    v2.add_metabolites({test_model.metabolites.B: -1,
+                        test_model.metabolites.C: 1})
+    v3 = Reaction("v3")
+    v3.add_metabolites({test_model.metabolites.C: -1,
+                        test_model.metabolites.A: 1})
+    test_model.add_reactions([EX_A, DM_C, v1, v2, v3])
+    DM_C.objective_coefficient = 1
+    return test_model
+
+
+@pytest.fixture(scope="function", params=optlang_solvers)
+def ll_test_model(request):
+    test_model = construct_ll_test_model()
+    test_model.solver = request.param
+    return test_model
+
+
 @contextmanager
 def captured_output():
     """ A context manager to test the IO summary methods """
@@ -295,36 +325,13 @@ class TestCobraFluxAnalysis:
                                         open_exchanges=True)
         assert result == []
 
-    @classmethod
-    def construct_ll_test_model(cls):
-        test_model = Model()
-        test_model.add_metabolites(Metabolite("A"))
-        test_model.add_metabolites(Metabolite("B"))
-        test_model.add_metabolites(Metabolite("C"))
-        EX_A = Reaction("EX_A")
-        EX_A.add_metabolites({test_model.metabolites.A: 1})
-        DM_C = Reaction("DM_C")
-        DM_C.add_metabolites({test_model.metabolites.C: -1})
-        v1 = Reaction("v1")
-        v1.add_metabolites({test_model.metabolites.A: -1,
-                            test_model.metabolites.B: 1})
-        v2 = Reaction("v2")
-        v2.add_metabolites({test_model.metabolites.B: -1,
-                            test_model.metabolites.C: 1})
-        v3 = Reaction("v3")
-        v3.add_metabolites({test_model.metabolites.C: -1,
-                            test_model.metabolites.A: 1})
-        test_model.add_reactions([EX_A, DM_C, v1, v2, v3])
-        DM_C.objective_coefficient = 1
-        return test_model
-
     def test_legacy_loopless_benchmark(self, benchmark):
-        test_model = self.construct_ll_test_model()
+        test_model = construct_ll_test_model()
         benchmark(lambda: construct_loopless_model(test_model).optimize(
             solver="cglpk"))
 
     def test_loopless_benchmark_before(self, benchmark):
-        test_model = self.construct_ll_test_model()
+        test_model = construct_ll_test_model()
 
         def _():
             with test_model:
@@ -334,7 +341,7 @@ class TestCobraFluxAnalysis:
         benchmark(_)
 
     def test_loopless_benchmark_after(self, benchmark):
-        test_model = self.construct_ll_test_model()
+        test_model = construct_ll_test_model()
         benchmark(loopless_solution, test_model)
 
     def test_legacy_loopless(self):
@@ -342,7 +349,7 @@ class TestCobraFluxAnalysis:
             get_solver_name(mip=True)
         except SolverNotFound:
             pytest.skip("no MILP solver found")
-        test_model = self.construct_ll_test_model()
+        test_model = construct_ll_test_model()
         feasible_sol = construct_loopless_model(test_model).optimize(
             solver="cglpk")
         assert feasible_sol.status == "optimal"
@@ -354,12 +361,11 @@ class TestCobraFluxAnalysis:
             with pytest.raises(UserWarning):
                 infeasible_mod.optimize(solver="cglpk")
 
-    def test_loopless_solution(self):
-        test_model = self.construct_ll_test_model()
-        solution_feasible = loopless_solution(test_model)
-        test_model.reactions.v3.lower_bound = 1
-        test_model.optimize()
-        solution_infeasible = loopless_solution(test_model)
+    def test_loopless_solution(self, ll_test_model):
+        solution_feasible = loopless_solution(ll_test_model)
+        ll_test_model.reactions.v3.lower_bound = 1
+        ll_test_model.optimize()
+        solution_infeasible = loopless_solution(ll_test_model)
         assert solution_feasible.fluxes["v3"] == 0.0
         assert solution_infeasible.fluxes["v3"] == 1.0
 
@@ -373,13 +379,12 @@ class TestCobraFluxAnalysis:
             with pytest.raises(UserWarning):
                 loopless_solution(model, fluxes=fluxes)
 
-    def test_add_loopless(self):
-        test_model = self.construct_ll_test_model()
-        add_loopless(test_model)
-        feasible_status = test_model.optimize().status
-        test_model.reactions.v3.lower_bound = 1
-        test_model.solver.optimize()
-        infeasible_status = test_model.solver.status
+    def test_add_loopless(self, ll_test_model):
+        add_loopless(ll_test_model)
+        feasible_status = ll_test_model.optimize().status
+        ll_test_model.reactions.v3.lower_bound = 1
+        ll_test_model.solver.optimize()
+        infeasible_status = ll_test_model.solver.status
         assert feasible_status == "optimal"
         assert infeasible_status == "infeasible"
 


### PR DESCRIPTION
milp don't have reduced costs / shadow prices and cplex throws error
when accessing these attributes. Use ugly catch-all to work-around, to be fixed with better errors from optlang