### PR TITLE
feat: assert solver status optimal

### DIFF
--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -9,6 +9,7 @@ from builtins import object, super
 from warnings import warn
 
 from numpy import zeros, asarray, nan
+from optlang.interface import OPTIMAL
 from pandas import Series
 
 from cobra.util.solver import check_solver_status
@@ -96,7 +97,7 @@ class Solution(object):
 
     def __repr__(self):
         """String representation of the solution instance."""
-        if self.status != "optimal":
+        if self.status != OPTIMAL:
             return "<Solution {0:s} at 0x{1:x}>".format(self.status, id(self))
         return "<Solution {0:.3f} at 0x{1:x}>".format(self.objective_value,
                                                       id(self))

--- a/cobra/exceptions.py
+++ b/cobra/exceptions.py
@@ -5,37 +5,32 @@ from __future__ import absolute_import, print_function
 import optlang.interface
 
 
-class SolveError(Exception):
+class OptimizationError(Exception):
     def __init__(self, message):
-        super(SolveError, self).__init__(message)
+        super(OptimizationError, self).__init__(message)
 
 
-class Infeasible(SolveError):
+class Infeasible(OptimizationError):
     pass
 
 
-class Unbounded(SolveError):
+class Unbounded(OptimizationError):
     pass
 
 
-class FeasibleButNotOptimal(SolveError):
+class FeasibleButNotOptimal(OptimizationError):
     pass
 
 
-class UndefinedSolution(SolveError):
+class UndefinedSolution(OptimizationError):
     pass
 
 
-_OPTLANG_TO_EXCEPTIONS_DICT = dict((
+OPTLANG_TO_EXCEPTIONS_DICT = dict((
     (optlang.interface.INFEASIBLE, Infeasible),
     (optlang.interface.UNBOUNDED, Unbounded),
     (optlang.interface.FEASIBLE, FeasibleButNotOptimal),
     (optlang.interface.UNDEFINED, UndefinedSolution)))
-
-
-class OptimizationError(Exception):
-    def __init__(self, message):
-        super(OptimizationError, self).__init__(message)
 
 
 class DefunctError(Exception):

--- a/cobra/flux_analysis/phenotype_phase_plane.py
+++ b/cobra/flux_analysis/phenotype_phase_plane.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from itertools import product
 from multiprocessing import Pool
 import pandas as pd
+from optlang.interface import OPTIMAL
 
 from numpy import (
     nan, abs, arange, dtype, empty, int32, linspace, meshgrid, unravel_index,
@@ -409,7 +410,7 @@ def _envelope_for_points(model, reactions, grid, carbon_io):
                 for reaction, coordinate in zip(reactions, point):
                     reaction.bounds = (coordinate, coordinate)
                 model.solver.optimize()
-                if model.solver.status == 'optimal':
+                if model.solver.status == OPTIMAL:
                     for reaction, coordinate in zip(reactions, point):
                         results[reaction.id].append(coordinate)
                     results['direction'].append(direction)

--- a/cobra/flux_analysis/single_deletion.py
+++ b/cobra/flux_analysis/single_deletion.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import pandas
 from six import iteritems, string_types
+from optlang.interface import OPTIMAL
 
 import cobra.solvers as legacy_solvers
 import cobra.util.solver as solvers
@@ -110,7 +111,7 @@ def single_reaction_deletion_fba(cobra_model, reaction_list, solver=None,
                     status = m.solver.status
                     status_dict[reaction.id] = status
                     growth_rate_dict[reaction.id] = m.solver.objective.value \
-                        if status == "optimal" else 0.
+                        if status == OPTIMAL else 0.
     else:
         # This entire block can be removed once the legacy solvers are
         # deprecated
@@ -180,7 +181,7 @@ def single_reaction_deletion_moma(cobra_model, reaction_list, solver=None,
                     m.solver.optimize()
                     status = m.solver.status
                     status_dict[reaction.id] = status
-                    if status == "optimal":
+                    if status == OPTIMAL:
                         growth = m.variables.moma_old_objective.primal
                     else:
                         growth = 0.0
@@ -285,7 +286,7 @@ def single_gene_deletion_fba(cobra_model, gene_list, solver=None,
                     status = m.solver.status
                     status_dict[gene.id] = status
                     growth_rate_dict[gene.id] = m.solver.objective.value if \
-                        status == "optimal" else 0.
+                        status == OPTIMAL else 0.
     else:
         for gene in gene_list:
             old_bounds = {}

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -158,9 +158,8 @@ def _fva_optlang(model, reaction_list, fraction, loopless):
     prob = model.problem
     with model as m:
         m.solver.optimize()
-        if m.solver.status != "optimal":
-            raise ValueError("There is no optimal solution "
-                             "for the chosen objective!")
+        sutil.assert_optimal(m, message="There is no optimal solution for "
+                                        "the chosen objective!")
         # Add objective as a variable to the model than set to zero
         # This also uses the fraction to create the lower bound for the
         # old objective


### PR DESCRIPTION
The pattern of checking if solver.status != 'optimal' is not and then
raise appropriate exception started to appear in a number of places -
let's have a function for that.

Also tidy up the use of optlang string constants.