### PR TITLE
refactor: return KeyError from dictlist.get_by_any

### DIFF
--- a/cobra/core/dictlist.py
+++ b/cobra/core/dictlist.py
@@ -77,10 +77,7 @@ class DictList(list):
             if isinstance(item, int):
                 return self[item]
             elif isinstance(item, string_types):
-                try:
-                    return self.get_by_id(item)
-                except KeyError:
-                    raise ValueError('%s not a member' % item)
+                return self.get_by_id(item)
             elif item in self:
                 return item
             else:

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -826,7 +826,11 @@ class Model(Object):
         if isinstance(value, sympy.Basic):
             value = self.problem.Objective(value, sloppy=False)
         if not isinstance(value, (dict, optlang.interface.Objective)):
-            value = {rxn: 1 for rxn in self.reactions.get_by_any(value)}
+            try:
+                reactions = self.reactions.get_by_any(value)
+            except KeyError:
+                raise ValueError('invalid objective')
+            value = {rxn: 1 for rxn in reactions}
         set_objective(self, value, additive=False)
 
     def summary(self, threshold=1E-8, fva=None, floatfmt='.3g', **kwargs):

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -64,7 +64,7 @@ class TestDictList:
         obj, test_list = dict_list
         assert test_list.get_by_any(0) == [obj]
         assert test_list.get_by_any('test1') == [obj]
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             test_list.get_by_any('not-in-list')
         with pytest.raises(TypeError):
             test_list.get_by_any(1.1)


### PR DESCRIPTION
KeyError is more sensible when a missing key than ValueError. Let
property setter convert where appropriate