### PR TITLE
fix: find_blocked_reactions solver set bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ manylinux_builder/wheelhouse
 venv/
 .benchmarks/
 glpk-4.*
+/.testmondata

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -238,7 +238,7 @@ def find_blocked_reactions(model, reaction_list=None,
             reaction_list = [i for i in reaction_list
                              if abs(solution.x_dict[i.id]) < zero_cutoff]
         else:
-            model.solver = solver
+            model.solver = solver_interface
             model.solver.optimize()
             solution = get_solution(model, reactions=reaction_list)
             reaction_list = [rxn for rxn in reaction_list if

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -312,6 +312,10 @@ class TestCobraFluxAnalysis:
         with pytest.raises(Infeasible):
             flux_variability_analysis(infeasible_model)
 
+    def test_find_blocked_reactions_solver_none(self, model):
+        result = find_blocked_reactions(model, model.reactions[40:46])
+        assert result == ['FRUpts2']
+
     @pytest.mark.parametrize("solver", all_solvers)
     def test_find_blocked_reactions(self, model, solver):
         result = find_blocked_reactions(model, model.reactions[40:46],


### PR DESCRIPTION
Solver should be set to the determined `solver_interface`, not the
original argument.