### PR TITLE
Increase testing speed

### DIFF
--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -32,9 +32,14 @@ def data_directory():
     return data_dir
 
 
-@pytest.fixture(scope="function")
-def model():
+@pytest.fixture(scope="session")
+def small_model():
     return create_test_model("textbook")
+
+
+@pytest.fixture(scope="function")
+def model(small_model):
+    return small_model.copy()
 
 
 @pytest.fixture(scope="function")

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -553,8 +553,8 @@ class TestSolverBasedModel:
         new_mod = Model("new model")
         new_mod.add_reactions(model.reactions)
         new_mod.objective = model.objective
-        assert (str(new_mod.objective.expression) ==
-                str(model.objective.expression))
+        assert (set(str(x) for x in model.objective.expression.args) == set(
+            str(x) for x in new_mod.objective.expression.args))
         new_mod.solver.optimize()
         assert abs(new_mod.objective.value - 0.874) < 0.001
 


### PR DESCRIPTION
Use a session scoped fixture to load the textbook model and a function scoped fixture that creates copies from it. Locally this cuts down the time for all tests by 10 s.

Also had to fix on order dependent test.