### PR TITLE
make test_all work with Python 2.7

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -118,4 +118,5 @@ Then start python and type the following into the Python shell
     test_all()
 
 You should see some skipped tests and expected failures, and the
-function should return ``False``.
+function should return ``0``. If you see a value other than ``0`` please file
+an `issue report <CONTRIBUTING.rst>`_.

--- a/cobra/test/__init__.py
+++ b/cobra/test/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 from os.path import abspath, dirname, join
 
 from cobra.io import read_sbml_model
@@ -50,7 +53,7 @@ def test_all(args=None):
 
         return pytest.main(
             ['--pyargs', 'cobra', '--benchmark-skip', '-v', '-rs'] + args
-        ) != 0
+        )
     else:
         raise ImportError('missing package pytest and pytest_benchmark'
                           ' required for testing')

--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 
 import json
@@ -6,7 +7,7 @@ from os.path import join
 
 import pytest
 
-from . import create_test_model, data_dir
+from cobra.test import create_test_model, data_dir
 
 try:
     from cPickle import load as _load


### PR DESCRIPTION
Previously, the `small_model` fixture was not found.