### PR TITLE
feat: gapfilling with optlang (fix #383)

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -316,6 +316,10 @@ class Model(Object):
         except Exception:  # pragma: no cover
             new._solver = copy(self.solver)  # pragma: no cover
 
+        # it doesn't make sense to retain the context of a copied model so
+        # assign a new empty context
+        new._contexts = list()
+
         return new
 
     def add_metabolites(self, metabolite_list):

--- a/cobra/flux_analysis/__init__.py
+++ b/cobra/flux_analysis/__init__.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     scipy = None
 
-from cobra.flux_analysis.gapfilling import growMatch
+from cobra.flux_analysis.gapfilling import gapfill, growMatch
 from cobra.flux_analysis.loopless import (
     construct_loopless_model, loopless_solution, add_loopless)
 from cobra.flux_analysis.parsimonious import pfba

--- a/cobra/flux_analysis/gapfilling.py
+++ b/cobra/flux_analysis/gapfilling.py
@@ -2,8 +2,338 @@
 
 from __future__ import absolute_import
 
-from cobra.exceptions import DefunctError
+from sympy import Add
+from warnings import warn
+
+from optlang.interface import OPTIMAL
+from cobra.core import Model
+from cobra.util import assert_optimal, fix_objective_as_constraint
 
 
-def growMatch():
-    raise DefunctError('growMatch', 'modelseed', 'http://modelseed.org/')
+class GapFiller(object):
+    """Class for performing gap filling.
+
+    This class implements gap filling based on a mixed-integer approach,
+    very similar to that described in [1]_ and the 'no-growth but growth'
+    part of [2]_ but with minor adjustments. In short, we add indicator
+    variables for using the reactions in the universal model, z_i and then
+    solve problem
+
+    minimize \sum_i c_i * z_i
+    s.t. Sv = 0
+         v_o >= t
+         lb_i <= v_i <= ub_i
+         v_i = 0 if z_i = 0
+
+    where lb, ub are the upper, lower flux bounds for reaction i, c_i is a
+    cost parameter and the objective v_o is greater than the lower bound t.
+    The default costs are 1 for reactions from the universal model, 100 for
+    exchange (uptake) reactions added and 1 for added demand reactions.
+
+    Note that this is a mixed-integer linear program and as such will
+    expensive to solve for large models. Consider using alternatives [3]_
+    such as CORDA instead [4,5]_.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The model to perform gap filling on.
+    universal : cobra.Model
+        A universal model with reactions that can be used to complete the
+        model.
+    lower_bound : float
+        The minimally accepted flux for the objective in the filled model.
+    penalties : dict, None
+        A dictionary with keys being 'universal' (all reactions included in
+        the universal model), 'exchange' and 'demand' (all additionally
+        added exchange and demand reactions) for the three reaction types.
+        Can also have reaction identifiers for reaction specific costs.
+        Defaults are 1, 100 and 1 respectively.
+    integer_threshold : float
+        The threshold at which a value is considered non-zero (aka
+        integrality threshold). If gapfilled models fail to validate,
+        you may want to lower this value.
+    exchange_reactions : bool
+        Consider adding exchange (uptake) reactions for all metabolites
+        in the model.
+    demand_reactions : bool
+        Consider adding demand reactions for all metabolites.
+
+    References
+    ----------
+    .. [1] Reed, Jennifer L., Trina R. Patel, Keri H. Chen, Andrew R. Joyce,
+       Margaret K. Applebee, Christopher D. Herring, Olivia T. Bui, Eric M.
+       Knight, Stephen S. Fong, and Bernhard O. Palsson. “Systems Approach
+       to Refining Genome Annotation.” Proceedings of the National Academy
+       of Sciences 103, no. 46 (2006): 17480–17484.
+
+       [2] Kumar, Vinay Satish, and Costas D. Maranas. “GrowMatch: An
+       Automated Method for Reconciling In Silico/In Vivo Growth
+       Predictions.” Edited by Christos A. Ouzounis. PLoS Computational
+       Biology 5, no. 3 (March 13, 2009): e1000308.
+       doi:10.1371/journal.pcbi.1000308.
+
+       [3] http://opencobra.github.io/cobrapy/tags/gapfilling/
+
+       [4] Schultz, André, and Amina A. Qutub. “Reconstruction of
+       Tissue-Specific Metabolic Networks Using CORDA.” Edited by Costas D.
+       Maranas. PLOS Computational Biology 12, no. 3 (March 4, 2016):
+       e1004808. doi:10.1371/journal.pcbi.1004808.
+
+       [5] Diener, Christian https://github.com/cdiener/corda
+     """
+
+    def __init__(self, model, universal=None, lower_bound=0.05,
+                 penalties=None, exchange_reactions=False,
+                 demand_reactions=True, integer_threshold=1e-6):
+        self.original_model = model
+        self.lower_bound = lower_bound
+        self.model = model.copy()
+        # TODO: adjust once optlang supports integrality constraint settings
+        try:
+            self.model.solver.configuration._iocp.tol_int = integer_threshold
+        except AttributeError:
+            try:
+                self.model.solver.problem.parameters.mip.tolerances. \
+                    integrality.set(integer_threshold)
+            except AttributeError:
+                warn("tried to set integrality constraint, but don't know "
+                     "how to do that for "
+                     "solver {}".format(self.model.problem.__name__))
+        self.universal = universal.copy() if universal else Model('universal')
+        self.penalties = dict(universal=1, exchange=100, demand=1)
+        if penalties is not None:
+            self.penalties.update(penalties)
+        self.integer_threshold = integer_threshold
+        self.indicators = list()
+        self.costs = dict()
+        self.extend_model(exchange_reactions, demand_reactions)
+        fix_objective_as_constraint(self.model, bound=lower_bound)
+        self.add_switches_and_objective()
+
+    def extend_model(self, exchange_reactions=False, demand_reactions=True):
+        """Extend gapfilling model.
+
+        Add reactions from universal model and optionally exchange and
+        demand reactions for all metabolites in the model to perform
+        gapfilling on.
+
+        Parameters
+        ----------
+        exchange_reactions : bool
+            Consider adding exchange (uptake) reactions for all metabolites
+            in the model.
+        demand_reactions : bool
+            Consider adding demand reactions for all metabolites.
+        """
+        for rxn in self.universal.reactions:
+            rxn.gapfilling_type = 'universal'
+        for met in self.model.metabolites:
+            if exchange_reactions:
+                rxn = self.universal.add_boundary(
+                    met, type='exchange_smiley', lb=-1000, ub=0,
+                    reaction_id='EX_{}'.format(met.id))
+                rxn.gapfilling_type = 'exchange'
+            if demand_reactions:
+                rxn = self.universal.add_boundary(
+                    met, type='demand_smiley', lb=0, ub=1000,
+                    reaction_id='DM_{}'.format(met.id))
+                rxn.gapfilling_type = 'demand'
+
+        new_reactions = self.universal.reactions.query(
+            lambda reaction: reaction not in self.model.reactions
+        )
+        self.model.add_reactions(new_reactions)
+
+    def update_costs(self):
+        """Update the coefficients for the indicator variables in the objective.
+
+        Done incrementally so that second time the function is called,
+        active indicators in the current solutions gets higher cost than the
+        unused indicators.
+        """
+        for var in self.indicators:
+            if var not in self.costs:
+                self.costs[var] = var.cost
+            else:
+                if var._get_primal() > self.integer_threshold:
+                    self.costs[var] += var.cost
+        self.model.objective.set_linear_coefficients(self.costs)
+
+    def add_switches_and_objective(self):
+        """ Update gapfilling model with switches and the indicator objective.
+        """
+        constraints = list()
+        big_m = max(max(abs(b) for b in r.bounds)
+                    for r in self.model.reactions)
+        prob = self.model.problem
+        for rxn in self.model.reactions:
+            if not hasattr(rxn, 'gapfilling_type') or rxn.id.startswith('DM_'):
+                continue
+            indicator = prob.Variable(
+                name='indicator_{}'.format(rxn.id), lb=0, ub=1, type='binary')
+            if rxn.id in self.penalties:
+                indicator.cost = self.penalties[rxn.id]
+            else:
+                indicator.cost = self.penalties[rxn.gapfilling_type]
+            indicator.rxn_id = rxn.id
+            self.indicators.append(indicator)
+
+            # if z = 1 v_i is allowed non-zero
+            # v_i - Mz <= 0   and   v_i + Mz >= 0
+            constraint_lb = prob.Constraint(
+                rxn.flux_expression - big_m * indicator, ub=0,
+                name='constraint_lb_{}'.format(rxn.id), sloppy=True)
+            constraint_ub = prob.Constraint(
+                rxn.flux_expression + big_m * indicator, lb=0,
+                name='constraint_ub_{}'.format(rxn.id), sloppy=True)
+
+            constraints.extend([constraint_lb, constraint_ub])
+
+        self.model.add_cons_vars(self.indicators)
+        self.model.add_cons_vars(constraints, sloppy=True)
+        self.model.objective = prob.Objective(
+            Add(*self.indicators), direction='min')
+        self.update_costs()
+
+    def fill(self, iterations=1):
+        """Perform the gapfilling by iteratively solving the model, updating
+        the costs and recording the used reactions.
+
+
+        Parameters
+        ----------
+        iterations : int
+            The number of rounds of gapfilling to perform. For every
+            iteration, the penalty for every used reaction increases
+            linearly. This way, the algorithm is encouraged to search for
+            alternative solutions which may include previously used
+            reactions. I.e., with enough iterations pathways including 10
+            steps will eventually be reported even if the shortest pathway
+            is a single reaction.
+
+        Returns
+        -------
+        iterable
+            A list of lists where each element is a list reactions that were
+            used to gapfill the model.
+
+        Raises
+        ------
+        RuntimeError
+            If the model fails to be validated (i.e. the original model with
+            the proposed reactions added, still cannot get the required flux
+            through the objective).
+        """
+        used_reactions = list()
+        for i in range(iterations):
+            self.model.solver.optimize()
+            assert_optimal(self.model, 'gapfilling optimization failed')
+            solution = [self.model.reactions.get_by_id(ind.rxn_id)
+                        for ind in self.indicators if
+                        ind._get_primal() > self.integer_threshold]
+            if not self.validate(solution):
+                raise RuntimeError('failed to validate gapfilled model, '
+                                   'try lowering the integer_threshold')
+            used_reactions.append(solution)
+            self.update_costs()
+        return used_reactions
+
+    def validate(self, reactions):
+        with self.original_model as model:
+            model.add_reactions(reactions)
+            model.solver.optimize()
+            return (model.solver.status == OPTIMAL and
+                    model.solver.objective.value >= self.lower_bound)
+
+
+def gapfill(model, universal=None, lower_bound=0.05,
+            penalties=None, demand_reactions=True, exchange_reactions=False,
+            iterations=1):
+    """Perform gapfilling on a model.
+
+    See documentation for the class GapFiller.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The model to perform gap filling on.
+    universal : cobra.Model, None
+        A universal model with reactions that can be used to complete the
+        model. Only gapfill considering demand and exchange reactions if
+        left missing.
+    lower_bound : float
+        The minimally accepted flux for the objective in the filled model.
+    penalties : dict, None
+        A dictionary with keys being 'universal' (all reactions included in
+        the universal model), 'exchange' and 'demand' (all additionally
+        added exchange and demand reactions) for the three reaction types.
+        Can also have reaction identifiers for reaction specific costs.
+        Defaults are 1, 100 and 1 respectively.
+    iterations : int
+        The number of rounds of gapfilling to perform. For every iteration,
+        the penalty for every used reaction increases linearly. This way,
+        the algorithm is encouraged to search for alternative solutions
+        which may include previously used reactions. I.e., with enough
+        iterations pathways including 10 steps will eventually be reported
+        even if the shortest pathway is a single reaction.
+    exchange_reactions : bool
+        Consider adding exchange (uptake) reactions for all metabolites
+        in the model.
+    demand_reactions : bool
+        Consider adding demand reactions for all metabolites.
+
+    Returns
+    -------
+    iterable
+        list of lists with on set of reactions that completes the model per
+        requested iteration.
+
+    Examples
+    --------
+    >>> import cobra.test as ct
+    >>> from cobra import Model
+    >>> from cobra.flux_analysis import gapfill
+    >>> model = ct.create_test_model("salmonella")
+    >>> universal = Model('universal')
+    >>> universal.add_reactions(model.reactions.GF6PTA.copy())
+    >>> model.remove_reactions([model.reactions.GF6PTA])
+    >>> gapfill(model, universal)
+    """
+    gapfiller = GapFiller(model, universal=universal,
+                          lower_bound=lower_bound, penalties=penalties,
+                          demand_reactions=demand_reactions,
+                          exchange_reactions=exchange_reactions)
+    return gapfiller.fill(iterations=iterations)
+
+
+def growMatch(model, Universal, dm_rxns=False, ex_rxns=False,
+              penalties=None, iterations=1, **solver_parameters):
+    """runs (partial implementation of) growMatch. Legacy function,
+    to be removed in future version of cobrapy in favor of gapfill. """
+
+    warn('use gapfill instead', DeprecationWarning)
+    if 'solver' in dict(**solver_parameters):
+        raise ValueError('growMatch implementation for cobra legacy solvers'
+                         ' is defunct. Choose optlang solver with '
+                         'model.solver = "solver"')
+    return gapfill(model, universal=Universal,
+                   iterations=iterations, penalties=penalties,
+                   demand_reactions=dm_rxns, exchange_reactions=ex_rxns)
+
+
+def SMILEY(model, metabolite_id, Universal,
+           dm_rxns=False, ex_rxns=False, penalties=None, **solver_parameters):
+    """runs the SMILEY algorithm. Legacy function,
+    to be removed in future version of cobrapy in favor of gapfill. """
+
+    warn('use gapfill instead', DeprecationWarning)
+    if 'solver' in dict(**solver_parameters):
+        raise ValueError('SMILEY implementation for cobra legacy solvers'
+                         ' is defunct. Choose optlang solver with '
+                         'model.solver = "solver"')
+    with model:
+        metabolite = model.metabolites.get_by_id(metabolite_id)
+        model.objective = model.add_boundary(metabolite, type='demand')
+        return gapfill(model, universal=Universal, penalties=penalties,
+                       demand_reactions=dm_rxns, exchange_reactions=ex_rxns)

--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -48,7 +48,7 @@ def large_model():
     return create_test_model("ecoli")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def salmonella():
     return create_test_model("salmonella")
 

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -394,6 +394,62 @@ class TestCobraFluxAnalysis:
         assert feasible_status == OPTIMAL
         assert infeasible_status == INFEASIBLE
 
+    def test_gapfilling(self, salmonella):
+        m = Model()
+        m.add_metabolites([Metabolite(m_id) for m_id in ["a", "b", "c"]])
+        exa = Reaction("EX_a")
+        exa.add_metabolites({m.metabolites.a: 1})
+        b2c = Reaction("b2c")
+        b2c.add_metabolites({m.metabolites.b: -1, m.metabolites.c: 1})
+        dmc = Reaction("DM_c")
+        dmc.add_metabolites({m.metabolites.c: -1})
+        m.add_reactions([exa, b2c, dmc])
+        m.objective = 'DM_c'
+
+        universal = Model()
+        a2b = Reaction("a2b")
+        a2d = Reaction("a2d")
+        universal.add_reactions([a2b, a2d])
+        a2b.build_reaction_from_string("a --> b", verbose=False)
+        a2d.build_reaction_from_string("a --> d", verbose=False)
+
+        # # GrowMatch
+        # result = gapfilling.growMatch(m, universal)[0]
+        result = gapfilling.gapfill(m, universal)[0]
+        assert len(result) == 1
+        assert result[0].id == "a2b"
+
+        # # SMILEY
+        # result = gapfilling.SMILEY(m, "b", universal)[0]
+        with m:
+            m.objective = m.add_boundary(m.metabolites.b, type='demand')
+            result = gapfilling.gapfill(m, universal)[0]
+            assert len(result) == 1
+            assert result[0].id == "a2b"
+
+        # # 2 rounds of GrowMatch with exchange reactions
+        # result = gapfilling.growMatch(m, None, ex_rxns=True, iterations=2)
+        result = gapfilling.gapfill(m, None, exchange_reactions=True,
+                                    iterations=2)
+        assert len(result) == 2
+        assert len(result[0]) == 1
+        assert len(result[1]) == 1
+        assert {i[0].id for i in result} == {"EX_b", "EX_c"}
+
+        # somewhat bigger model
+        universal = Model("universal_reactions")
+        with salmonella as model:
+            for i in [i.id for i in model.metabolites.f6p_c.reactions]:
+                reaction = model.reactions.get_by_id(i)
+                universal.add_reactions([reaction.copy()])
+                model.remove_reactions([reaction])
+            gf = gapfilling.GapFiller(model, universal,
+                                      penalties={'TKT2': 1e3},
+                                      demand_reactions=False)
+            solution = gf.fill()
+            assert 'TKT2' not in {r.id for r in solution[0]}
+            assert gf.validate(solution[0])
+
     def test_phenotype_phase_plane_benchmark(self, model, benchmark):
         benchmark(calculate_phenotype_phase_plane,
                   model, "EX_glc__D_e", "EX_o2_e",

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -634,6 +634,12 @@ class TestCobraModel:
         model_copy.remove_reactions(model_copy.reactions[0:5])
         assert old_reaction_count == len(model.reactions)
         assert len(model.reactions) != len(model_copy.reactions)
+        # copying a model should not copy its context
+        with model:
+            model.remove_reactions([model.reactions.ACALD])
+            cp_model = model.copy()
+            assert len(cp_model._contexts) == 0
+        assert 'ACALD' not in cp_model.reactions
 
     def test_deepcopy_benchmark(self, model, benchmark):
         benchmark(deepcopy, model)

--- a/cobra/util/util.py
+++ b/cobra/util/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, print_function
 
+import sympy
 import logging
 
 import cobra

--- a/documentation_builder/gapfilling.ipynb
+++ b/documentation_builder/gapfilling.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Gapfillling\n",
+    "\n",
+    "Model gap filling is the task of figuring out which reactions have to be added to a model to make it feasible. Several such algorithms have been reported e.g. [Kumar et al. 2009](http://dx.doi.org/10.1371/journal.pcbi.1000308) and [Reed et al. 2006](http://www.pnas.org/content/103/46/17480.short). Cobrapy has a gap filling implementation that is very similar to that of Reed et al. where we use a mixed-integer linear program to figure out the smallest number of reactions that need to be added for a user-defined collection of reactions, i.e. a universal model. Briefly, the problem that we try to solve is\n",
+    "$$\\textrm{minimize}: \\sum_i c_i * z_i$$\n",
+    "subject to\n",
+    "$$Sv = 0$$\n",
+    "$$v^\\star \\geq t$$\n",
+    "$$l_i\\leq v_i \\leq u_i$$\n",
+    "$$v_i = 0 \\textrm{ if } z_i = 0$$\n",
+    "Where $l_i$, $u_i$ are lower and upper bounds for reaction $i$ and $z_i$ is an indicator variable that is zero if the reaction is not used and otherwise 1, $c_i$ is a user-defined cost associated with using the $i$th reaction, $v^\\star$ is the flux of the objective and $t$ a lower bound for that objective. To demonstrate, let's take a model and remove some essential reactions from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import cobra.test\n",
+    "from cobra.flux_analysis import gapfill\n",
+    "model = cobra.test.create_test_model(\"salmonella\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "In this model D-Fructose-6-phosphate is an essential metabolite. We will remove all the reactions using it, and at them to a separate model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "universal = cobra.Model(\"universal_reactions\")\n",
+    "for i in [i.id for i in model.metabolites.f6p_c.reactions]:\n",
+    "    reaction = model.reactions.get_by_id(i)\n",
+    "    universal.add_reaction(reaction.copy())\n",
+    "    model.remove_reactions([reaction])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Now, because of these gaps, the model won't grow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.optimize().objective_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "We will use can use the model's original objective, growth, to figure out which of the removed reactions are required for the model be feasible again. This is very similar to making the 'no-growth but growth (NGG)' predictions of [Kumar et al. 2009](http://dx.doi.org/10.1371/journal.pcbi.1000308)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GF6PTA\n",
+      "F6PP\n",
+      "TKT2\n",
+      "FBP\n",
+      "MAN6PI\n"
+     ]
+    }
+   ],
+   "source": [
+    "solution = gapfill(model, universal, demand_reactions=False)\n",
+    "for reaction in solution[0]:\n",
+    "    print(reaction.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "We can obtain multiple possible reaction sets by having the algorithm go through multiple iterations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---- Run 1 ----\n",
+      "GF6PTA\n",
+      "F6PP\n",
+      "TKT2\n",
+      "FBP\n",
+      "MAN6PI\n",
+      "---- Run 2 ----\n",
+      "GF6PTA\n",
+      "TALA\n",
+      "PGI\n",
+      "F6PA\n",
+      "MAN6PI\n",
+      "---- Run 3 ----\n",
+      "GF6PTA\n",
+      "F6PP\n",
+      "TKT2\n",
+      "FBP\n",
+      "MAN6PI\n",
+      "---- Run 4 ----\n",
+      "GF6PTA\n",
+      "TALA\n",
+      "PGI\n",
+      "F6PA\n",
+      "MAN6PI\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = gapfill(model, universal, demand_reactions=False, iterations=4)\n",
+    "for i, entries in enumerate(result):\n",
+    "    print(\"---- Run %d ----\" % (i + 1))\n",
+    "    for e in entries:\n",
+    "        print(e.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "We can also instead of using the original objective, specify a given metabolite that we want the model to be able to produce."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FBP\n"
+     ]
+    }
+   ],
+   "source": [
+    "with model:\n",
+    "    model.objective = model.add_boundary(model.metabolites.f6p_c, type='demand')\n",
+    "    solution = gapfill(model, universal)\n",
+    "    for reaction in solution[0]:\n",
+    "        print(reaction.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Finally, note that using mixed-integer linear programming is computationally quite expensive and for larger models you may want to consider alternative [gap filling methods](http://opencobra.github.io/cobrapy/tags/gapfilling/) and [reconstruction methods](http://opencobra.github.io/cobrapy/tags/reconstruction/)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -19,6 +19,7 @@ be viewed at `nbviewer
     phenotype_phase_plane
     sampling
     loopless
+    gapfilling
     solvers
     constraints_objectives
     pymatbridge

--- a/release-notes/0.6.0.md
+++ b/release-notes/0.6.0.md
@@ -137,6 +137,12 @@ The model class has new method `model.add_boundary` which can be used
 to add sink, exchange or demand reactions with the appropriate bounds
 and prefixes (DM, SK or EX).
 
+### Gapfilling
+
+The `SMILEY` and `growMatch` implementations were refactored to a
+single new function `cobra.flux_analysis.gapfilling.gapfill` which
+handles both use-cases.
+
 ## Fixes
 
 - Handle multiple IDs in Matlab models
@@ -178,8 +184,6 @@ the next major cobrapy release.
 - optknock was completely removed, users are advised to use cameo for
   this functionality
 - dual_problem was removed
-- gapfilling algorithms were removed without replacement, to be
-  re-introduced in a different package
 - `cobra.topology` was removed, possibly to be reintroduced in a
   different package
 - flux_variability_analysis results must be transformed to have them
@@ -192,3 +196,5 @@ the next major cobrapy release.
 - objective coefficients of reactions can now only be set once the
   reaction is attached to a model.
 - `Reaction.{x,y}`, `Metabolite.y` are defunct for legacy solvers.
+- `SMILEY` and `growMatch` algorithms are defunct in combination with
+  the legacy solvers.


### PR DESCRIPTION
Suggested re-factor of the gapfilling algorithms. Is the api okay? The reactions are no longer split in forward and reverse, does that make it less useful?

~~Also, sadly this implementation still has a serious bug that I searched too long for and would be happy for hints: the old tests pass but the gapfilling.ipynb doesn't since for some reason the solver ignores the switch constraints allowing flux through reactions that aren't switched on.~~
 