### PR TITLE
refactor: remove `FrozenDict` [fix #502]

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -20,7 +20,6 @@ from cobra.core.object import Object
 from cobra.util.context import resettable, get_context
 from cobra.util.solver import (
     linear_reaction_coefficients, set_objective, check_solver_status)
-from cobra.util.util import FrozenDict
 
 # precompiled regular expressions
 # Matches and/or in a gene reaction rule
@@ -375,7 +374,7 @@ class Reaction(Object):
     # read-only
     @property
     def metabolites(self):
-        return FrozenDict(self._metabolites)
+        return self._metabolites.copy()
 
     @property
     def genes(self):

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import re
 from copy import copy, deepcopy
@@ -9,17 +9,6 @@ import pytest
 from six.moves import range
 
 from cobra import DictList, Object
-from cobra.util import FrozenDict
-
-
-@pytest.fixture(scope="session")
-def seed():
-    return 1234
-
-
-@pytest.fixture(scope="session")
-def frozen_dict():
-    return FrozenDict({"A": 1, "B": 2, "C": 3, "D": 4, "E": [2, 3, 4, 5]})
 
 
 @pytest.fixture(scope="function")
@@ -304,21 +293,3 @@ class TestDictList:
         # should only add 1 element
         assert len(test_list) == 2
         assert test_list.index("test2") == 1
-
-
-class FrozenDictTestCase:
-    def test_frozen_attributes(self, frozen_dict):
-        with pytest.raises(AttributeError):
-            frozen_dict.popitem()
-        with pytest.raises(AttributeError):
-            frozen_dict.pop("A")
-        with pytest.raises(AttributeError):
-            frozen_dict.__setitem__("C", 1)
-        with pytest.raises(AttributeError):
-            frozen_dict.setdefault("K")
-        with pytest.raises(AttributeError):
-            frozen_dict.__delitem__("A")
-        with pytest.raises(AttributeError):
-            frozen_dict.update()
-
-        assert hasattr(frozen_dict, "__hash__")

--- a/cobra/util/util.py
+++ b/cobra/util/util.py
@@ -2,50 +2,6 @@
 
 from __future__ import absolute_import
 
-import sympy
-import logging
-import operator
-from collections import Mapping
-
-from six import iteritems
-
-
-class FrozenDict(Mapping):
-    def __init__(self, *args, **kwargs):
-        super(FrozenDict, self).__init__()
-        self.__dict = dict(*args, **kwargs)
-        self.__hash = None
-        self.__items = None
-
-    def __getitem__(self, item):
-        return self.__dict[item]
-
-    def __iter__(self):
-        return iter(self.__dict)
-
-    def __len__(self):
-        return len(self.__dict)
-
-    def __hash__(self):
-        if self.__items is None:
-            self.__items = sorted(iteritems(self.__dict))
-        if self.__hash is None:
-            self.__hash = hash(self.__items)
-        return self.__hash
-
-    def __repr__(self):
-        if self.__items is None:
-            self.__items = sorted(iteritems(self.__dict))
-        return '{}({!r})'.format(self.__class__.__name__, self.__items)
-
-    def copy(self, *args, **kwargs):
-        new_dict = self.__dict.copy()
-
-        if args or kwargs:
-            new_dict.update(dict(*args, **kwargs))
-
-        return self.__class__(new_dict)
-
 
 class AutoVivification(dict):
     """Implementation of perl's autovivification feature. Checkout


### PR DESCRIPTION
Return a copy of the metabolites dict instead of a read-only object.