### PR TITLE
reset variable cache

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -608,6 +608,7 @@ class Model(Object):
                 reaction._model = None
 
                 if context:
+                    context(reaction._reset_var_cache)
                     context(partial(setattr, reaction, '_model', self))
                     context(partial(self.reactions.add, reaction))
 

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -509,7 +509,8 @@ class TestReaction:
         assert ("PGI" in model.reactions)
         assert (pgi.id in model.variables)
         assert (pgi.reverse_id in model.variables)
-        pgi.forward_variable
+        assert pgi._forward_variable.problem is model.solver
+        
 
     def test_delete(self, model):
         pgi = model.reactions.PGI

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -509,8 +509,7 @@ class TestReaction:
         assert ("PGI" in model.reactions)
         assert (pgi.id in model.variables)
         assert (pgi.reverse_id in model.variables)
-        assert pgi._forward_variable.problem is model.solver
-        
+        assert pgi.forward_variable.problem is model.solver
 
     def test_delete(self, model):
         pgi = model.reactions.PGI

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -498,12 +498,18 @@ class TestReaction:
     #            ).as_coefficients_dict()
 
     def test_remove_from_model(self, model):
-        pgi = model.reactions.PGI
-        pgi.remove_from_model()
-        assert pgi.model is None
-        assert not ("PGI" in model.reactions)
-        assert not (pgi.id in model.variables)
-        assert not (pgi.reverse_id in model.variables)
+        with model:
+            pgi = model.reactions.PGI
+            pgi.remove_from_model()
+            assert pgi.model is None
+            assert not ("PGI" in model.reactions)
+            assert not (pgi.id in model.variables)
+            assert not (pgi.reverse_id in model.variables)
+
+        assert ("PGI" in model.reactions)
+        assert (pgi.id in model.variables)
+        assert (pgi.reverse_id in model.variables)
+        pgi.forward_variable
 
     def test_delete(self, model):
         pgi = model.reactions.PGI


### PR DESCRIPTION
This fixes #506, explicitly adds in a call to `reaction._reset_var_cache` when adding back in the reaction.