### PR TITLE
Clarify add_metabolites behavior with string keys

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -710,8 +710,9 @@ class Reaction(Object):
         ----------
         metabolites_to_add : dict
             Dictionary with metabolite objects or metabolite identifiers as
-            keys and coefficients as values.
-
+            keys and coefficients as values. If keys are strings (name of a
+            metabolite) the reaction must already be part of a model and a
+            metabolite with the given name must exist in the model.
 
         combine : bool
             Describes behavior a metabolite already exists in the reaction.
@@ -752,7 +753,10 @@ class Reaction(Object):
                             raise e
                 elif isinstance(metabolite, string_types):
                     # if we want to handle creation, this should be changed
-                    raise ValueError("reaction '%s' does not belong to a model"
+                    raise ValueError("Reaction '%s' does not belong to a "
+                                     "model. Either add the reaction to a "
+                                     "model or use Metabolite objects instead "
+                                     "of strings as keys."
                                      % self.id)
                 self._metabolites[metabolite] = coefficient
                 # make the metabolite aware that it is involved in this

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -324,7 +324,7 @@ class TestCobraModel:
             model.add_reaction(dummy_reaction)
             if not getattr(model, 'solver', None):
                 solver_dict[solver].create_problem(model)
-            model.remove_reactions([dummy_reaction], delete=False)
+            model.remove_reactions([dummy_reaction])
 
         benchmark(benchmark_add_reaction)
 


### PR DESCRIPTION
Based on an E-mail I received.

**Behavior:** using string keys in `add_metabolites` for a reaction that has not yet been added to a model

**Problem:** Error is not very informative and docstring does not mention the limitations for string keys.

**Fix:** Error message that suggests solution and mentioning the limitation in the docstring.

Also fixes a small problem in the add_reaction benchmark that still used the the `delete` argument in `remove_from_model`.   