### PR TITLE
Fix/model add etc

### DIFF
--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -16,6 +16,7 @@ except ImportError:
 
 import cobra.util.solver as sutil
 from cobra.solvers import solver_dict
+from cobra import Model, Metabolite, Reaction
 
 
 def pytest_addoption(parser):
@@ -60,6 +61,19 @@ def solved_model(data_directory):
               "rb") as infile:
         solution = _load(infile)
     return solution, model
+
+
+@pytest.fixture(scope="session")
+def tiny_toy_model():
+    tiny = Model("Toy Model")
+    m1 = Metabolite("M1")
+    d1 = Reaction("ex1")
+    d1.add_metabolites({m1: -1})
+    d1.upper_bound = 0
+    d1.lower_bound = -1000
+    tiny.add_reactions([d1])
+    tiny.objective = 'ex1'
+    return tiny
 
 
 @pytest.fixture(scope="function")

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -25,18 +25,6 @@ solver_trials = ['glpk',
                                     reason='no cplex')]
 
 
-@pytest.fixture(scope="function")
-def tiny_toy_model():
-    model = Model("Toy Model")
-    m1 = Metabolite("M1")
-    d1 = Reaction("ex1")
-    d1.add_metabolites({m1: -1})
-    d1.upper_bound = 0
-    d1.lower_bound = -1000
-    model.add_reactions([d1])
-    return model
-
-
 @pytest.fixture(scope="function", params=solver_trials)
 def solved_model(request, model):
     model.solver = request.param

--- a/release-notes/0.6.2.md
+++ b/release-notes/0.6.2.md
@@ -7,12 +7,19 @@
   with the concept of being able to later revert the change.
   [#506](https://github.com/opencobra/cobrapy/issues/506),
   [#508](https://github.com/opencobra/cobrapy/pull/508).
+- Adding two models (`modela + modelb`) again results in a model with
+  the objective set to the sum of the two models objectives
+  [#505](https://github.com/opencobra/cobrapy/issues/505).
 - When adding reactions to a model, the reactions with identifiers
   identical to those in the model are
   ignored. [#511](https://github.com/opencobra/cobrapy/issues/511)
 
+## New features
+- `model.merge` can be used to merge two models, more flexibly than
+  the overloaded + and += operators.
 
 ## Deprecated features
 
-- `reaction.delete` has been deprecated in favor of
-  `reaction.remove_from_model`
+- `reaction.delete` has been deprecated in favor of `reaction.remove_from_model`
+- overloaded `+` and `+=` for `cobra.Model` are deprecated in favor of
+  `model.merge`

--- a/release-notes/0.6.2.md
+++ b/release-notes/0.6.2.md
@@ -7,6 +7,9 @@
   with the concept of being able to later revert the change.
   [#506](https://github.com/opencobra/cobrapy/issues/506),
   [#508](https://github.com/opencobra/cobrapy/pull/508).
+- When adding reactions to a model, the reactions with identifiers
+  identical to those in the model are
+  ignored. [#511](https://github.com/opencobra/cobrapy/issues/511)
 
 
 ## Deprecated features

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ tag = True
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
-	((?P<release>[ab])(?P<num>\d+))?
+	(?P<release>[a]*)(?P<num>\d*)
 serialize = 
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
@@ -13,11 +13,10 @@ tag_name = {new_version}
 
 [bumpversion:part:release]
 optional_value = placeholder
-first_value = a
+first_value = placeholder
 values = 
-	a
-	b
 	placeholder
+    a
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"


### PR DESCRIPTION
- chore in setup.cfg for parsing versions
- make adding existing reactions just ignore them instead of ValueError #511 
- make objective the sum of the two models objectives when adding and introduce new `model.merge` #505. Should all reactions be prefixed here instead of only the pre-existing?

I go on vacation a couple of weeks now, welcome to finish the PR 😛  😎  🌞  

