### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     version="0.6.1",
     packages=find_packages(),
     setup_requires=setup_requirements,
-    install_requires=["future", "swiglpk", "optlang>=1.1.5", "ruamel.yaml",
+    install_requires=["future", "swiglpk", "optlang>=1.1.5", "ruamel.yaml<0.15",
                       "pandas>=0.17.0", "numpy>=1.6", "tabulate"],
     tests_require=["jsonschema > 2.5", "pytest", "pytest-benchmark"],
     extras_require=extras,


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.
