### PR TITLE
[sampling] use shared memory for all large arrays

### DIFF
--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -85,7 +85,7 @@ def shared_np_array(shape, data=None):
         if not same:
             raise ValueError("`data` must have the same shape"
                              "as the created array.")
-        np_array = data[:]
+        np_array[:] = data
 
     return np_array
 

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -72,8 +72,8 @@ def shared_np_array(shape, data=None):
     data : numpy.array
         Data to copy to the new array. Has to have the same shape.
     """
-    N = np.prod(shape)
-    array = Array(ctypes.c_double, int(N))
+    size = np.prod(shape)
+    array = Array(ctypes.c_double, int(size))
     np_array = np.frombuffer(array.get_obj())
     np_array.reshape(shape)
 
@@ -229,14 +229,9 @@ class HRSampler(object):
         """Generate the warmup points for the sampler.
 
         Generates warmup points by setting each flux as the sole objective
-        and minimizing/maximizing it.
-
-        Parameters
-        ----------
-        solver : str or cobra solver interface, optional
-            The solver used for the arising LP problems.
-        **solver_args
-            Additional arguments passed to the solver.
+        and minimizing/maximizing it. Also caches the projection of the
+        warmup points into the nullspace for non-homogeneous problems (only
+        if necessary).
         """
         self.n_warmup = 0
         idx = np.hstack([self.fwd_idx, self.rev_idx])

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -75,7 +75,7 @@ def shared_np_array(shape, data=None):
     size = np.prod(shape)
     array = Array(ctypes.c_double, int(size))
     np_array = np.frombuffer(array.get_obj())
-    np_array.reshape(shape)
+    np_array = np_array.reshape(shape)
 
     if data is not None:
         if len(shape) != len(data.shape):


### PR DESCRIPTION
Sorry for the delay. Took me quite a while to figure out how to manage class attributes in shared memory with `multiprocessing.Pool`. This PR moves all of those to shared memory so additional process in the OptGPSampler do not duplicate those anymore. This has the following effects on `OptGPSampler`:

1. constant memory use independent of the number of processes
2. a bit faster `sample` since the initial memory copy is gone
3. now allows sampling of models with arbitrary size in memory (as long as you have enough RAM for the built matrices), no more 4GB limit due to `pickle` constraints
4. runs much smoother in jupyter now, no idea why though

Also added a section to the docstrings giving the rough order of memory usage.

[Benchmark and convergence analysis] (https://github.com/cdiener/cobra-docker/blob/master/sampling_benchmark.ipynb)

Fixes #516.