### PR TITLE
Add some pydocstyle options to `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]*)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 tag_name = {new_version}
@@ -14,7 +14,7 @@ tag_name = {new_version}
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
     a
 
@@ -35,6 +35,8 @@ exclude = __init__.py,docs
 
 [pydocstyle]
 match_dir = cobra
+convention = numpy
+match = (?!test_).*\.py
 
 [aliases]
 test = pytest
@@ -49,4 +51,3 @@ line_length = 79
 multi_line_output = 4
 known_third_party = future,six
 known_first_party = cobra
-


### PR DESCRIPTION
Adds some options for pydocstyle that:

1. use the numpy docstyle standard
2. ignore tests since those do not require docstrings