### PR TITLE
fix: production envelope with unspecified c-source

### DIFF
--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -699,10 +699,15 @@ class TestProductionEnvelope:
         df = production_envelope(model, ["EX_o2_e"])
         assert abs(sum(df.flux) - 9.342) < 0.001
 
+    def test_envelope_multi_reaction_objective(self, model):
+        obj = {model.reactions.EX_ac_e: 1,
+               model.reactions.EX_co2_e: 1}
+        with pytest.raises(ValueError):
+            production_envelope(model, "EX_o2_e", obj)
+
     def test_envelope_two(self, model):
         df = production_envelope(model, ["EX_glc__D_e", "EX_o2_e"],
-                                 objective="EX_ac_e",
-                                 c_source="EX_glc__D_e")
+                                 objective="EX_ac_e")
         assert abs(numpy.sum(df.carbon_yield) - 83.579) < 0.001
         assert abs(numpy.sum(df.flux) - 1737.466) < 0.001
         assert abs(numpy.sum(df.mass_yield) - 82.176) < 0.001

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -6,6 +6,10 @@
   [was broken](https://github.com/opencobra/cobrapy/issues/537)
   following the release of 0.6.0 and has now been fixed (and now with
   unit tests).
+- `production_envelope` failed when model C-source was formulated as
+  -> x instead of x <-. Fixed added option to guess the C-source by
+  taking the medium reaction with the highest input C flux.
+- `model_to_pymatbridge` needs scipy and that's correctly handled now.
 
 ## New features
 - `flux_variability_analysis` now has the `pfba_factor` parameter


### PR DESCRIPTION
Fix bug in production_envelopee occurring for models where the C-source
was formulated as -> x instead of x <-

Also support guessing the C-source reaction.