### PR TITLE
make it explicit that `model_to_pymatbridge` needs scipy

### DIFF
--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -283,6 +283,8 @@ def model_to_pymatbridge(model, variable_name="model", matlab=None):
         used in IPython magics.
 
     """
+    if scipy_sparse is None:
+        raise ImportError("`model_to_pymatbridge` requires scipy!")
     if matlab is None:  # assumed to be running an IPython magic
         from IPython import get_ipython
         matlab = get_ipython().magics_manager.registry["MatlabMagics"].Matlab


### PR DESCRIPTION
Throws an error if one attempts to use `model_to_pymatbridge` without having scipy installed. Gave a cryptic error before.

Fixes #517.