### PR TITLE
Fix esolver by changing sol path in esolver command

### DIFF
--- a/cobra/solvers/esolver.py
+++ b/cobra/solvers/esolver.py
@@ -75,7 +75,7 @@ class Esolver(cglpk.GLP):
         with NamedTemporaryFile(suffix=".sol") as f:
             self.solution_filepath = f.name
         command = [ESOLVER_COMMAND, "-b", self.basis_filepath,
-                   "-O", self.solution_filepath[:-4]]
+                   "-O", self.solution_filepath]
         if existing_basis is not None and isfile(existing_basis):
             command.extend(["-B", existing_basis])
         command.extend(["-L", lp_filepath])


### PR DESCRIPTION
This small fix was necessary for me to solve with esolver in cobrapy 0.6.2.

Using esolver version: QSopt_ex 2.5.10.3.