### PR TITLE
feat: add html representations

### DIFF
--- a/cobra/core/gene.py
+++ b/cobra/core/gene.py
@@ -268,3 +268,25 @@ class Gene(Species):
                 the_reaction.lower_bound = 0
                 the_reaction.upper_bound = 0
         self._reaction.clear()
+
+    def _repr_html_(self):
+        return """
+        <table>
+            <tr>
+                <td><strong>Gene identifier</strong></td><td>{id}</td>
+            </tr><tr>
+                <td><strong>Name</strong></td><td>{name}</td>
+            </tr><tr>
+                <td><strong>Memory address</strong></td>
+                <td>{address}</td>
+            </tr><tr>
+                <td><strong>Functional</strong></td><td>{functional}</td>
+            </tr><tr>
+                <td><strong>In {n_reactions} reaction(s)</strong></td><td>
+                    {reactions}</td>
+            </tr>
+        </table>""".format(id=self.id, name=self.name,
+                           functional=self.functional,
+                           address='0x0%x' % id(self),
+                           n_reactions=len(self.reactions),
+                           reactions=', '.join(r.id for r in self.reactions))

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -229,3 +229,27 @@ class Metabolite(Species):
         from cobra.flux_analysis.summary import metabolite_summary
         return metabolite_summary(self, threshold=threshold, fva=fva,
                                   floatfmt=floatfmt, **kwargs)
+
+    def _repr_html_(self):
+        return """
+        <table>
+            <tr>
+                <td><strong>Metabolite identifier</strong></td><td>{id}</td>
+            </tr><tr>
+                <td><strong>Name</strong></td><td>{name}</td>
+            </tr><tr>
+                <td><strong>Memory address</strong></td>
+                <td>{address}</td>
+            </tr><tr>
+                <td><strong>Formula</strong></td><td>{formula}</td>
+            </tr><tr>
+                <td><strong>Compartment</strong></td><td>{compartment}</td>
+            </tr><tr>
+                <td><strong>In {n_reactions} reaction(s)</strong></td><td>
+                    {reactions}</td>
+            </tr>
+        </table>""".format(id=self.id, name=self.name, formula=self.formula,
+                           address='0x0%x' % id(self),
+                           compartment=self.compartment,
+                           n_reactions=len(self.reactions),
+                           reactions=', '.join(r.id for r in self.reactions))

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -26,7 +26,6 @@ from cobra.util.solver import (
     check_solver_status, assert_optimal)
 from cobra.util.util import AutoVivification
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -1020,3 +1019,35 @@ class Model(Object):
             sum=self.objective.expression + right.objective.expression
         )[objective]
         return new_model
+
+    def _repr_html_(self):
+        return """
+        <table>
+            <tr>
+                <td><strong>Name</strong></td>
+                <td>{name}</td>
+            </tr><tr>
+                <td><strong>Memory address</strong></td>
+                <td>{address}</td>
+            </tr><tr>
+                <td><strong>Number of metabolites</strong></td>
+                <td>{num_metabolites}</td>
+            </tr><tr>
+                <td><strong>Number of reactions</strong></td>
+                <td>{num_reactions}</td>
+            </tr><tr>
+                <td><strong>Objective expression</strong></td>
+                <td>{objective}</td>
+            </tr><tr>
+                <td><strong>Compartments</strong></td>
+                <td>{compartments}</td>
+            </tr>
+          </table>""".format(
+            name=self.id,
+            address='0x0%x' % id(self),
+            num_metabolites=len(self.metabolites),
+            num_reactions=len(self.reactions),
+            objective=str(self.objective.expression),
+            compartments=", ".join(
+                v if v else k for k, v in iteritems(self.compartments)
+            ))

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -1036,6 +1036,37 @@ class Reaction(Object):
                     met = Metabolite(met_id)
                 self.add_metabolites({met: num})
 
+    def _repr_html_(self):
+        return """
+        <table>
+            <tr>
+                <td><strong>Reaction identifier</strong></td><td>{id}</td>
+            </tr><tr>
+                <td><strong>Name</strong></td><td>{name}</td>
+            </tr><tr>
+                <td><strong>Memory address</strong></td>
+                <td>{address}</td>
+            </tr><tr>
+                <td><strong>Stoichiometry</strong></td>
+                <td>
+                    <p style='text-align:right'>{stoich_id}</p>
+                    <p style='text-align:right'>{stoich_name}</p>
+                </td>
+            </tr><tr>
+                <td><strong>GPR</strong></td><td>{gpr}</td>
+            </tr><tr>
+                <td><strong>Lower bound</strong></td><td>{lb}</td>
+            </tr><tr>
+                <td><strong>Upper bound</strong></td><td>{ub}</td>
+            </tr>
+        </table>
+        """.format(id=self.id, name=self.name,
+                   address='0x0%x' % id(self),
+                   stoich_id=self.build_reaction_string(),
+                   stoich_name=self.build_reaction_string(True),
+                   gpr=self.gene_reaction_rule,
+                   lb=self.lower_bound, ub=self.upper_bound)
+
 
 def separate_forward_and_reverse_bounds(lower_bound, upper_bound):
     """Split a given (lower_bound, upper_bound) interval into a negative

--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -102,6 +102,16 @@ class Solution(object):
         return "<Solution {0:.3f} at 0x{1:x}>".format(self.objective_value,
                                                       id(self))
 
+    def _repr_html_(self):
+        if self.status == OPTIMAL:
+            html = ('<strong><em>Optimal</em> solution with objective value '
+                    '{:.3f}</strong><br>{}'
+                    .format(self.objective_value,
+                            self.to_frame()._repr_html_()))
+        else:
+            html = '<strong><em>{}</em> solution</strong>'.format(self.status)
+        return html
+
     def __dir__(self):
         """Hide deprecated attributes and methods from the public interface."""
         fields = sorted(dir(type(self)) + list(self.__dict__))

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -289,6 +289,9 @@ class TestReactions:
         assert new._model is not model
         assert len(new.metabolites) == 3
 
+    def test_repr_html_(self, model):
+        assert '<table>' in model.reactions[0]._repr_html_()
+
 
 class TestCobraMetabolites:
     def test_metabolite_formula(self):
@@ -305,6 +308,14 @@ class TestCobraMetabolites:
         assert met.elements == {}
         met.elements = orig_elements
         assert met.formula == orig_formula
+
+    def test_repr_html_(self, model):
+        assert '<table>' in model.metabolites.h2o_c._repr_html_()
+
+
+class TestCobraGenes:
+    def test_repr_html_(self, model):
+        assert '<table>' in model.genes[0]._repr_html_()
 
 
 class TestCobraModel:
@@ -867,6 +878,9 @@ class TestCobraModel:
                 assert model.reactions[0].bounds == bounds2
             assert model.reactions[0].bounds == bounds1
         assert model.reactions[0].bounds == bounds0
+
+    def test_repr_html_(self, model):
+        assert '<table>' in model._repr_html_()
 
 
 class TestStoichiometricMatrix:

--- a/documentation_builder/faq.ipynb
+++ b/documentation_builder/faq.ipynb
@@ -2,80 +2,56 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# FAQ"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "This document will address frequently asked questions not addressed in other pages of the documentation."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I install cobrapy?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Please see the [INSTALL.rst](https://github.com/opencobra/cobrapy/blob/master/INSTALL.rst) file."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I cite cobrapy?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Please cite the 2013 publication: [10.1186/1752-0509-7-74](http://dx.doi.org/doi:10.1186/1752-0509-7-74)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I rename reactions or metabolites?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "TL;DR Use `Model.repair` afterwards\n",
     "\n",
@@ -85,21 +61,8 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/moritz/.virtualenvs/cobra/lib/python3.5/site-packages/optlang/gurobi_interface.py:26: UserWarning: Be careful! The GUROBI interface is still under construction ...\n",
-      "  warn(\"Be careful! The GUROBI interface is still under construction ...\")\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from __future__ import print_function\n",
     "import cobra.test\n",
@@ -116,10 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The Model.repair function will rebuild the necessary indexes"
    ]
@@ -127,16 +87,30 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Metabolite identifier</strong></td><td>test_dcaACP_c</td>\n",
+       "            </tr>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td><td>Decanoyl-ACP-n-C100ACP</td>\n",
+       "            </tr>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0110f09630</td>\n",
+       "            </tr><tr>\n",
+       "            <tr>\n",
+       "                <td><strong>Formula</strong></td><td>C21H39N2O8PRS</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
       "text/plain": [
-       "<Metabolite test_dcaACP_c at 0x7fa92b9257f0>"
+       "<Metabolite test_dcaACP_c at 0x110f09630>"
       ]
      },
      "execution_count": 2,
@@ -151,20 +125,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I delete a gene?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "That depends on what precisely you mean by delete a gene.\n",
     "\n",
@@ -174,11 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -199,30 +163,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If you want to actually remove all traces of a gene from a model, this is more difficult because this will require changing all the `gene_reaction_rule` strings for reactions involving the gene."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I change the reversibility of a Reaction?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "`Reaction.reversibility` is a property in cobra which is computed when it is requested from the lower and upper bounds."
    ]
@@ -230,11 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -254,10 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Trying to set it directly will result in an error or warning: "
    ]
@@ -265,17 +213,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "cobra/core/reaction.py:484 \u001b[1;31mUserWarning\u001b[0m: Setting reaction reversibility is ignored\n"
+      "cobra/core/reaction.py:501 \u001b[1;31mUserWarning\u001b[0m: Setting reaction reversibility is ignored\n"
      ]
     }
    ],
@@ -288,10 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The way to change the reversibility is to change the bounds to make the reaction irreversible."
    ]
@@ -299,11 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -323,30 +260,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## How do I generate an LP file from a COBRA model?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### For optlang based solvers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "With optlang solvers, the LP formulation of a model is obtained by it's string representation. All solvers behave the same way."
    ]
@@ -355,9 +283,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -367,20 +293,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### For cobrapy's internal solvers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "With the internal solvers, we first create the problem and use functions bundled with the solver. \n",
     "\n",
@@ -390,11 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model = cobra.test.create_test_model()\n",
@@ -410,20 +326,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### How do I visualize my flux solutions?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "cobrapy works well with the [escher](https://escher.github.io/) package, which is well suited to this purpose. Consult the [escher documentation](https://escher.readthedocs.org/en/latest/) for examples."
    ]
@@ -445,9 +355,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2+"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/documentation_builder/getting_started.ipynb
+++ b/documentation_builder/getting_started.ipynb
@@ -2,30 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Getting Started"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Loading a model and inspecting it"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "To begin with, cobrapy comes with bundled models for _Salmonella_ and _E. coli_, as well as a \"textbook\" model of _E. coli_ core metabolism. To load a test model, type"
    ]
@@ -33,11 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -51,10 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The reactions, metabolites, and genes attributes of the cobrapy model are a special type of list called a `cobra.DictList`, and each one is made up of `cobra.Reaction`, `cobra.Metabolite` and `cobra.Gene` objects respectively."
    ]
@@ -63,9 +47,6 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": true
    },
    "outputs": [
@@ -87,30 +68,100 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
+   "source": [
+    "When using [Jupyter notebook](https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/) this type of information is rendered as a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>e_coli_core</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x01116ea9e8</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>72</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>95</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*Biomass_Ecoli_core_reverse_2cdba + 1.0*Biomass_Ecoli_core</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>cytosol, extracellular</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
+      "text/plain": [
+       "<Model e_coli_core at 0x1116ea9e8>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Just like a regular list, objects in the `DictList` can be retrieved by index. For example, to get the 30th reaction in the model (at index 29 because of [0-indexing](https://en.wikipedia.org/wiki/Zero-based_numbering)):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Reaction identifier</strong></td><td>EX_glu__L_e</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>L-Glutamate exchange</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b8643c8</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Stoichiometry</strong></td>\n",
+       "                <td>\n",
+       "                    <p style='text-align:right'>glu__L_e --> </p>\n",
+       "                    <p style='text-align:right'>L-Glutamate --> </p>\n",
+       "                </td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>GPR</strong></td><td></td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Lower bound</strong></td><td>0.0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Upper bound</strong></td><td>1000.0</td>\n",
+       "            </tr>\n",
+       "        </table>\n",
+       "        "
+      ],
       "text/plain": [
-       "<Reaction EX_glu__L_e at 0x10eff01d0>"
+       "<Reaction EX_glu__L_e at 0x11b8643c8>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -121,30 +172,43 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Additionally, items can be retrieved by their `id` using the `DictList.get_by_id()` function. For example, to get the cytosolic atp metabolite object (the id is \"atp_c\"), we can do the following:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Metabolite identifier</strong></td><td>atp_c</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>ATP</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b7f82b0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Formula</strong></td><td>C10H12N5O13P3</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartment</strong></td><td>c</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 13 reaction(s)</strong></td><td>\n",
+       "                    PYK, GLNS, ATPS4r, SUCOAS, PPCK, GLNabc, ATPM, ACKr, Biomass_Ecoli_core, ADK1, PPS, PFK, PGK</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
       "text/plain": [
-       "<Metabolite atp_c at 0x10efa52b0>"
+       "<Metabolite atp_c at 0x11b7f82b0>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,22 +219,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "As an added bonus, users with an interactive shell such as IPython will be able to tab-complete to list elements inside a list. While this is not recommended behavior for most code because of the possibility for characters like \"-\" inside ids, this is very useful while in an interactive prompt:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -178,7 +235,7 @@
        "(-10.0, 1000.0)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -189,40 +246,56 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Reactions"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We will consider the reaction glucose 6-phosphate isomerase, which interconverts glucose 6-phosphate and fructose 6-phosphate. The reaction id for this reaction in our test model is PGI."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Reaction identifier</strong></td><td>PGI</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>glucose-6-phosphate isomerase</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b886a90</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Stoichiometry</strong></td>\n",
+       "                <td>\n",
+       "                    <p style='text-align:right'>g6p_c <=> f6p_c</p>\n",
+       "                    <p style='text-align:right'>D-Glucose 6-phosphate <=> D-Fructose 6-phosphate</p>\n",
+       "                </td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>GPR</strong></td><td>b4025</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Lower bound</strong></td><td>-1000.0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Upper bound</strong></td><td>1000.0</td>\n",
+       "            </tr>\n",
+       "        </table>\n",
+       "        "
+      ],
       "text/plain": [
-       "<Reaction PGI at 0x10f306828>"
+       "<Reaction PGI at 0x11b886a90>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,22 +307,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can view the full name and reaction catalyzed as strings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -267,22 +333,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can also view reaction upper and lower bounds. Because the `pgi.lower_bound` < 0, and `pgi.upper_bound` > 0, `pgi` is reversible."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -300,22 +359,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can also ensure the reaction is mass balanced. This function will return elements which violate mass balance. If it comes back empty, then the reaction is mass balanced."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -323,7 +375,7 @@
        "{}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -334,22 +386,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In order to add a metabolite, we pass in a `dict` with the metabolite object and its coefficient"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -357,7 +402,7 @@
        "'g6p_c + h_c <=> f6p_c'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -369,10 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The reaction is no longer mass balanced"
    ]
@@ -380,11 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -403,10 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can remove the metabolite, and the reaction will be balanced once again."
    ]
@@ -414,11 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -437,10 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "It is also possible to build the reaction from a string. However, care must be taken when doing this to ensure reaction id's match those in the model. The direction of the arrow is also used to update the upper and lower bounds."
    ]
@@ -448,11 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -470,11 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -494,11 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -518,20 +534,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Metabolites"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We will consider cytosolic atp as our metabolite, which has the id `\"atp_c\"` in our test model."
    ]
@@ -539,16 +549,32 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Metabolite identifier</strong></td><td>atp_c</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>ATP</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b7f82b0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Formula</strong></td><td>C10H12N5O13P3</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartment</strong></td><td>c</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 13 reaction(s)</strong></td><td>\n",
+       "                    PYK, GLNS, ATPS4r, SUCOAS, PPCK, GLNabc, ATPM, ACKr, Biomass_Ecoli_core, ADK1, PPS, PFK, PGK</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
       "text/plain": [
-       "<Metabolite atp_c at 0x10efa52b0>"
+       "<Metabolite atp_c at 0x11b7f82b0>"
       ]
      },
      "execution_count": 16,
@@ -563,22 +589,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
-    "We can print out the metabolite name and compartment (cytosol in this case)."
+    "We can print out the metabolite name and compartment (cytosol in this case) directly as string."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -596,10 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can see that ATP is a charged molecule in our model."
    ]
@@ -607,11 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -630,10 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We can see the chemical formula for the metabolite as well."
    ]
@@ -641,11 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -661,10 +666,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The reactions attribute gives a `frozenset` of all reactions using the given metabolite. We can use this to count the number of reactions which use atp."
    ]
@@ -672,11 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -695,10 +693,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "A metabolite like glucose 6-phosphate will participate in fewer reactions."
    ]
@@ -706,19 +701,15 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "frozenset({<Reaction G6PDH2r at 0x10eff8a20>,\n",
-       "           <Reaction Biomass_Ecoli_core at 0x10efea2b0>,\n",
-       "           <Reaction GLCpts at 0x10eff8d30>,\n",
-       "           <Reaction PGI at 0x10f306828>})"
+       "frozenset({<Reaction G6PDH2r at 0x11b870c88>,\n",
+       "           <Reaction GLCpts at 0x11b870f98>,\n",
+       "           <Reaction PGI at 0x11b886a90>,\n",
+       "           <Reaction Biomass_Ecoli_core at 0x11b85a5f8>})"
       ]
      },
      "execution_count": 21,
@@ -732,20 +723,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Genes"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `gene_reaction_rule` is a boolean representation of the gene requirements for this reaction to be active as described in [Schellenberger et al 2011 Nature Protocols 6(9):1290-307](http://dx.doi.org/doi:10.1038/nprot.2011.308).\n",
     "\n",
@@ -755,11 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -779,10 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Corresponding gene objects also exist. These objects are tracked by the reactions itself, as well as by the model"
    ]
@@ -790,16 +768,12 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "frozenset({<Gene b4025 at 0x10efdc9b0>})"
+       "frozenset({<Gene b4025 at 0x11b844cc0>})"
       ]
      },
      "execution_count": 23,
@@ -814,16 +788,30 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Gene identifier</strong></td><td>b4025</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td>pgi</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b844cc0</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Functional</strong></td><td>True</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 1 reaction(s)</strong></td><td>\n",
+       "                    PGI</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
       "text/plain": [
-       "<Gene b4025 at 0x10efdc9b0>"
+       "<Gene b4025 at 0x11b844cc0>"
       ]
      },
      "execution_count": 24,
@@ -838,10 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Each gene keeps track of the reactions it catalyzes"
    ]
@@ -849,16 +834,12 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "frozenset({<Reaction PGI at 0x10f306828>})"
+       "frozenset({<Reaction PGI at 0x11b886a90>})"
       ]
      },
      "execution_count": 25,
@@ -872,10 +853,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Altering the gene_reaction_rule will create new gene objects if necessary and update all relationships."
    ]
@@ -883,16 +861,12 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "frozenset({<Gene spam at 0x10efea748>, <Gene eggs at 0x10efea0f0>})"
+       "frozenset({<Gene spam at 0x11b850908>, <Gene eggs at 0x11b850eb8>})"
       ]
      },
      "execution_count": 26,
@@ -908,11 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -931,10 +901,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Newly created genes are also added to the model"
    ]
@@ -942,16 +909,30 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Gene identifier</strong></td><td>spam</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Name</strong></td><td></td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x011b850908</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Functional</strong></td><td>True</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>In 1 reaction(s)</strong></td><td>\n",
+       "                    PGI</td>\n",
+       "            </tr>\n",
+       "        </table>"
+      ],
       "text/plain": [
-       "<Gene spam at 0x10efea748>"
+       "<Gene spam at 0x11b850908>"
       ]
      },
      "execution_count": 28,
@@ -965,10 +946,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `delete_model_genes` function will evaluate the GPR and set the upper and lower bounds to 0 if the reaction is knocked out. This function can preserve existing deletions or reset them using the `cumulative_deletions` flag."
    ]
@@ -976,11 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1003,10 +977,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The undelete_model_genes can be used to reset a gene deletion"
    ]
@@ -1014,11 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1035,20 +1002,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Making changes reversibly using models as contexts"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Quite often, one wants to make small changes to a model and evaluate the impacts of these. For example, we may want to knock-out all reactions sequentially, and see what the impact of this is on the objective function. One way of doing this would be to create a new copy of the model before each knock-out with `model.copy()`. However, even with small models, this is a very slow approach as models are quite complex objects. Better then would be to do the knock-out, optimizing and then manually resetting the reaction bounds before proceeding with the next reaction. Since this is such a common scenario however, cobrapy allows us to use the model as a context, to have changes reverted automatically."
    ]
@@ -1056,11 +1017,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1086,10 +1043,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If we look at those knocked reactions, see that their bounds have all been reverted."
    ]
@@ -1097,11 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1124,10 +1074,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Nested contexts are also supported"
    ]
@@ -1135,11 +1082,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1168,20 +1111,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Most methods that modify the model are supported like this including adding and removing reactions and metabolites and setting the objective. Supported methods and functions mention this in the corresponding documentation."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "While it does not have any actual effect, for syntactic convenience it is also possible to refer to the model by a different name than outside the context. Such as"
    ]
@@ -1190,9 +1127,7 @@
    "cell_type": "code",
    "execution_count": 34,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1217,9 +1152,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/documentation_builder/io.ipynb
+++ b/documentation_builder/io.ipynb
@@ -26,7 +26,7 @@
      "output_type": "stream",
      "text": [
       "mini test files: \n",
-      "mini_fbc2.xml.gz, mini_fbc1.xml, mini_fbc2.xml.bz2, mini_fbc2.xml, mini.pickle, mini.yml, mini.mat, mini.json, mini_cobra.xml\n"
+      "mini.json, mini.mat, mini.pickle, mini.yml, mini_cobra.xml, mini_fbc1.xml, mini_fbc2.xml, mini_fbc2.xml.bz2, mini_fbc2.xml.gz\n"
      ]
     }
    ],
@@ -68,8 +68,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x01074fd080</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>cytosol, extracellular</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa99860a128>"
+       "<Model mini_textbook at 0x1074fd080>"
       ]
      },
      "execution_count": 2,
@@ -110,8 +134,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0112fa6b38</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>cytosol, extracellular</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa9b74bf9b0>"
+       "<Model mini_textbook at 0x112fa6b38>"
       ]
      },
      "execution_count": 4,
@@ -156,8 +204,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0113061080</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>cytosol, extracellular</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa9b7f82240>"
+       "<Model mini_textbook at 0x113061080>"
       ]
      },
      "execution_count": 6,
@@ -201,8 +273,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0113013390</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>extracellular, cytosol</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa9b7ed2860>"
+       "<Model mini_textbook at 0x113013390>"
       ]
      },
      "execution_count": 8,
@@ -248,8 +344,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0113000b70</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>c, e</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa999136160>"
+       "<Model mini_textbook at 0x113000b70>"
       ]
      },
      "execution_count": 10,
@@ -276,8 +396,32 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "        <table>\n",
+       "            <tr>\n",
+       "                <td><strong>Name</strong></td>\n",
+       "                <td>mini_textbook</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Memory address</strong></td>\n",
+       "                <td>0x0113758438</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of metabolites</strong></td>\n",
+       "                <td>23</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Number of reactions</strong></td>\n",
+       "                <td>18</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Objective expression</strong></td>\n",
+       "                <td>-1.0*ATPM_reverse_5b752 - 1.0*PFK_reverse_d24a6 + 1.0*PFK + 1.0*ATPM</td>\n",
+       "            </tr><tr>\n",
+       "                <td><strong>Compartments</strong></td>\n",
+       "                <td>c, e</td>\n",
+       "            </tr>\n",
+       "          </table>"
+      ],
       "text/plain": [
-       "<Model mini_textbook at 0x7fa9b7eda9e8>"
+       "<Model mini_textbook at 0x113758438>"
       ]
      },
      "execution_count": 11,
@@ -340,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2+"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/documentation_builder/simulating.ipynb
+++ b/documentation_builder/simulating.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import cobra.test\n",
@@ -40,7 +42,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<Solution 0.874 at 0x11c071710>\n"
+      "<Solution 0.874 at 0x112eb3d30>\n"
      ]
     }
    ],
@@ -92,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The solvers that can be used with cobrapy are so fast that for many small to mid-size models computing the solution can be even faster than it takes us to collect the values from the solver and convert that to objects that are usable for us in python. When we use `model.optimize` we gather values for all reactions and metabolites and that can take some time. If we are only interested in the flux value of a single reaction or the objective, it is faster to instead use `model.slim_optimize` which only does the optimization and returns the objective value leaving it up to you to fetch other values that you may need. For example, let's optimize and get the objective value."
+    "The solvers that can be used with cobrapy are so fast that for many small to mid-size models computing the solution can be even faster than it takes to collect the values from the solver and convert to them python objects. With `model.optimize`, we gather values for all reactions and metabolites and that can take a significant amount of time if done repeatedly. If we are only interested in the flux value of a single reaction or the objective, it is faster to instead use `model.slim_optimize` which only does the optimization and returns the objective value leaving it up to you to fetch other values that you may need."
    ]
   },
   {
@@ -104,8 +106,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.64 ms, sys: 127 µs, total: 2.77 ms\n",
-      "Wall time: 2.84 ms\n"
+      "CPU times: user 3.84 ms, sys: 672 µs, total: 4.51 ms\n",
+      "Wall time: 6.16 ms\n"
      ]
     },
     {
@@ -133,8 +135,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 104 µs, sys: 13 µs, total: 117 µs\n",
-      "Wall time: 122 µs\n"
+      "CPU times: user 229 µs, sys: 19 µs, total: 248 µs\n",
+      "Wall time: 257 µs\n"
      ]
     },
     {
@@ -169,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -198,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -236,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -269,27 +271,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Changing the Objectives"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "The objective function is determined from the objective_coefficient attribute of the objective reaction(s). Generally, a \"biomass\" function which describes the composition of metabolites which make up a cell is used."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
-    "hidden": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -298,27 +296,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Currently in the model, there is only one reaction in the objective (the biomass reaction), with an linear coefficient of 1."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{<Reaction Biomass_Ecoli_core at 0x10efce518>: 1.0}"
+       "{<Reaction Biomass_Ecoli_core at 0x112eab4a8>: 1.0}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -330,27 +324,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "The objective function can be changed by assigning Model.objective, which can be a reaction object (or just it's name), or a `dict` of `{Reaction: objective_coefficient}`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{<Reaction ATPM at 0x10efce4e0>: 1.0}"
+       "{<Reaction ATPM at 0x112eab470>: 1.0}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -367,10 +357,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -378,7 +366,7 @@
        "174.99999999999966"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,37 +377,30 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "We can also have more complicated objectives including quadratic terms."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Running FVA"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "FBA will not give always give unique solution, because multiple flux states can achieve the same optimum. FVA (or flux variability analysis) finds the ranges of each metabolic flux at the optimum."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {
-    "collapsed": true,
-    "hidden": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -428,15 +409,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -448,18 +440,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>ACALD</th>\n",
-       "      <td>5.243759e-30</td>\n",
-       "      <td>-4.809828e-14</td>\n",
+       "      <td>-2.208811e-30</td>\n",
+       "      <td>-5.247085e-14</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACALDt</th>\n",
        "      <td>0.000000e+00</td>\n",
-       "      <td>-4.809828e-14</td>\n",
+       "      <td>-5.247085e-14</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACKr</th>\n",
-       "      <td>-9.253692e-30</td>\n",
-       "      <td>-7.356207e-14</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>-8.024953e-14</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACONTa</th>\n",
@@ -474,11 +466,11 @@
        "    <tr>\n",
        "      <th>ACt2r</th>\n",
        "      <td>0.000000e+00</td>\n",
-       "      <td>-7.356207e-14</td>\n",
+       "      <td>-8.024953e-14</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ADK1</th>\n",
-       "      <td>3.126388e-13</td>\n",
+       "      <td>3.410605e-13</td>\n",
        "      <td>0.000000e+00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -489,12 +481,12 @@
        "    <tr>\n",
        "      <th>AKGt2r</th>\n",
        "      <td>0.000000e+00</td>\n",
-       "      <td>-2.660756e-14</td>\n",
+       "      <td>-2.902643e-14</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ALCD2x</th>\n",
        "      <td>0.000000e+00</td>\n",
-       "      <td>-4.168517e-14</td>\n",
+       "      <td>-4.547474e-14</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -502,19 +494,19 @@
       ],
       "text/plain": [
        "             maximum       minimum\n",
-       "ACALD   5.243759e-30 -4.809828e-14\n",
-       "ACALDt  0.000000e+00 -4.809828e-14\n",
-       "ACKr   -9.253692e-30 -7.356207e-14\n",
+       "ACALD  -2.208811e-30 -5.247085e-14\n",
+       "ACALDt  0.000000e+00 -5.247085e-14\n",
+       "ACKr    0.000000e+00 -8.024953e-14\n",
        "ACONTa  2.000000e+01  2.000000e+01\n",
        "ACONTb  2.000000e+01  2.000000e+01\n",
-       "ACt2r   0.000000e+00 -7.356207e-14\n",
-       "ADK1    3.126388e-13  0.000000e+00\n",
+       "ACt2r   0.000000e+00 -8.024953e-14\n",
+       "ADK1    3.410605e-13  0.000000e+00\n",
        "AKGDH   2.000000e+01  2.000000e+01\n",
-       "AKGt2r  0.000000e+00 -2.660756e-14\n",
-       "ALCD2x  0.000000e+00 -4.168517e-14"
+       "AKGt2r  0.000000e+00 -2.902643e-14\n",
+       "ALCD2x  0.000000e+00 -4.547474e-14"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -525,24 +517,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Setting parameter `fraction_of_optimium=0.90` would give the flux ranges for reactions at 90% optimality."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -554,7 +555,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>ACALD</th>\n",
-       "      <td>6.957398e-16</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>-2.692308</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -564,7 +565,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACKr</th>\n",
-       "      <td>1.919072e-15</td>\n",
+       "      <td>6.635712e-30</td>\n",
        "      <td>-4.117647</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -579,7 +580,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ACt2r</th>\n",
-       "      <td>1.714115e-15</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>-4.117647</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -594,7 +595,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>AKGt2r</th>\n",
-       "      <td>9.070758e-16</td>\n",
+       "      <td>2.651196e-16</td>\n",
        "      <td>-1.489362</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -608,19 +609,19 @@
       ],
       "text/plain": [
        "             maximum   minimum\n",
-       "ACALD   6.957398e-16 -2.692308\n",
+       "ACALD   0.000000e+00 -2.692308\n",
        "ACALDt  0.000000e+00 -2.692308\n",
-       "ACKr    1.919072e-15 -4.117647\n",
+       "ACKr    6.635712e-30 -4.117647\n",
        "ACONTa  2.000000e+01  8.461538\n",
        "ACONTb  2.000000e+01  8.461538\n",
-       "ACt2r   1.714115e-15 -4.117647\n",
+       "ACt2r   0.000000e+00 -4.117647\n",
        "ADK1    1.750000e+01  0.000000\n",
        "AKGDH   2.000000e+01  2.500000\n",
-       "AKGt2r  9.070758e-16 -1.489362\n",
+       "AKGt2r  2.651196e-16 -1.489362\n",
        "ALCD2x  0.000000e+00 -2.333333"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -632,24 +633,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "The standard FVA may contain loops, i.e. high absolute flux values that only can be high if they are allowed to participate in loops (a mathematical artifact that cannot happen in vivo). Use the `loopless` argument to avoid such loops. Below, we can see that FRD7 and SUCDi reactions can participate in loops but that this is avoided when using the looplesss FVA."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -679,7 +689,7 @@
        "SUCDi   1000.0     20.0"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -691,15 +701,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -729,7 +750,7 @@
        "SUCDi     20.0     20.0"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -740,41 +761,35 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "### Running FVA in summary methods"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Flux variability analysis can also be embedded in calls to summary methods. For instance, the expected variability in substrate consumption and product formation can be quickly found by"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IN FLUXES                     OUT FLUXES                     OBJECTIVES\n",
-      "----------------------------  -----------------------------  ------------\n",
-      "id          Flux  Range       id          Flux  Range        ATPM  175\n",
-      "--------  ------  ----------  --------  ------  -----------\n",
+      "IN FLUXES                     OUT FLUXES                    OBJECTIVES\n",
+      "----------------------------  ----------------------------  ------------\n",
+      "id          Flux  Range       id          Flux  Range       ATPM  175\n",
+      "--------  ------  ----------  --------  ------  ----------\n",
       "o2_e          60  [55.9, 60]  co2_e         60  [54.2, 60]\n",
       "glc__D_e      10  [9.5, 10]   h2o_e         60  [54.2, 60]\n",
       "nh4_e          0  [0, 0.673]  for_e          0  [0, 5.83]\n",
-      "                              h_e            0  [0, 5.83]\n",
+      "pi_e           0  [0, 0.171]  h_e            0  [0, 5.83]\n",
       "                              ac_e           0  [0, 2.06]\n",
       "                              acald_e        0  [0, 1.35]\n",
       "                              pyr_e          0  [0, 1.35]\n",
@@ -782,8 +797,7 @@
       "                              lac__D_e       0  [0, 1.13]\n",
       "                              succ_e         0  [0, 0.875]\n",
       "                              akg_e          0  [0, 0.745]\n",
-      "                              glu__L_e       0  [0, 0.673]\n",
-      "                              pi_e           0  [0, -0.171]\n"
+      "                              glu__L_e       0  [0, 0.673]\n"
      ]
     }
    ],
@@ -794,19 +808,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Similarly, variability in metabolite mass balances can also be checked with flux variability analysis."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -814,24 +824,23 @@
      "text": [
       "PRODUCING REACTIONS -- Pyruvate (pyr_c)\n",
       "---------------------------------------\n",
-      "%       FLUX  RANGE       RXN ID      REACTION\n",
-      "----  ------  ----------  ----------  ----------------------------------------\n",
-      "52%    10     [0, -5.83]  GLCpts      glc__D_e + pep_c --> g6p_c + pyr_c\n",
-      "48%     9.12  [0, -5.83]  PYK         adp_c + h_c + pep_c --> atp_c + pyr_c\n",
+      "%       FLUX  RANGE         RXN ID      REACTION\n",
+      "----  ------  ------------  ----------  ----------------------------------------\n",
+      "50%       10  [1.25, 18.8]  PYK         adp_c + h_c + pep_c --> atp_c + pyr_c\n",
+      "50%       10  [9.5, 10]     GLCpts      glc__D_e + pep_c --> g6p_c + pyr_c\n",
+      "0%         0  [0, 8.75]     ME1         mal__L_c + nad_c --> co2_c + nadh_c +...\n",
+      "0%         0  [0, 8.75]     ME2         mal__L_c + nadp_c --> co2_c + nadph_c...\n",
       "\n",
       "CONSUMING REACTIONS -- Pyruvate (pyr_c)\n",
       "---------------------------------------\n",
-      "%       FLUX  RANGE       RXN ID      REACTION\n",
-      "----  ------  ----------  ----------  ----------------------------------------\n",
-      "100%   19.1   [0, 5.83]   PDH         coa_c + nad_c + pyr_c --> accoa_c + c...\n",
-      "0%      0     [0, 5.83]   Biomass...  1.496 3pg_c + 3.7478 accoa_c + 59.81 ...\n",
-      "0%      0     [0, 5.83]   FRUpts2     fru_e + pep_c --> f6p_c + pyr_c\n",
-      "0%      0     [0, 5.83]   LDH_D       lac__D_c + nad_c <=> h_c + nadh_c + p...\n",
-      "0%      0     [0, 5.83]   ME1         mal__L_c + nad_c --> co2_c + nadh_c +...\n",
-      "0%      0     [0, 5.83]   ME2         mal__L_c + nadp_c --> co2_c + nadph_c...\n",
-      "0%      0     [0, 5.83]   PFL         coa_c + pyr_c --> accoa_c + for_c\n",
-      "0%      0     [0, 5.83]   PPS         atp_c + h2o_c + pyr_c --> amp_c + 2.0...\n",
-      "0%      0     [0, 5.83]   PYRt2       h_e + pyr_e <=> h_c + pyr_c\n"
+      "%       FLUX  RANGE         RXN ID      REACTION\n",
+      "----  ------  ------------  ----------  ----------------------------------------\n",
+      "100%      20  [13, 28.8]    PDH         coa_c + nad_c + pyr_c --> accoa_c + c...\n",
+      "0%         0  [0, 8.75]     PPS         atp_c + h2o_c + pyr_c --> amp_c + 2.0...\n",
+      "0%         0  [0, 5.83]     PFL         coa_c + pyr_c --> accoa_c + for_c\n",
+      "0%         0  [0, 1.35]     PYRt2       h_e + pyr_e <=> h_c + pyr_c\n",
+      "0%         0  [0, 1.13]     LDH_D       lac__D_c + nad_c <=> h_c + nadh_c + p...\n",
+      "0%         0  [0, 0.132]    Biomass...  1.496 3pg_c + 3.7478 accoa_c + 59.81 ...\n"
      ]
     }
    ],
@@ -841,36 +850,30 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "In these summary methods, the values are reported as a the center point +/- the range of the FVA solution, calculated from the maximum and minimum values."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Running pFBA"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Parsimonious FBA (often written pFBA) finds a flux distribution which gives the optimal growth rate, but minimizes the total sum of flux. This involves solving two sequential linear programs, but is handled transparently by cobrapy. For more details on pFBA, please see [Lewis et al. (2010)](http://dx.doi.org/10.1038/msb.2010.47)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {
-    "hidden": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -881,27 +884,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "These functions should give approximately the same objective value."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "hidden": true
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2.2204460492503131e-16"
+       "7.7715611723760958e-16"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,6 +9,9 @@
   `Model.optimize` when repeatedly doing optimizations and only making
   use of the objective value as avoiding the need to fetch all values
   from the solver object.
+- solution, model, metabolite and reaction now have html
+  representation so they give more informative prints in jupyter
+  notebooks.
 
 ## Deprecated features
 


### PR DESCRIPTION
When using cobrapy in jupyter, it is useful to have html representations
of common classes. Add for model, reaction, metabolite and solution.

![screen shot 2017-07-18 at 16 08 27](https://user-images.githubusercontent.com/1300566/28321363-5d7f4952-6bd3-11e7-8a18-cc1d7efbea17.png)

![screen shot 2017-07-18 at 16 09 03](https://user-images.githubusercontent.com/1300566/28321391-71d233a6-6bd3-11e7-898e-db7c6577c225.png)

![screen shot 2017-07-18 at 16 09 45](https://user-images.githubusercontent.com/1300566/28321420-897794e2-6bd3-11e7-8c1d-f0cbd9aeb799.png)

![screen shot 2017-07-18 at 16 10 12](https://user-images.githubusercontent.com/1300566/28321453-9af31840-6bd3-11e7-9682-46c95146cda4.png)
