### PR TITLE
feat: option to raise error from model.optimize

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -814,7 +814,7 @@ class Model(Object):
         else:
             assert_optimal(self, message)
 
-    def optimize(self, objective_sense=None, **kwargs):
+    def optimize(self, objective_sense=None, raise_error=False, **kwargs):
         """
         Optimize the model using flux balance analysis.
 
@@ -823,6 +823,9 @@ class Model(Object):
         objective_sense : {None, 'maximize' 'minimize'}, optional
             Whether fluxes should be maximized or minimized. In case of None,
             the previous direction is used.
+        raise_error : bool
+            If true, raise an OptimizationError if solver status is not
+             optimal.
         solver : {None, 'glpk', 'cglpk', 'gurobi', 'cplex'}, optional
             If unspecified will use the currently defined `self.solver`
             otherwise it will use the given solver and update the attribute.
@@ -855,7 +858,7 @@ class Model(Object):
                     "max": "maximize", "min": "minimize"}[original_direction]
             solution = optimize(self, objective_sense=objective_sense,
                                 **kwargs)
-            check_solver_status(solution.status)
+            check_solver_status(solution.status, raise_error=raise_error)
             return solution
 
         self.solver = solver
@@ -863,7 +866,7 @@ class Model(Object):
             {"maximize": "max", "minimize": "min"}.get(
                 objective_sense, original_direction)
         self.slim_optimize()
-        solution = get_solution(self)
+        solution = get_solution(self, raise_error=raise_error)
         self.objective.direction = original_direction
         return solution
 

--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -273,7 +273,7 @@ class LegacySolution(object):
              DeprecationWarning)
 
 
-def get_solution(model, reactions=None, metabolites=None):
+def get_solution(model, reactions=None, metabolites=None, raise_error=False):
     """
     Generate a solution representation of the current solver state.
 
@@ -287,6 +287,8 @@ def get_solution(model, reactions=None, metabolites=None):
     metabolites : list, optional
         An iterable of `cobra.Metabolite` objects. Uses `model.metabolites` by
         default.
+    raise_error : bool
+        If true, raise an OptimizationError if solver status is not optimal.
 
     Returns
     -------
@@ -297,7 +299,7 @@ def get_solution(model, reactions=None, metabolites=None):
     This is only intended for the `optlang` solver interfaces and not the
     legacy solvers.
     """
-    check_solver_status(model.solver.status)
+    check_solver_status(model.solver.status, raise_error=raise_error)
     if reactions is None:
         reactions = model.reactions
     if metabolites is None:

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -767,6 +767,17 @@ class TestCobraModel:
             with pytest.raises(OptimizationError):
                 model.slim_optimize(error_value=None)
 
+    @pytest.mark.parametrize("solver", optlang_solvers)
+    def test_optimize(self, model, solver):
+        model.solver = solver
+        with model:
+            assert model.optimize().objective_value > 0.872
+            model.reactions.Biomass_Ecoli_core.lower_bound = 10
+            with pytest.warns(UserWarning):
+                model.optimize()
+            with pytest.raises(OptimizationError):
+                model.optimize(raise_error=True)
+
     def test_change_objective(self, model):
         # Test for correct optimization behavior
         model.optimize()

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -394,11 +394,11 @@ def fix_objective_as_constraint(model, fraction=1, bound=None,
     add_cons_vars_to_problem(model, constraint, sloppy=True)
 
 
-def check_solver_status(status):
+def check_solver_status(status, raise_error=False):
     """Perform standard checks on a solver's status."""
     if status == optlang.interface.OPTIMAL:
         return
-    elif status == optlang.interface.INFEASIBLE:
+    elif status == optlang.interface.INFEASIBLE and not raise_error:
         warn("solver status is '{}'".format(status), UserWarning)
     elif status is None:
         raise RuntimeError(

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -14,6 +14,8 @@
   notebooks.
 - New convenience functions `cobra.flux_analysis.find_essential_genes` and
   `cobra.flux_analysis.find_essential_reactions`.
+- `Model.optimize` has new parameter `raise_error` to enable option to
+  get trigger exception if no feasible solution could be found.
 
 ## Deprecated features
 


### PR DESCRIPTION
Add a feature to replace this

```
model.slim_optimize()
assert_optimal(model)
solution = get_solution(model)
```

with just

```
solution = model.optimize(raise_error=True)
```

and avoid the imports `assert_optimal` and `get_solution` in other packages