### PR TITLE
refactor: make model.medium pandas df

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -9,6 +9,7 @@ from functools import partial
 from warnings import warn
 
 import optlang
+import pandas as pd
 import six
 import sympy
 from six import iteritems, string_types
@@ -186,8 +187,9 @@ class Model(Object):
             elif reaction.products:
                 return reaction.upper_bound
 
-        return {rxn.id: get_active_bound(rxn) for rxn in self.exchanges
-                if is_active(rxn)}
+        return pd.DataFrame({rxn.id: get_active_bound(rxn) for rxn
+                             in self.exchanges if is_active(rxn)},
+                            index=['bound'])
 
     @medium.setter
     def medium(self, medium):
@@ -217,7 +219,7 @@ class Model(Object):
         for rxn_id, bound in iteritems(medium):
             rxn = self.reactions.get_by_id(rxn_id)
             media_rxns.append(rxn)
-            set_active_bound(rxn, bound)
+            set_active_bound(rxn, float(bound))
 
         boundary_rxns = set(self.exchanges)
         media_rxns = set(media_rxns)

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -833,7 +833,7 @@ class TestCobraModel:
         # Test basic setting and getting methods
         medium = model.medium
         model.medium = medium
-        assert model.medium == medium
+        assert model.medium.to_dict() == medium.to_dict()
 
         # Test context management
         with model:

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -12,6 +12,7 @@
 - solution, model, metabolite and reaction now have html
   representation so they give more informative prints in jupyter
   notebooks.
+- `Model.medium` now returns a data frame instead of dictionary.
 
 ## Deprecated features
 


### PR DESCRIPTION
Make model.medium return data frame instead as nicer to read in
notebooks (backwards compatible)