### PR TITLE
refactor: don't use str(reaction) to get reaction.id

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -1036,6 +1036,10 @@ class Reaction(Object):
                     met = Metabolite(met_id)
                 self.add_metabolites({met: num})
 
+    def __str__(self):
+        return "{id}: {stoichiometry}".format(
+            id=self.id, stoichiometry=self.build_reaction_string())
+
     def _repr_html_(self):
         return """
         <table>

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -141,11 +141,11 @@ def _fva_legacy(cobra_model, reaction_list, fraction_of_optimum,
 def calculate_lp_variability(lp, solver, cobra_model, reaction_list,
                              **solver_args):
     """calculate max and min of selected variables in an LP"""
-    fva_results = {str(r): {} for r in reaction_list}
+    fva_results = {r.id: {} for r in reaction_list}
     for what in ("minimum", "maximum"):
         sense = "minimize" if what == "minimum" else "maximize"
         for r in reaction_list:
-            r_id = str(r)
+            r_id = r.id
             i = cobra_model.reactions.index(r_id)
             solver.change_variable_objective(lp, i, 1.)
             solver.solve_problem(lp, objective_sense=sense, **solver_args)
@@ -182,7 +182,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless, pfba_factor):
         A dictionary containing the results.
     """
     prob = model.problem
-    fva_results = {str(rxn): {} for rxn in reaction_list}
+    fva_results = {rxn.id: {} for rxn in reaction_list}
     with model as m:
         m.slim_optimize(error_value=None,
                         message="There is no optimal solution for the "
@@ -213,7 +213,7 @@ def _fva_optlang(model, reaction_list, fraction, loopless, pfba_factor):
         for what in ("minimum", "maximum"):
             sense = "min" if what == "minimum" else "max"
             for rxn in reaction_list:
-                r_id = str(rxn)
+                r_id = rxn.id
                 rxn = m.reactions.get_by_id(r_id)
                 # The previous objective assignment already triggers a reset
                 # so directly update coefs here to not trigger redundant resets

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -94,6 +94,11 @@ class TestReactions:
         model.genes.A2B3.knock_out()
         assert not model.reactions.rxn.functional
 
+    def test_str(self):
+        rxn = Reaction('rxn')
+        rxn.add_metabolites({Metabolite('A'): -1, Metabolite('B'): 1})
+        assert str(rxn) == 'rxn: A --> B'
+
     @pytest.mark.parametrize("solver", list(solver_dict))
     def test_add_metabolite_benchmark(self, model, benchmark, solver):
         reaction = model.reactions.get_by_id("PGI")

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -16,6 +16,9 @@
   `cobra.flux_analysis.find_essential_reactions`.
 - `Model.optimize` has new parameter `raise_error` to enable option to
   get trigger exception if no feasible solution could be found.
+- `str(reaction)` now gives the more useful reaction id and the
+  reaction string.
 
 ## Deprecated features
 
+- `str(reaction)` no longer gives `reaction.id`.


### PR DESCRIPTION
The string representation should be something nice and readable, not
necessarily the id-property. For this it is safer to use that property
directly. Change the str representation to something more useful than
the reaction id (include the reaction string)