### PR TITLE
[sampling] Fix a reprojection bug

### DIFF
--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -280,9 +280,40 @@ class HRSampler(object):
                                       self.warmup[0:self.n_warmup, ])
 
     def _reproject(self, p):
-        """Reproject a point into the feasibility region."""
+        """Reproject a point into the feasibility region.
+
+        This function is guaranteed to return a new feasible point. However,
+        no guarantees in terms of proximity to the original point can be made.
+
+        Parameters
+        ----------
+        p : numpy.array
+            The current sample point.
+
+        Returns
+        -------
+        numpy.array
+            A new feasible point. If `p` was feasible it wil return p.
+        """
         nulls = self.problem.nullspace
-        return nulls.dot(nulls.T.dot(p))
+        equalities = self.problem.equalities
+        # don't reproject if point is feasible
+        if np.allclose(equalities.dot(p), self.problem.b,
+                       rtol=0, atol=feasibility_tol):
+            new = p
+        else:
+            LOGGER.info("feasibility violated in sample"
+                        " %d, trying to reproject" % self.n_samples)
+            new = nulls.dot(nulls.T.dot(p))
+        # Projections may violate bounds
+        # set to random point in space in that case
+        if any(self._bounds_dist(new) < -bounds_tol):
+            LOGGER.info("reprojection failed in sample"
+                        " %d, using random point in space" % self.n_samples)
+            idx = np.random.randint(self.n_warmup,
+                                    size=min(2, int(np.sqrt(self.n_warmup))))
+            new = self.warmup[idx, :].mean(axis=0)
+        return new
 
     def _bounds_dist(self, p):
         """Get the lower and upper bound distances. Negative is bad."""

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -806,6 +806,13 @@ class TestCobraFluxSampling:
         relative_diff = (s_inhom.std() + 1e-12)/(s_hom.std() + 1e-12)
         assert 0.5 < relative_diff.abs().mean() < 2
 
+    def test_reproject(self):
+        s = self.optgp.sample(10, fluxes=False).as_matrix()
+        proj = numpy.apply_along_axis(self.optgp._reproject, 1, s)
+        assert all(self.optgp.validate(proj) == "v")
+        s = numpy.random.rand(10, self.optgp.warmup.shape[1])
+        proj = numpy.apply_along_axis(self.optgp._reproject, 1, s)
+        assert all(self.optgp.validate(proj) == "v")
 
 class TestProductionEnvelope:
     """Test the production envelope."""

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -814,6 +814,7 @@ class TestCobraFluxSampling:
         proj = numpy.apply_along_axis(self.optgp._reproject, 1, s)
         assert all(self.optgp.validate(proj) == "v")
 
+
 class TestProductionEnvelope:
     """Test the production envelope."""
 


### PR DESCRIPTION
In rare cases the reprojection will yield bounds violations. If that occurs along with an infeasible sampling center the sampler will fail. This PR now guarantees that `sampler._reproject` always returns a feasible point and will not attempt to reproject already feasible points either (like it did before).