### PR TITLE
removing solution links to model

### DIFF
--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -34,9 +34,6 @@ class Solution(object):
         The (optimal) value for the objective function.
     status : str
         The solver status related to the solution.
-    reactions : list
-        A list of `cobra.Reaction` objects for which the solution is
-        retrieved.
     fluxes : pandas.Series
         Contains the reaction fluxes (primal values of variables).
     reduced_costs : pandas.Series
@@ -61,7 +58,7 @@ class Solution(object):
         Use `reduced_costs` instead.
     """
 
-    def __init__(self, objective_value, status, reactions, fluxes,
+    def __init__(self, objective_value, status, fluxes,
                  reduced_costs=None, metabolites=None, shadow_prices=None,
                  **kwargs):
         """
@@ -73,26 +70,18 @@ class Solution(object):
             The (optimal) value for the objective function.
         status : str
             The solver status related to the solution.
-        reactions : list
-            A list of `cobra.Reaction` objects for which the solution is
-            retrieved.
         fluxes : pandas.Series
             Contains the reaction fluxes (primal values of variables).
         reduced_costs : pandas.Series
             Contains reaction reduced costs (dual values of variables).
-        metabolites : list
-            A list of `cobra.Metabolite` objects for which the solution is
-            retrieved.
         shadow_prices : pandas.Series
             Contains metabolite shadow prices (dual values of constraints).
         """
         super(Solution, self).__init__(**kwargs)
         self.objective_value = objective_value
         self.status = status
-        self.reactions = reactions
         self.fluxes = fluxes
         self.reduced_costs = reduced_costs
-        self.metabolites = metabolites
         self.shadow_prices = shadow_prices
 
     def __repr__(self):
@@ -331,9 +320,7 @@ def get_solution(model, reactions=None, metabolites=None, raise_error=False):
             met_index.append(met.id)
             shadow[i] = constr_duals[met.id]
     return Solution(model.solver.objective.value, model.solver.status,
-                    reactions,
                     Series(index=rxn_index, data=fluxes, name="fluxes"),
                     Series(index=rxn_index, data=reduced,
                            name="reduced_costs"),
-                    metabolites,
                     Series(index=met_index, data=shadow, name="shadow_prices"))

--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -38,9 +38,6 @@ class Solution(object):
         Contains the reaction fluxes (primal values of variables).
     reduced_costs : pandas.Series
         Contains reaction reduced costs (dual values of variables).
-    metabolites : list
-        A list of `cobra.Metabolite` objects for which the solution is
-        retrieved.
     shadow_prices : pandas.Series
         Contains metabolite shadow prices (dual values of constraints).
 
@@ -58,9 +55,8 @@ class Solution(object):
         Use `reduced_costs` instead.
     """
 
-    def __init__(self, objective_value, status, fluxes,
-                 reduced_costs=None, metabolites=None, shadow_prices=None,
-                 **kwargs):
+    def __init__(self, objective_value, status, fluxes, reduced_costs=None,
+                 shadow_prices=None, **kwargs):
         """
         Initialize a `Solution` from its components.
 

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -36,7 +36,6 @@ class TestSolution:
     def test_solution_contains_only_reaction_specific_values(self,
                                                              solved_model):
         solution, model = solved_model
-        assert set(model.reactions) == set(solution.reactions)
         reaction_ids = set([reaction.id for reaction in model.reactions])
         if isinstance(solution, Solution):
             assert set(solution.fluxes.index) == reaction_ids


### PR DESCRIPTION
We talked about this a bit, but `solution.reactions[0].model` points back to the original model that generated the solution.

Do we really need these class members? Other than [this](https://github.com/opencobra/cobrapy/blob/devel/cobra/test/test_solver_model.py#L39) line, everything else seems to pass fine when I remove them.

Thoughts on whether we want this? Let me know if I've missed anything?