### PR TITLE
summary now accepts solution kwarg, resolves if missing

### DIFF
--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -216,10 +216,13 @@ class Metabolite(Species):
 
         Parameters
         ----------
-        solution: cobra.core.solution
+        solution : cobra.core.Solution
             A previously solved model solution to use for generating the
             summary. If none provided (default), the summary method will
-            resolve the model.
+            resolve the model. Note that the solution object must match the
+            model, i.e., changes to the model such as changed bounds,
+            added or removed reactions are not taken into account by this
+            method.
 
         threshold : float
             a value below which to ignore reaction fluxes

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -206,8 +206,8 @@ class Metabolite(Species):
         """
         self._model.remove_metabolites(self, destructive)
 
-    def summary(self, solution=None, threshold=0.01, fva=False, floatfmt='.3g',
-                **kwargs):
+    def summary(self, solution=None, threshold=0.01, fva=False,
+                floatfmt='.3g'):
         """Print a summary of the reactions which produce and consume this
         metabolite.
 
@@ -237,7 +237,7 @@ class Metabolite(Species):
         """
         from cobra.flux_analysis.summary import metabolite_summary
         return metabolite_summary(self, solution=solution, threshold=threshold,
-                                  fva=fva, floatfmt=floatfmt, **kwargs)
+                                  fva=fva, floatfmt=floatfmt)
 
     def _repr_html_(self):
         return """

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -206,7 +206,8 @@ class Metabolite(Species):
         """
         self._model.remove_metabolites(self, destructive)
 
-    def summary(self, threshold=0.01, fva=False, floatfmt='.3g', **kwargs):
+    def summary(self, solution=None, threshold=0.01, fva=False, floatfmt='.3g',
+                **kwargs):
         """Print a summary of the reactions which produce and consume this
         metabolite.
 
@@ -215,6 +216,11 @@ class Metabolite(Species):
 
         Parameters
         ----------
+        solution: cobra.core.solution
+            A previously solved model solution to use for generating the
+            summary. If none provided (default), the summary method will
+            resolve the model.
+
         threshold : float
             a value below which to ignore reaction fluxes
 
@@ -227,8 +233,8 @@ class Metabolite(Species):
             format method for floats, passed to tabulate. Default is '.3g'.
         """
         from cobra.flux_analysis.summary import metabolite_summary
-        return metabolite_summary(self, threshold=threshold, fva=fva,
-                                  floatfmt=floatfmt, **kwargs)
+        return metabolite_summary(self, solution=solution, threshold=threshold,
+                                  fva=fva, floatfmt=floatfmt, **kwargs)
 
     def _repr_html_(self):
         return """

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -941,10 +941,13 @@ class Model(Object):
 
         Parameters
         ----------
-        solution: cobra.core.solution
+        solution: cobra.core.Solution
             A previously solved model solution to use for generating the
             summary. If none provided (default), the summary method will
-            resolve the model.
+            resolve the model. Note that the solution object must match the
+            model, i.e., changes to the model such as changed bounds,
+            added or removed reactions are not taken into account by this
+            method.
 
         threshold : float
             tolerance for determining if a flux is zero (not printed)

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -934,12 +934,18 @@ class Model(Object):
             value = {rxn: 1 for rxn in reactions}
         set_objective(self, value, additive=False)
 
-    def summary(self, threshold=1E-8, fva=None, floatfmt='.3g', **kwargs):
+    def summary(self, solution=None, threshold=1E-8, fva=None, floatfmt='.3g',
+                **kwargs):
         """Print a summary of the input and output fluxes of the model. This
         method requires the model to have been previously solved.
 
         Parameters
         ----------
+        solution: cobra.core.solution
+            A previously solved model solution to use for generating the
+            summary. If none provided (default), the summary method will
+            resolve the model.
+
         threshold : float
             tolerance for determining if a flux is zero (not printed)
 
@@ -952,8 +958,8 @@ class Model(Object):
 
         """
         from cobra.flux_analysis.summary import model_summary
-        return model_summary(self, threshold=threshold, fva=fva,
-                             floatfmt=floatfmt, **kwargs)
+        return model_summary(self, solution=solution, threshold=threshold,
+                             fva=fva, floatfmt=floatfmt, **kwargs)
 
     def __enter__(self):
         """Record all future changes to the model, undoing them when a call to

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -934,8 +934,7 @@ class Model(Object):
             value = {rxn: 1 for rxn in reactions}
         set_objective(self, value, additive=False)
 
-    def summary(self, solution=None, threshold=1E-8, fva=None, floatfmt='.3g',
-                **kwargs):
+    def summary(self, solution=None, threshold=1E-8, fva=None, floatfmt='.3g'):
         """Print a summary of the input and output fluxes of the model. This
         method requires the model to have been previously solved.
 
@@ -962,7 +961,7 @@ class Model(Object):
         """
         from cobra.flux_analysis.summary import model_summary
         return model_summary(self, solution=solution, threshold=threshold,
-                             fva=fva, floatfmt=floatfmt, **kwargs)
+                             fva=fva, floatfmt=floatfmt)
 
     def __enter__(self):
         """Record all future changes to the model, undoing them when a call to

--- a/cobra/flux_analysis/summary.py
+++ b/cobra/flux_analysis/summary.py
@@ -24,19 +24,22 @@ def metabolite_summary(met, solution=None, threshold=0.01, fva=False,
     """Print a summary of the reactions which produce and consume this
     metabolite
 
-    solution: cobra.core.solution
-        A previously solved model solution to use for generating the summary.
-        If none provided (default), the summary method will resolve the model.
+    solution : cobra.core.Solution
+        A previously solved model solution to use for generating the
+        summary. If none provided (default), the summary method will resolve
+        the model. Note that the solution object must match the model, i.e.,
+        changes to the model such as changed bounds, added or removed
+        reactions are not taken into account by this method.
 
-    threshold: float
+    threshold : float
         a value below which to ignore reaction fluxes
 
-    fva: float (0->1), or None
+    fva : float (0->1), or None
         Whether or not to include flux variability analysis in the output.
         If given, fva should be a float between 0 and 1, representing the
         fraction of the optimum objective to be searched.
 
-    floatfmt: string
+    floatfmt : string
         format method for floats, passed to tabulate. Default is '.3g'.
 
     """
@@ -120,18 +123,21 @@ def model_summary(model, solution=None, threshold=1E-8, fva=None,
                   floatfmt='.3g', **solver_args):
     """Print a summary of the input and output fluxes of the model.
 
-    solution: cobra.core.solution
-        A previously solved model solution to use for generating the summary.
-        If none provided (default), the summary method will resolve the model.
+    solution : cobra.core.Solution
+        A previously solved model solution to use for generating the
+        summary. If none provided (default), the summary method will resolve
+        the model. Note that the solution object must match the model, i.e.,
+        changes to the model such as changed bounds, added or removed
+        reactions are not taken into account by this method.
 
-    threshold: float
+    threshold : float
         tolerance for determining if a flux is zero (not printed)
 
-    fva: int or None
+    fva : int or None
         Whether or not to calculate and report flux variability in the
         output summary
 
-    floatfmt: string
+    floatfmt : string
         format method for floats, passed to tabulate. Default is '.3g'.
 
     """


### PR DESCRIPTION
This is a PR to fix #520 and de-couple the summary methods from connection via `reaction.flux` to the underlying solver in memory.

`model.summary()` now accepts a kwarg `solution`, which if given will re-use the fluxes from a previous solution. Otherwise puts in a call to `model.optimize()` to get an updated set of fluxes. Speeds don't seem to be affected that much, especially if the solver is able to re-use the solution basis.