### PR TITLE
fix: avoid adding extra notes in legacy sbml

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -334,6 +334,12 @@ class Model(Object):
         # First check whether the metabolites exist in the model
         metabolite_list = [x for x in metabolite_list
                            if x.id not in self.metabolites]
+
+        bad_ids = [m for m in metabolite_list
+                   if not isinstance(m.id, string_types) or len(m.id) < 1]
+        if len(bad_ids) != 0:
+            raise ValueError('invalid identifiers in {}'.format(repr(bad_ids)))
+
         for x in metabolite_list:
             x._model = self
         self.metabolites += metabolite_list

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -354,9 +354,7 @@ def create_cobra_model_from_sbml_file(sbml_filename, old_sbml=False,
 
 
 def parse_legacy_sbml_notes(note_string, note_delimiter=':'):
-    """Deal with legacy SBML format issues arising from the
-    COBRA Toolbox for MATLAB and BiGG.ucsd.edu developers.
-
+    """Deal with various legacy SBML format issues.
     """
     note_dict = {}
     start_tag = '<p>'
@@ -564,7 +562,7 @@ def get_libsbml_document(cobra_model,
         # they are set to be identical
         note_dict = the_reaction.notes.copy()
         if the_reaction.gene_reaction_rule:
-            note_dict['GENE_ASSOCIATION'] = [
+            note_dict['GENE ASSOCIATION'] = [
                 str(the_reaction.gene_reaction_rule)]
         if the_reaction.subsystem:
             note_dict['SUBSYSTEM'] = [str(the_reaction.subsystem)]

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -118,6 +118,8 @@ class TestReactions:
         benchmark(add_remove_metabolite)
 
     def test_add_metabolite(self, model):
+        with pytest.raises(ValueError):
+            model.add_metabolites(Metabolite())
         with model:
             with model:
                 reaction = model.reactions.get_by_id("PGI")


### PR DESCRIPTION
Underscores in keys for `KEY: value` associations in the notes field are
replaced with spaces so internally use only underscore free keys or
key-values may get repeated in legacy sbml output. Tricky to create
meaningful test for this as the notes field as (mis)using
legacy/incomplete sbml specification for sake of backwards
compatibility.

Also include check to not add Metabolite's with missing id's as causes confusing errors. Found this when trying the model in the original #333 