### PR TITLE
Truncate long `__repr_html__` outputs

### DIFF
--- a/cobra/core/gene.py
+++ b/cobra/core/gene.py
@@ -11,6 +11,7 @@ from warnings import warn
 
 from cobra.core.species import Species
 from cobra.util import resettable
+from cobra.util.util import format_long_string
 
 keywords = list(kwlist)
 keywords.remove("and")
@@ -289,4 +290,5 @@ class Gene(Species):
                            functional=self.functional,
                            address='0x0%x' % id(self),
                            n_reactions=len(self.reactions),
-                           reactions=', '.join(r.id for r in self.reactions))
+                           reactions=format_long_string(
+                               ', '.join(r.id for r in self.reactions), 200))

--- a/cobra/core/metabolite.py
+++ b/cobra/core/metabolite.py
@@ -12,6 +12,7 @@ from cobra.exceptions import OptimizationError
 from cobra.core.formula import elements_and_molecular_weights
 from cobra.core.species import Species
 from cobra.util.solver import check_solver_status
+from cobra.util.util import format_long_string
 
 
 # Numbers are not required because of the |(?=[A-Z])? block. See the
@@ -257,8 +258,10 @@ class Metabolite(Species):
                 <td><strong>In {n_reactions} reaction(s)</strong></td><td>
                     {reactions}</td>
             </tr>
-        </table>""".format(id=self.id, name=self.name, formula=self.formula,
+        </table>""".format(id=self.id, name=format_long_string(self.name),
+                           formula=self.formula,
                            address='0x0%x' % id(self),
                            compartment=self.compartment,
                            n_reactions=len(self.reactions),
-                           reactions=', '.join(r.id for r in self.reactions))
+                           reactions=format_long_string(
+                               ', '.join(r.id for r in self.reactions), 200))

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -24,7 +24,7 @@ from cobra.util.solver import (
     SolverNotFound, get_solver_name, interface_to_str, set_objective, solvers,
     add_cons_vars_to_problem, remove_cons_vars_from_problem, choose_solver,
     check_solver_status, assert_optimal)
-from cobra.util.util import AutoVivification
+from cobra.util.util import AutoVivification, format_long_string
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1064,7 +1064,7 @@ class Model(Object):
             address='0x0%x' % id(self),
             num_metabolites=len(self.metabolites),
             num_reactions=len(self.reactions),
-            objective=str(self.objective.expression),
+            objective=format_long_string(str(self.objective.expression), 100),
             compartments=", ".join(
                 v if v else k for k, v in iteritems(self.compartments)
             ))

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -20,6 +20,7 @@ from cobra.core.object import Object
 from cobra.util.context import resettable, get_context
 from cobra.util.solver import (
     linear_reaction_coefficients, set_objective, check_solver_status)
+from cobra.util.util import format_long_string
 
 # precompiled regular expressions
 # Matches and/or in a gene reaction rule
@@ -1064,11 +1065,14 @@ class Reaction(Object):
                 <td><strong>Upper bound</strong></td><td>{ub}</td>
             </tr>
         </table>
-        """.format(id=self.id, name=self.name,
+        """.format(id=format_long_string(self.id, 100),
+                   name=format_long_string(self.name, 100),
                    address='0x0%x' % id(self),
-                   stoich_id=self.build_reaction_string(),
-                   stoich_name=self.build_reaction_string(True),
-                   gpr=self.gene_reaction_rule,
+                   stoich_id=format_long_string(
+                       self.build_reaction_string(), 200),
+                   stoich_name=format_long_string(
+                       self.build_reaction_string(True), 200),
+                   gpr=format_long_string(self.gene_reaction_rule, 100),
                    lb=self.lower_bound, ub=self.upper_bound)
 
 

--- a/cobra/core/solution.py
+++ b/cobra/core/solution.py
@@ -10,7 +10,7 @@ from warnings import warn
 
 from numpy import empty, nan
 from optlang.interface import OPTIMAL
-from pandas import Series, DataFrame
+from pandas import Series, DataFrame, option_context
 
 from cobra.util.solver import check_solver_status
 
@@ -89,10 +89,11 @@ class Solution(object):
 
     def _repr_html_(self):
         if self.status == OPTIMAL:
-            html = ('<strong><em>Optimal</em> solution with objective value '
-                    '{:.3f}</strong><br>{}'
-                    .format(self.objective_value,
-                            self.to_frame()._repr_html_()))
+            with option_context('display.max_rows', 10):
+                html = ('<strong><em>Optimal</em> solution with objective '
+                        'value {:.3f}</strong><br>{}'
+                        .format(self.objective_value,
+                                self.to_frame()._repr_html_()))
         else:
             html = '<strong><em>{}</em> solution</strong>'.format(self.status)
         return html

--- a/cobra/flux_analysis/summary.py
+++ b/cobra/flux_analysis/summary.py
@@ -10,14 +10,8 @@ from tabulate import tabulate
 
 from cobra.flux_analysis.variability import flux_variability_analysis
 from cobra.util.solver import linear_reaction_coefficients
+from cobra.util.util import format_long_string
 from cobra.core import get_solution
-
-
-def format_long_string(string, max_length):
-    if len(string) > max_length:
-        string = string[:max_length - 3]
-        string += '...'
-    return string
 
 
 def metabolite_summary(met, solution=None, threshold=0.01, fva=False,

--- a/cobra/util/util.py
+++ b/cobra/util/util.py
@@ -3,6 +3,13 @@
 from __future__ import absolute_import
 
 
+def format_long_string(string, max_length=50):
+    if len(string) > max_length:
+        string = string[:max_length - 3]
+        string += '...'
+    return string
+
+
 class AutoVivification(dict):
     """Implementation of perl's autovivification feature. Checkout
     http://stackoverflow.com/a/652284/280182 """


### PR DESCRIPTION
This PR uses the short function previously in `cobra.flux_analysis.summary` to truncate overly long strings in the repr_html output. Closes #577 

Here's a preview:

![image](https://user-images.githubusercontent.com/2576846/29337775-dcf99c66-81cf-11e7-95be-de6b62e2117a.png)

Do we want to be even more aggressive with the truncation? less aggressive? There's definitely a balance between not blasting the whole screen and still displaying useful information for larger models.