### PR TITLE
refactor: transform production envelope to wide format with multiple carbon sources

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -981,9 +981,10 @@ class Model(Object):
     @objective_direction.setter
     @resettable
     def objective_direction(self, value):
-        if value.lower().startswith("max"):
+        value = value.lower()
+        if value.startswith("max"):
             self.solver.objective.direction = "max"
-        elif value.lower().startswith("min"):
+        elif value.startswith("min"):
             self.solver.objective.direction = "min"
         else:
             raise ValueError("Unknown objective direction '{}'.".format(value))

--- a/cobra/flux_analysis/phenotype_phase_plane.py
+++ b/cobra/flux_analysis/phenotype_phase_plane.py
@@ -446,12 +446,12 @@ def add_envelope(model, reactions, grid, c_input, c_output, threshold):
                         grid.at[i, 'carbon_yield_{}'.format(direction)] = \
                             total_yield([rxn.flux for rxn in c_input],
                                         input_components,
-                                        model.solver.objective.value,
+                                        obj_val,
                                         output_components)
                         grid.at[i, 'mass_yield_{}'.format(direction)] = \
                             total_yield([rxn.flux for rxn in c_input],
                                         input_weights,
-                                        model.solver.objective.value,
+                                        obj_val,
                                         output_weight)
 
 

--- a/cobra/flux_analysis/phenotype_phase_plane.py
+++ b/cobra/flux_analysis/phenotype_phase_plane.py
@@ -430,9 +430,8 @@ def add_envelope(model, reactions, grid, c_input, c_output, threshold):
         output_weight = []
 
     for direction in ('minimum', 'maximum'):
-        sense = "min" if direction == "minimum" else "max"
         with model:
-            model.solver.objective.direction = sense
+            model.objective_direction = direction
             for i in range(len(grid)):
                 with model:
                     for rxn in reactions:

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -842,6 +842,15 @@ class TestProductionEnvelope:
         with pytest.raises(ValueError):
             production_envelope(model, "EX_o2_e", obj)
 
+    @pytest.mark.parametrize("variables, num", [
+        (["EX_glc__D_e"], 30),
+        (["EX_glc__D_e", "EX_o2_e"], 20),
+        (["EX_glc__D_e", "EX_o2_e", "EX_ac_e"], 10)
+    ])
+    def test_multi_variable_envelope(self, model, variables, num):
+        df = production_envelope(model, variables, points=num)
+        assert len(df) == num ** len(variables)
+
     def test_envelope_two(self, model):
         df = production_envelope(model, ["EX_glc__D_e", "EX_o2_e"],
                                  objective="EX_ac_e")

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -834,7 +834,7 @@ class TestProductionEnvelope:
 
     def test_envelope_one(self, model):
         df = production_envelope(model, ["EX_o2_e"])
-        assert abs(sum(df.flux) - 9.342) < 0.001
+        assert numpy.isclose(df["flux_maximum"].sum(), 9.342, atol=1e-3)
 
     def test_envelope_multi_reaction_objective(self, model):
         obj = {model.reactions.EX_ac_e: 1,
@@ -845,9 +845,10 @@ class TestProductionEnvelope:
     def test_envelope_two(self, model):
         df = production_envelope(model, ["EX_glc__D_e", "EX_o2_e"],
                                  objective="EX_ac_e")
-        assert abs(numpy.sum(df.carbon_yield) - 83.579) < 0.001
-        assert abs(numpy.sum(df.flux) - 1737.466) < 0.001
-        assert abs(numpy.sum(df.mass_yield) - 82.176) < 0.001
+        assert numpy.isclose(df["flux_maximum"].sum(), 1737.466, atol=1e-3)
+        assert numpy.isclose(df["carbon_yield_maximum"].sum(), 83.579,
+                             atol=1e-3)
+        assert numpy.isclose(df["mass_yield_maximum"].sum(), 82.176, atol=1e-3)
 
 
 class TestReactionUtils:


### PR DESCRIPTION
fix #582 

So far this PR re-organizes the code for `production_envelope` a little bit and catches the potential `ZeroDivisionError` in `mass_yield`. However, I suggest the following further changes which is why I marked this PR as WIP.

1. Allow specification of more than one carbon source.
2. Transform the resulting data frame into wide format (the way it's done in cameo) meaning that maximum and minimum are separate columns.
3. Use the configured solver threshold to convert below threshold values to zero.