### PR TITLE
Add some helpers for media

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -24,6 +24,7 @@ from cobra.util.solver import (
     add_cons_vars_to_problem, remove_cons_vars_from_problem, choose_solver,
     check_solver_status, assert_optimal)
 from cobra.util.util import AutoVivification, format_long_string
+from cobra.media import exchanges
 
 LOGGER = logging.getLogger(__name__)
 
@@ -233,18 +234,21 @@ class Model(Object):
             elif reaction.products:
                 reaction.upper_bound = bound
 
+        exchange_rxns = set(self.exchanges)
+
         # Set the given media bounds
         media_rxns = list()
         for rxn_id, bound in iteritems(medium):
             rxn = self.reactions.get_by_id(rxn_id)
+            if rxn not in exchange_rxns:
+                LOGGER.warn("%s does not seem to be an" % rxn.id +
+                            " an exchange reaction. Applying bounds anyway.")
             media_rxns.append(rxn)
             set_active_bound(rxn, bound)
-
-        boundary_rxns = set(self.exchanges)
         media_rxns = set(media_rxns)
 
         # Turn off reactions not present in media
-        for rxn in (boundary_rxns - media_rxns):
+        for rxn in (exchange_rxns - media_rxns):
             set_active_bound(rxn, 0)
 
     def __add__(self, other_model):
@@ -729,7 +733,16 @@ class Model(Object):
     def exchanges(self):
         """Exchange reactions in model.
 
-        Reactions that either don't have products or substrates.
+        Reactions that exchange mass with the exterior. Uses annotations
+        and heuristics to exclude non-exchanges such as sink reactions.
+        """
+        return exchanges(self, ext_compartment=None)
+
+    @property
+    def boundary(self):
+        """Boundary reactions in the model.
+
+        Reactions that either have no substrate or product.
         """
         return [rxn for rxn in self.reactions if rxn.boundary]
 

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -9,8 +9,7 @@ from six import iteritems
 from optlang.symbolics import Zero
 
 from cobra.core import Metabolite, Reaction, get_solution
-from cobra.util import (linear_reaction_coefficients,
-                        create_stoichiometric_matrix, nullspace)
+from cobra.util import create_stoichiometric_matrix, nullspace
 from cobra.manipulation.modify import convert_to_irreversible
 
 
@@ -84,6 +83,7 @@ def add_loopless(model, zero_cutoff=1e-12):
 def _add_cycle_free(model, fluxes):
     """Add constraints for CycleFreeFlux."""
     model.objective = Zero
+    objective_vars = []
     for rxn in model.reactions:
         flux = fluxes[rxn.id]
         if rxn.boundary:
@@ -91,14 +91,13 @@ def _add_cycle_free(model, fluxes):
             continue
         if flux >= 0:
             rxn.lower_bound = max(0, rxn.lower_bound)
-            model.objective.set_linear_coefficients(
-                {rxn.forward_variable: 1, rxn.reverse_variable: -1})
+            objective_vars.append(rxn.forward_variable)
         else:
             rxn.upper_bound = min(0, rxn.upper_bound)
-            model.objective.set_linear_coefficients(
-                {rxn.forward_variable: -1, rxn.reverse_variable: 1})
+            objective_vars.append(rxn.reverse_variable)
 
-    model.solver.objective.direction = "min"
+    model.objective.set_linear_coefficients(dict.fromkeys(objective_vars, 1.0))
+    model.objective.direction = "min"
 
 
 def loopless_solution(model, fluxes=None):
@@ -117,10 +116,6 @@ def loopless_solution(model, fluxes=None):
         A dictionary {rxn_id: flux} that assigns a flux to each reaction. If
         not None will use the provided flux values to obtain a close loopless
         solution.
-        Note that this requires a linear objective function involving
-        only the model reactions. This is the case if
-        `linear_reaction_coefficients(model)` is a correct representation of
-        the objective.
 
     Returns
     -------
@@ -131,12 +126,13 @@ def loopless_solution(model, fluxes=None):
 
     Notes
     -----
-
     The returned flux solution has the following properties:
 
     - it contains the minimal number of loops possible and no loops at all if
       all flux bounds include zero
-    - it has the same exact objective value as the previous solution
+    - it has an objective value close to the original one and the same
+      objective value id the objective expression can not form a cycle
+      (which is usually true since it consumes metabolites)
     - it has the same exact exchange fluxes as the previous solution
     - all fluxes have the same sign (flow in the same direction) as the
       previous solution
@@ -154,19 +150,17 @@ def loopless_solution(model, fluxes=None):
     if fluxes is None:
         sol = model.optimize(objective_sense=None)
         fluxes = sol.fluxes
-        obj_val = sol.objective_value
-    else:
-        coefs = linear_reaction_coefficients(model)
-        obj_val = sum(coefs[rxn] * fluxes[rxn.id] for rxn in coefs)
 
     with model:
         prob = model.problem
+        # Needs one fixed bound for cplex...
         loopless_obj_constraint = prob.Constraint(
             model.objective.expression,
-            lb=obj_val, ub=obj_val, name="loopless_obj_constraint")
+            lb=-1e32, name="loopless_obj_constraint")
         model.add_cons_vars([loopless_obj_constraint])
         _add_cycle_free(model, fluxes)
         solution = model.optimize(objective_sense=None)
+        solution.objective_value = loopless_obj_constraint.primal
 
     return solution
 
@@ -203,6 +197,7 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
     """
     current = model.objective.value
     sol = get_solution(model)
+    objective_dir = model.objective.direction
 
     # boundary reactions can not be part of cycles
     if reaction.boundary:
@@ -212,10 +207,8 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
             return current
 
     with model:
-        model.objective = 1.0 * model.variables.fva_old_objective
         _add_cycle_free(model, sol.fluxes)
-        model.slim_optimize()
-        flux = reaction.flux
+        flux = model.slim_optimize()
 
         # If the previous optimum is maintained in the loopless solution it was
         # loopless and we are done
@@ -242,10 +235,11 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
                 rxn.bounds = max(0, rxn.lower_bound), min(0, rxn.upper_bound)
 
         if solution:
-            best = model.optimize(objective_sense=None)
+            best = model.optimize()
         else:
             model.slim_optimize()
             best = reaction.flux
+    model.objective.direction = objective_dir
     return best
 
 

--- a/cobra/media/__init__.py
+++ b/cobra/media/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+"""Imports for the media module."""
+
+from cobra.media.media import exchanges, minimal_medium

--- a/cobra/media/__init__.py
+++ b/cobra/media/__init__.py
@@ -2,4 +2,5 @@
 
 """Imports for the media module."""
 
-from cobra.media.media import exchanges, minimal_medium
+from cobra.media.media import (exchanges, minimal_medium,
+                               external_compartment, is_exchange)

--- a/cobra/media/media.py
+++ b/cobra/media/media.py
@@ -1,0 +1,210 @@
+"""Manages functions for growth media analysis and manipulation."""
+
+from collections import Counter
+from sympy.core.singleton import S
+from optlang.interface import OPTIMAL
+import numpy as np
+import pandas as pd
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+default_excludes = ["biosynthesis", "transcription", "replication", "sink",
+                    "demand", "DM_", "SN_", "SK_"]
+"""A list of sub-strings in reaction IDs that usually indicate that
+the reaction is *not* an exchange reaction."""
+
+
+def external_compartment(model):
+    """Find the external compartment in the model.
+
+    Uses a simple heuristic where the external compartment should be the one
+    with the most exchange reactions.
+
+    Arguments
+    ---------
+    model : cobra.Model
+        A cobra model.
+
+    Returns
+    -------
+    str
+        The putative external compartment.
+    """
+    counts = Counter(tuple(r.compartments)[0] for r in model.exchanges)
+    return counts.most_common(1)[0][0]
+
+
+def exchanges(model, ext_compartment=None):
+    """Find exchange reactions.
+
+    Arguments
+    ---------
+    model : cobra.Model
+        A cobra model.
+    ext_compartment : str or None
+        The id for the external compartment. If None will be detected
+        automatically.
+
+    Returns
+    -------
+    list of cobra.reaction
+        A list of likely exchange reactions.
+    """
+    if ext_compartment is None:
+        ext_compartment = external_compartment(model)
+    exchange_reactions = model.reactions.query(
+            lambda r: (r.boundary and not
+                       any(ex in r.id for ex in default_excludes) and
+                       ext_compartment in r.compartments))
+    return exchange_reactions
+
+
+def add_linear_obj(model):
+    """Add a linear version of a minimal medium to the model solver.
+
+    Changes the optimization objective to finding the growth medium requiring
+    the smallest total import flux::
+
+        minimize sum |r_i| for r_i in import_reactions
+
+    Arguments
+    ---------
+    model : cobra.Model
+        The model to modify.
+    """
+    coefs = {}
+    for rxn in model.exchanges:
+        export = len(rxn.reactants) == 1
+        if export:
+            coefs[rxn.reverse_variable] = 1
+        else:
+            coefs[rxn.forward_variable] = 1
+    model.objective.set_linear_coefficients(coefs)
+    model.objective.direction = "min"
+
+
+def add_mip_obj(model):
+    """Add a mixed-integer version of a minimal medium to the model.
+
+    Changes the optimization objective to finding the medium with the least
+    components::
+
+        minimize size(R) where R part of import_reactions
+
+    Arguments
+    ---------
+    model : cobra.model
+        The model to modify.
+    """
+    if len(model.variables) > 1e4:
+        LOGGER.warning("the MIP version of minimal media is extremely slow for"
+                       " models that large :(")
+    boundary_rxns = model.exchanges
+    M = max(np.max(np.abs(r.bounds)) for r in boundary_rxns)
+    prob = model.problem
+    coefs = {}
+    to_add = []
+    for rxn in boundary_rxns:
+        export = len(rxn.reactants) == 1
+        indicator = prob.Variable("ind_" + rxn.id, lb=0, ub=1, type="binary")
+        if export:
+            vrv = rxn.reverse_variable
+            indicator_const = prob.Constraint(
+                vrv - indicator * M, ub=0, name="ind_constraint_" + rxn.name)
+        else:
+            vfw = rxn.forward_variable
+            indicator_const = prob.Constraint(
+                vfw - indicator * M, ub=0, name="ind_constraint_" + rxn.name)
+        to_add.extend([indicator, indicator_const])
+        coefs[indicator] = 1
+    model.add_cons_vars(to_add)
+    model.solver.update()
+    model.objective.set_linear_coefficients(coefs)
+    model.objective.direction = "min"
+
+
+def minimal_medium(model, min_growth=0.1, exports=False,
+                   minimize_components=False, open_exchanges=False):
+    """Find the minimal growth medium for the model.
+
+    Finds the minimal growth medium for the model which allows for
+    model as well as individual growth. Here, a minimal medium can either
+    be the medium requiring the smallest total import flux or the medium
+    requiring the least components (ergo ingredients), which will be much
+    slower.
+
+    Arguments
+    ---------
+    model : cobra.model
+        The model to modify.
+    min_growth : positive float or array-like object.
+        The minimum growth rate (objective) that has to be achieved.
+    exports : boolean
+        Whether to include export fluxes in the returned medium. Defaults to
+        False which will only return import fluxes.
+    minimize_components : boolean
+        Whether to minimize the number of components instead of the total
+        import flux. Might be more intuitive if set to True but may also be
+        slow to calculate for large communities.
+    open_exchanges : boolean or number
+        Whether to ignore currently set bounds and make all exchange reactions
+        in the model possible. If set to a number all exchange reactions will
+        be opened with (-number, number) as bounds.
+
+    Returns
+    -------
+    pandas.Series or None
+        A series {rid: flux} giving the import flux for each required import
+        reaction and (optionally) the associated export fluxes. All exchange
+        fluxes are oriented into the import reaction e.g. positive fluxes
+        denote imports and negative fluxes exports. Returns None if the
+        minimization is infeasible.
+
+    """
+    LOGGER.info("calculating minimal medium for %s" % model.id)
+    boundary_rxns = exchanges(model)
+    if isinstance(open_exchanges, bool):
+        open_bound = 1000
+    else:
+        open_bound = open_exchanges
+
+    with model as mod:
+        if open_exchanges:
+            LOGGER.info("opening exchanges for %d imports" %
+                        len(boundary_rxns))
+            for rxn in boundary_rxns:
+                rxn.bounds = (-open_bound, open_bound)
+        LOGGER.info("applying growth rate constraints")
+        obj_const = mod.problem.Constraint(
+            mod.objective.expression, lb=min_growth,
+            name="medium_obj_constraint")
+        mod.add_cons_vars([obj_const])
+        mod.solver.update()
+        mod.objective = S.Zero
+        LOGGER.info("adding new media objective")
+        if minimize_components:
+            add_mip_obj(mod)
+        else:
+            add_linear_obj(mod)
+        mod.solver.optimize()
+        if mod.solver.status != OPTIMAL:
+            LOGGER.warning("minimization of medium was infeasible")
+            return None
+
+        LOGGER.info("formatting medium")
+        medium = pd.Series()
+        tol = model.solver.configuration.tolerances.feasibility
+        for rxn in boundary_rxns:
+            export = len(rxn.reactants) == 1
+            flux = rxn.flux
+            if abs(flux) < tol:
+                continue
+            if export:
+                medium[rxn.id] = -flux
+            elif not export:
+                medium[rxn.id] = flux
+        if not exports:
+            medium = medium[medium > 0]
+
+    return medium

--- a/cobra/media/media.py
+++ b/cobra/media/media.py
@@ -1,7 +1,7 @@
 """Manages functions for growth media analysis and manipulation."""
 
 from collections import Counter
-from sympy.core.singleton import S
+from optlang.symbolics import Zero
 from optlang.interface import OPTIMAL
 import numpy as np
 import pandas as pd
@@ -231,7 +231,7 @@ def minimal_medium(model, min_growth=0.1, exports=False,
             name="medium_obj_constraint")
         mod.add_cons_vars([obj_const])
         mod.solver.update()
-        mod.objective = S.Zero
+        mod.objective = Zero
         LOGGER.info("adding new media objective")
         tol = mod.solver.configuration.tolerances.feasibility
 
@@ -244,7 +244,7 @@ def minimal_medium(model, min_growth=0.1, exports=False,
             if mod.solver.status != OPTIMAL:
                 LOGGER.warning("minimization of medium was infeasible")
                 return None
-            exclusion = mod.problem.Constraint(S.Zero, ub=0)
+            exclusion = mod.problem.Constraint(Zero, ub=0)
             mod.add_cons_vars([exclusion])
             mod.solver.update()
             media = []

--- a/cobra/media/media.py
+++ b/cobra/media/media.py
@@ -191,12 +191,14 @@ def minimal_medium(model, min_growth=0.1, exports=False,
 
     Returns
     -------
-    pandas.Series or None
+    pandas.Series, pandas.DataFrame or None
         A series {rid: flux} giving the import flux for each required import
         reaction and (optionally) the associated export fluxes. All exchange
         fluxes are oriented into the import reaction e.g. positive fluxes
-        denote imports and negative fluxes exports. Returns None if the
-        minimization is infeasible.
+        denote imports and negative fluxes exports. If `minimize_components`
+        is a number larger 1 may return a DataFrame where each column is a
+        minimal medium. Returns None if the minimization is infeasible
+        (for instance if min_growth > maximum growth rate).
 
     Notes
     -----
@@ -252,7 +254,7 @@ def minimal_medium(model, min_growth=0.1, exports=False,
                 if len(seen) > 0:
                     exclusion.set_linear_coefficients(
                         dict.fromkeys(vars, 1))
-                    exclusion.ub = len(seen) - 1
+                    exclusion.ub = best - 1
                 num_components = mod.slim_optimize()
                 if mod.solver.status != OPTIMAL or num_components > best:
                     break

--- a/cobra/media/media.py
+++ b/cobra/media/media.py
@@ -74,7 +74,7 @@ def add_linear_obj(model):
         The model to modify.
     """
     coefs = {}
-    for rxn in model.exchanges:
+    for rxn in exchanges(model):
         export = len(rxn.reactants) == 1
         if export:
             coefs[rxn.reverse_variable] = 1
@@ -100,28 +100,63 @@ def add_mip_obj(model):
     if len(model.variables) > 1e4:
         LOGGER.warning("the MIP version of minimal media is extremely slow for"
                        " models that large :(")
-    boundary_rxns = model.exchanges
-    M = max(np.max(np.abs(r.bounds)) for r in boundary_rxns)
+    exchange_rxns = exchanges(model)
+    M = max(np.max(np.abs(r.bounds)) for r in exchange_rxns)
     prob = model.problem
     coefs = {}
     to_add = []
-    for rxn in boundary_rxns:
+    for rxn in exchange_rxns:
         export = len(rxn.reactants) == 1
         indicator = prob.Variable("ind_" + rxn.id, lb=0, ub=1, type="binary")
         if export:
             vrv = rxn.reverse_variable
             indicator_const = prob.Constraint(
-                vrv - indicator * M, ub=0, name="ind_constraint_" + rxn.name)
+                vrv - indicator * M, ub=0, name="ind_constraint_" + rxn.id)
         else:
             vfw = rxn.forward_variable
             indicator_const = prob.Constraint(
-                vfw - indicator * M, ub=0, name="ind_constraint_" + rxn.name)
+                vfw - indicator * M, ub=0, name="ind_constraint_" + rxn.id)
         to_add.extend([indicator, indicator_const])
         coefs[indicator] = 1
     model.add_cons_vars(to_add)
     model.solver.update()
     model.objective.set_linear_coefficients(coefs)
     model.objective.direction = "min"
+
+
+def _as_medium(exchanges, tolerance=1e-6, exports=False):
+    """Convert a solution to medium.
+
+    Arguments
+    ---------
+    exchanges : list of cobra.reaction
+        The exchange reactions to consider.
+    tolerance : positive double
+        The absolute tolerance for fluxes. Fluxes with an absolute value
+        smaller than this number will be ignored.
+    exports : bool
+        Whether to return export fluxes as well.
+
+    Returns
+    -------
+    pandas.Series
+        The "medium", meaning all active import fluxes in the solution.
+    """
+    LOGGER.info("formatting medium")
+    medium = pd.Series()
+    for rxn in exchanges:
+        export = len(rxn.reactants) == 1
+        flux = rxn.flux
+        if abs(flux) < tolerance:
+            continue
+        if export:
+            medium[rxn.id] = -flux
+        elif not export:
+            medium[rxn.id] = flux
+    if not exports:
+        medium = medium[medium > 0]
+
+    return medium
 
 
 def minimal_medium(model, min_growth=0.1, exports=False,
@@ -143,10 +178,12 @@ def minimal_medium(model, min_growth=0.1, exports=False,
     exports : boolean
         Whether to include export fluxes in the returned medium. Defaults to
         False which will only return import fluxes.
-    minimize_components : boolean
+    minimize_components : boolean or positive int
         Whether to minimize the number of components instead of the total
         import flux. Might be more intuitive if set to True but may also be
-        slow to calculate for large communities.
+        slow to calculate for large communities. If set to a number `n` will
+        return up to `n` alternative solutions all with the same number of
+        components.
     open_exchanges : boolean or number
         Whether to ignore currently set bounds and make all exchange reactions
         in the model possible. If set to a number all exchange reactions will
@@ -161,9 +198,20 @@ def minimal_medium(model, min_growth=0.1, exports=False,
         denote imports and negative fluxes exports. Returns None if the
         minimization is infeasible.
 
+    Notes
+    -----
+    Due to numerical issues the `minimize_components` option will usually only
+    minimized the number or "large" import fluxes. Specifically, the detection
+    limit is given by `integrality_tolerance * max_bound` where `max_bound` is
+    the largest bound on an import reaction. Thus, if you are interested
+    in small import fluxes as well you may have to adjust the integrality
+    tolerance at first with
+    `model.solver.configuration.tolerances.integrality = 1e-7` for instance.
+    However, this will be *very* slow for large models especially with GLPK.
+
     """
     LOGGER.info("calculating minimal medium for %s" % model.id)
-    boundary_rxns = exchanges(model)
+    exchange_rxns = exchanges(model)
     if isinstance(open_exchanges, bool):
         open_bound = 1000
     else:
@@ -172,8 +220,8 @@ def minimal_medium(model, min_growth=0.1, exports=False,
     with model as mod:
         if open_exchanges:
             LOGGER.info("opening exchanges for %d imports" %
-                        len(boundary_rxns))
-            for rxn in boundary_rxns:
+                        len(exchange_rxns))
+            for rxn in exchange_rxns:
                 rxn.bounds = (-open_bound, open_bound)
         LOGGER.info("applying growth rate constraints")
         obj_const = mod.problem.Constraint(
@@ -183,28 +231,44 @@ def minimal_medium(model, min_growth=0.1, exports=False,
         mod.solver.update()
         mod.objective = S.Zero
         LOGGER.info("adding new media objective")
+        tol = mod.solver.configuration.tolerances.feasibility
+
         if minimize_components:
             add_mip_obj(mod)
+            if isinstance(minimize_components, bool):
+                minimize_components = 1
+            seen = set()
+            best = num_components = mod.slim_optimize()
+            if mod.solver.status != OPTIMAL:
+                LOGGER.warning("minimization of medium was infeasible")
+                return None
+            exclusion = mod.problem.Constraint(S.Zero, ub=0)
+            mod.add_cons_vars([exclusion])
+            mod.solver.update()
+            media = []
+            for i in range(minimize_components):
+                LOGGER.info("finding alternative medium #%d" % (i + 1))
+                vars = [mod.variables["ind_" + s] for s in seen]
+                if len(seen) > 0:
+                    exclusion.set_linear_coefficients(
+                        dict.fromkeys(vars, 1))
+                    exclusion.ub = len(seen) - 1
+                num_components = mod.slim_optimize()
+                if mod.solver.status != OPTIMAL or num_components > best:
+                    break
+                medium = _as_medium(exchange_rxns, tol, exports=exports)
+                media.append(medium)
+                seen.update(medium.index[medium > 0])
+            if len(media) > 1:
+                medium = pd.concat(media, axis=1).fillna(0.0)
+            else:
+                medium = media[0]
         else:
             add_linear_obj(mod)
-        mod.solver.optimize()
-        if mod.solver.status != OPTIMAL:
-            LOGGER.warning("minimization of medium was infeasible")
-            return None
-
-        LOGGER.info("formatting medium")
-        medium = pd.Series()
-        tol = model.solver.configuration.tolerances.feasibility
-        for rxn in boundary_rxns:
-            export = len(rxn.reactants) == 1
-            flux = rxn.flux
-            if abs(flux) < tol:
-                continue
-            if export:
-                medium[rxn.id] = -flux
-            elif not export:
-                medium[rxn.id] = flux
-        if not exports:
-            medium = medium[medium > 0]
+            mod.slim_optimize()
+            if mod.solver.status != OPTIMAL:
+                LOGGER.warning("minimization of medium was infeasible")
+                return None
+            medium = _as_medium(exchange_rxns, tol, exports=exports)
 
     return medium

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -485,11 +485,6 @@ class TestCobraFluxAnalysis:
         fluxes = model.optimize().fluxes
         ll_solution = loopless_solution(model, fluxes=fluxes)
         assert len(ll_solution.fluxes) == len(model.reactions)
-        fluxes["Biomass_Ecoli_core"] = 1
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning):
-                loopless_solution(model, fluxes=fluxes)
 
     def test_add_loopless(self, ll_test_model):
         add_loopless(ll_test_model)

--- a/cobra/test/test_media.py
+++ b/cobra/test/test_media.py
@@ -14,6 +14,13 @@ class TestExchangeDetection:
         ex = media.exchanges(model)
         assert all(r.id.startswith("EX_") for r in ex)
 
+    def test_sbo_terms(Self, model):
+        assert not media.is_exchange(model.reactions.ATPM, "e")
+        model.reactions.ATPM.annotation["SBO"] = "SBO:0000627"
+        assert media.is_exchange(model.reactions.ATPM, "bla")
+        model.reactions.ATPM.annotation["SBO"] = "SBO:0000632"
+        assert not media.is_exchange(model.reactions.ATPM, "e")
+
 
 class TestMinimalMedia:
 

--- a/cobra/test/test_media.py
+++ b/cobra/test/test_media.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
+import pandas as pd
 import cobra.media.media as media
 
 
@@ -31,6 +32,14 @@ class TestMinimalMedia:
         assert len(medium) <= 3
         assert all(medium > 1e-6)
 
+    def test_medium_alternative_mip(self, model):
+        medium = media.minimal_medium(model, 0.8, minimize_components=5,
+                                      open_exchanges=True)
+        assert isinstance(medium, pd.DataFrame)
+        assert medium.shape[1] == 5
+        assert all((medium > 0).sum() <= 4)
+        assert all(medium.sum(axis=1) > 1e-6)
+
     def test_benchmark_medium_linear(self, model, benchmark):
         benchmark(media.minimal_medium, model, 0.8)
 
@@ -46,6 +55,8 @@ class TestMinimalMedia:
     def test_open_exchanges(self, model):
         model.reactions.EX_glc__D_e.bounds = 0, 0
         medium = media.minimal_medium(model, 0.8)
+        assert medium is None
+        medium = media.minimal_medium(model, 0.8, minimize_components=True)
         assert medium is None
 
         medium = media.minimal_medium(model, 0.8, open_exchanges=True)

--- a/cobra/test/test_media.py
+++ b/cobra/test/test_media.py
@@ -36,8 +36,9 @@ class TestMinimalMedia:
         medium = media.minimal_medium(model, 0.8, minimize_components=5,
                                       open_exchanges=True)
         assert isinstance(medium, pd.DataFrame)
+        assert medium.shape[0] >= 5
         assert medium.shape[1] == 5
-        assert all((medium > 0).sum() <= 4)
+        assert all((medium > 0).sum() == 3)
         assert all(medium.sum(axis=1) > 1e-6)
 
     def test_benchmark_medium_linear(self, model, benchmark):

--- a/cobra/test/test_media.py
+++ b/cobra/test/test_media.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+import cobra.media.media as media
+
+
+class TestExchangeDetection:
+
+    def test_external_compartment(self, model):
+        assert media.external_compartment(model) == "e"
+
+    def test_exchanges(self, model):
+        ex = media.exchanges(model)
+        assert all(r.id.startswith("EX_") for r in ex)
+
+
+class TestMinimalMedia:
+
+    def test_medium_linear(self, model):
+        medium = media.minimal_medium(model, 0.8)
+        assert len(medium) <= 4
+        assert all(medium > 1e-6)
+
+    def test_medium_mip(self, model):
+        medium = media.minimal_medium(model, 0.8, minimize_components=True)
+        assert len(medium) <= 4
+        assert all(medium > 1e-6)
+
+        # Anaerobic growth
+        medium = media.minimal_medium(model, 0.1, minimize_components=True)
+        assert len(medium) <= 3
+        assert all(medium > 1e-6)
+
+    def test_benchmark_medium_linear(self, model, benchmark):
+        benchmark(media.minimal_medium, model, 0.8)
+
+    def test_benchmark_medium_mip(self, model, benchmark):
+        benchmark(media.minimal_medium, model, 0.8, True)
+
+    def test_medium_exports(self, model):
+        medium = media.minimal_medium(model, 0.8, exports=True,
+                                      minimize_components=True)
+        assert len(medium) > 4
+        assert any(medium < -1e-6)
+
+    def test_open_exchanges(self, model):
+        model.reactions.EX_glc__D_e.bounds = 0, 0
+        medium = media.minimal_medium(model, 0.8)
+        assert medium is None
+
+        medium = media.minimal_medium(model, 0.8, open_exchanges=True)
+        assert len(medium) >= 3
+        medium = media.minimal_medium(model, 0.8, open_exchanges=100)
+        assert len(medium) >= 3

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -605,6 +605,10 @@ class TestCobraModel:
         assert set(model.exchanges) == set([rxn for rxn in model.reactions
                                             if rxn.id.startswith("EX")])
 
+    def test_boundary_reactions(self, model):
+        assert set(model.boundary) == set(model.reactions.query(
+            lambda r: r.boundary))
+
     @pytest.mark.parametrize("metabolites, reaction_type, prefix", [
         ("exchange", "exchange", "EX_"),
         ("demand", "demand", "DM_"),

--- a/documentation_builder/cobra.core.rst
+++ b/documentation_builder/cobra.core.rst
@@ -1,83 +1,83 @@
-cobra.core package
-==================
+cobra\.core package
+===================
 
 Submodules
 ----------
 
-cobra.core.arraybasedmodel module
----------------------------------
+cobra\.core\.arraybasedmodel module
+-----------------------------------
 
 .. automodule:: cobra.core.arraybasedmodel
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.dictlist module
---------------------------
+cobra\.core\.dictlist module
+----------------------------
 
 .. automodule:: cobra.core.dictlist
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.formula module
--------------------------
+cobra\.core\.formula module
+---------------------------
 
 .. automodule:: cobra.core.formula
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.gene module
-----------------------
+cobra\.core\.gene module
+------------------------
 
 .. automodule:: cobra.core.gene
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.metabolite module
-----------------------------
+cobra\.core\.metabolite module
+------------------------------
 
 .. automodule:: cobra.core.metabolite
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.model module
------------------------
+cobra\.core\.model module
+-------------------------
 
 .. automodule:: cobra.core.model
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.object module
-------------------------
+cobra\.core\.object module
+--------------------------
 
 .. automodule:: cobra.core.object
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.reaction module
---------------------------
+cobra\.core\.reaction module
+----------------------------
 
 .. automodule:: cobra.core.reaction
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.solution module
---------------------------
+cobra\.core\.solution module
+----------------------------
 
 .. automodule:: cobra.core.solution
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.core.species module
--------------------------
+cobra\.core\.species module
+---------------------------
 
 .. automodule:: cobra.core.species
     :members:

--- a/documentation_builder/cobra.design.rst
+++ b/documentation_builder/cobra.design.rst
@@ -1,11 +1,11 @@
-cobra.design package
-====================
+cobra\.design package
+=====================
 
 Submodules
 ----------
 
-cobra.design.design_algorithms module
--------------------------------------
+cobra\.design\.design\_algorithms module
+----------------------------------------
 
 .. automodule:: cobra.design.design_algorithms
     :members:

--- a/documentation_builder/cobra.flux_analysis.rst
+++ b/documentation_builder/cobra.flux_analysis.rst
@@ -1,99 +1,99 @@
-cobra.flux_analysis package
-===========================
+cobra\.flux\_analysis package
+=============================
 
 Submodules
 ----------
 
-cobra.flux_analysis.deletion_worker module
-------------------------------------------
+cobra\.flux\_analysis\.deletion\_worker module
+----------------------------------------------
 
 .. automodule:: cobra.flux_analysis.deletion_worker
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.double_deletion module
-------------------------------------------
+cobra\.flux\_analysis\.double\_deletion module
+----------------------------------------------
 
 .. automodule:: cobra.flux_analysis.double_deletion
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.gapfilling module
--------------------------------------
+cobra\.flux\_analysis\.gapfilling module
+----------------------------------------
 
 .. automodule:: cobra.flux_analysis.gapfilling
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.loopless module
------------------------------------
+cobra\.flux\_analysis\.loopless module
+--------------------------------------
 
 .. automodule:: cobra.flux_analysis.loopless
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.moma module
--------------------------------
+cobra\.flux\_analysis\.moma module
+----------------------------------
 
 .. automodule:: cobra.flux_analysis.moma
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.parsimonious module
----------------------------------------
+cobra\.flux\_analysis\.parsimonious module
+------------------------------------------
 
 .. automodule:: cobra.flux_analysis.parsimonious
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.phenotype_phase_plane module
-------------------------------------------------
+cobra\.flux\_analysis\.phenotype\_phase\_plane module
+-----------------------------------------------------
 
 .. automodule:: cobra.flux_analysis.phenotype_phase_plane
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.reaction module
------------------------------------
+cobra\.flux\_analysis\.reaction module
+--------------------------------------
 
 .. automodule:: cobra.flux_analysis.reaction
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.sampling module
------------------------------------
+cobra\.flux\_analysis\.sampling module
+--------------------------------------
 
 .. automodule:: cobra.flux_analysis.sampling
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.single_deletion module
-------------------------------------------
+cobra\.flux\_analysis\.single\_deletion module
+----------------------------------------------
 
 .. automodule:: cobra.flux_analysis.single_deletion
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.summary module
-----------------------------------
+cobra\.flux\_analysis\.summary module
+-------------------------------------
 
 .. automodule:: cobra.flux_analysis.summary
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.flux_analysis.variability module
---------------------------------------
+cobra\.flux\_analysis\.variability module
+-----------------------------------------
 
 .. automodule:: cobra.flux_analysis.variability
     :members:

--- a/documentation_builder/cobra.io.rst
+++ b/documentation_builder/cobra.io.rst
@@ -1,37 +1,53 @@
-cobra.io package
-================
+cobra\.io package
+=================
 
 Submodules
 ----------
 
-cobra.io.json module
---------------------
+cobra\.io\.dict module
+----------------------
+
+.. automodule:: cobra.io.dict
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+cobra\.io\.json module
+----------------------
 
 .. automodule:: cobra.io.json
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.io.mat module
--------------------
+cobra\.io\.mat module
+---------------------
 
 .. automodule:: cobra.io.mat
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.io.sbml module
---------------------
+cobra\.io\.sbml module
+----------------------
 
 .. automodule:: cobra.io.sbml
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.io.sbml3 module
----------------------
+cobra\.io\.sbml3 module
+-----------------------
 
 .. automodule:: cobra.io.sbml3
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+cobra\.io\.yaml module
+----------------------
+
+.. automodule:: cobra.io.yaml
     :members:
     :undoc-members:
     :show-inheritance:

--- a/documentation_builder/cobra.manipulation.rst
+++ b/documentation_builder/cobra.manipulation.rst
@@ -1,35 +1,35 @@
-cobra.manipulation package
-==========================
+cobra\.manipulation package
+===========================
 
 Submodules
 ----------
 
-cobra.manipulation.annotate module
-----------------------------------
+cobra\.manipulation\.annotate module
+------------------------------------
 
 .. automodule:: cobra.manipulation.annotate
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.manipulation.delete module
---------------------------------
+cobra\.manipulation\.delete module
+----------------------------------
 
 .. automodule:: cobra.manipulation.delete
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.manipulation.modify module
---------------------------------
+cobra\.manipulation\.modify module
+----------------------------------
 
 .. automodule:: cobra.manipulation.modify
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.manipulation.validate module
-----------------------------------
+cobra\.manipulation\.validate module
+------------------------------------
 
 .. automodule:: cobra.manipulation.validate
     :members:

--- a/documentation_builder/cobra.media.rst
+++ b/documentation_builder/cobra.media.rst
@@ -1,0 +1,22 @@
+cobra\.media package
+====================
+
+Submodules
+----------
+
+cobra\.media\.media module
+--------------------------
+
+.. automodule:: cobra.media.media
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: cobra.media
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/documentation_builder/cobra.rst
+++ b/documentation_builder/cobra.rst
@@ -11,22 +11,23 @@ Subpackages
     cobra.flux_analysis
     cobra.io
     cobra.manipulation
+    cobra.media
     cobra.topology
     cobra.util
 
 Submodules
 ----------
 
-cobra.config module
--------------------
+cobra\.config module
+--------------------
 
 .. automodule:: cobra.config
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.exceptions module
------------------------
+cobra\.exceptions module
+------------------------
 
 .. automodule:: cobra.exceptions
     :members:

--- a/documentation_builder/cobra.topology.rst
+++ b/documentation_builder/cobra.topology.rst
@@ -1,11 +1,11 @@
-cobra.topology package
-======================
+cobra\.topology package
+=======================
 
 Submodules
 ----------
 
-cobra.topology.reporter_metabolites module
-------------------------------------------
+cobra\.topology\.reporter\_metabolites module
+---------------------------------------------
 
 .. automodule:: cobra.topology.reporter_metabolites
     :members:

--- a/documentation_builder/cobra.util.rst
+++ b/documentation_builder/cobra.util.rst
@@ -1,37 +1,45 @@
-cobra.util package
-==================
+cobra\.util package
+===================
 
 Submodules
 ----------
 
-cobra.util.array module
------------------------
+cobra\.util\.array module
+-------------------------
 
 .. automodule:: cobra.util.array
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.util.context module
--------------------------
+cobra\.util\.context module
+---------------------------
 
 .. automodule:: cobra.util.context
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.util.solver module
-------------------------
+cobra\.util\.solver module
+--------------------------
 
 .. automodule:: cobra.util.solver
     :members:
     :undoc-members:
     :show-inheritance:
 
-cobra.util.util module
-----------------------
+cobra\.util\.util module
+------------------------
 
 .. automodule:: cobra.util.util
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+cobra\.util\.version\_info module
+---------------------------------
+
+.. automodule:: cobra.util.version_info
     :members:
     :undoc-members:
     :show-inheritance:

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -17,6 +17,7 @@ be viewed at `nbviewer
     simulating
     deletions
     phenotype_phase_plane
+    media
     sampling
     loopless
     gapfilling

--- a/documentation_builder/media.ipynb
+++ b/documentation_builder/media.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -46,7 +46,7 @@
        " 'EX_pi_e': 1000.0}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,12 +80,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can simply assign the new medium to the model's `medium` attribute."
+    "You can simply assign the new medium to the model's `medium` attribute. Import reaction that do not appear in the medium dictionary are assumed to be deactivated (fixed at zero flux)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -106,7 +106,7 @@
        " 'EX_pi_e': 1000.0}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -186,7 +186,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,39 +201,162 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default `minimal_medium` minimizes the total import flux (sum of all import fluxes), but you can also request the minimal medium with the least components."
+    "By default `minimal_medium` minimizes the total import flux (sum of all import fluxes), but you can also request the minimal medium with the least components. This is the fastest method which also gives nearly unqiue solutions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "EX_glc__D_e    10.000000\n",
-       "EX_h2o_e        6.934291\n",
-       "EX_nh4_e        1.151308\n",
-       "EX_pi_e         0.776723\n",
+       "EX_nh4_e        3.907885\n",
+       "EX_o2_e        22.707651\n",
+       "EX_pi_e         2.636432\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "minimal_medium(model, min_growth=0.2, minimize_components=True)"
+    "minimal_medium(model, min_growth=0.5, minimize_components=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that minimizing the number of components there are many alternative solutions having the same components but different import fluxes. In fact in this case there are several solutions using four different components. To see more than just one possible solution you can pass a number to the `minimize components` argument (the maximum number of alternative solutions). All alternative solutions will have the same number of components but will differ by at least one component (import flux).\n",
+    "\n",
+    "In order to observe those alternative solutions in that model we will also have to open previously closed exchnage reactions which can be achieved with the `open_exchanges` argument."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>EX_fru_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>521.357767</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_glc__D_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>519.750758</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_gln__L_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>40.698058</td>\n",
+       "      <td>18.848678</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_glu__L_e</th>\n",
+       "      <td>348.101944</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_mal__L_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1000.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_nh4_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>81.026921</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_o2_e</th>\n",
+       "      <td>500.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>EX_pi_e</th>\n",
+       "      <td>66.431529</td>\n",
+       "      <td>54.913419</td>\n",
+       "      <td>12.583458</td>\n",
+       "      <td>54.664344</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      0           1            2           3\n",
+       "EX_fru_e       0.000000  521.357767     0.000000    0.000000\n",
+       "EX_glc__D_e    0.000000    0.000000     0.000000  519.750758\n",
+       "EX_gln__L_e    0.000000   40.698058    18.848678    0.000000\n",
+       "EX_glu__L_e  348.101944    0.000000     0.000000    0.000000\n",
+       "EX_mal__L_e    0.000000    0.000000  1000.000000    0.000000\n",
+       "EX_nh4_e       0.000000    0.000000     0.000000   81.026921\n",
+       "EX_o2_e      500.000000    0.000000     0.000000    0.000000\n",
+       "EX_pi_e       66.431529   54.913419    12.583458   54.664344"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minimal_medium(model, min_growth=0.8, minimize_components=4, open_exchanges=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output will be a pandas DataFrame. This way we can see the many different growth media the model supports. For instance there is only one aerobic medium (#1) and one that uses Fructose instead of Glucose (#2)."
+   ]
   }
  ],
  "metadata": {

--- a/documentation_builder/media.ipynb
+++ b/documentation_builder/media.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Growth media\n",
+    "\n",
+    "One essential part of metabolic modeling is applying an environment that mimicks *in vivo* conditions. In metabolic models that is achieved by controlling which metabolites the the model can consume. For instance if we ran an experiment with *E. coli* in a growth medium without Histidine our model should not be able to import Histidine either.\n",
+    "\n",
+    "However, metabolites are not really variables in a metabolic model so there is no way of telling the model \"there is no Histidine in the growth medium\". As an alternative we can apply constraints to the respective import reactions, thus telling the model \"there is way you can import Histidine\". This can be achieved easily by fixing the respective import reaction at zero flux.\n",
+    "\n",
+    "So in summary, the notion COBRApy has of a growth medium is a bit different. Whereas you might be used to see a growth medium as a collection of metabolites and their concentrations COBRApy sees a growth medium **as a collection of import reactions and their maximum import fluxes**. Let's look at a small example to see how that works.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting and assigning growth media\n",
+    "\n",
+    "We will use a small model of *E. coli* central carbon metabolism which is included in COBRApy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Growth rate = 0.8739215069684307\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'EX_co2_e': 1000.0,\n",
+       " 'EX_glc__D_e': 10.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
+       " 'EX_h_e': 1000.0,\n",
+       " 'EX_nh4_e': 1000.0,\n",
+       " 'EX_o2_e': 1000.0,\n",
+       " 'EX_pi_e': 1000.0}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from cobra.test import create_test_model\n",
+    "\n",
+    "model = create_test_model(\"textbook\")\n",
+    "print(\"Growth rate =\", model.slim_optimize())\n",
+    "model.medium"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see by default the model permits imports for most major components. Now, let us simulate anaerobic growth. For that we will make a copy of the original medium and prohibit the import of Oxygen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "anaerobic = model.medium\n",
+    "anaerobic[\"EX_o2_e\"] = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can simply assign the new medium to the model's `medium` attribute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Growth rate = 0.21166294973531286\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'EX_co2_e': 1000.0,\n",
+       " 'EX_glc__D_e': 10.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
+       " 'EX_h_e': 1000.0,\n",
+       " 'EX_nh4_e': 1000.0,\n",
+       " 'EX_pi_e': 1000.0}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.medium = anaerobic\n",
+    "print(\"Growth rate =\", model.slim_optimize())\n",
+    "model.medium"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see Oxygen does not appear in the medium anymore (missing reactions have an import of zero), however the model still exhibits growth since *E. coli* can grow under anaerobic conditions (albeit with a lower growth rate)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In practice you might want to apply a ceratin growth medium only for one simulation and go back to the previous growth medium afterwards. To make this easy `model.medium` automatically integrates with the COBRApy context manager."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temporary medium = {'EX_co2_e': 1000.0, 'EX_glc__D_e': 10.0, 'EX_h_e': 1000.0, 'EX_h2o_e': 1000.0, 'EX_nh4_e': 1000.0, 'EX_pi_e': 1000.0}\n",
+      "Model medium = {'EX_co2_e': 1000.0, 'EX_glc__D_e': 10.0, 'EX_h_e': 1000.0, 'EX_h2o_e': 1000.0, 'EX_nh4_e': 1000.0, 'EX_o2_e': 1000.0, 'EX_pi_e': 1000.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = create_test_model(\"textbook\")\n",
+    "\n",
+    "with model:\n",
+    "    model.medium = anaerobic\n",
+    "    print(\"Temporary medium =\", model.medium)\n",
+    "\n",
+    "print(\"Model medium =\", model.medium)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see the anaerobic medium was only applied inside the `with` block."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Minimal media\n",
+    "\n",
+    "Sometimes you might be interested which is the minimal medium that still allows for a certain growth rate. A function for this question (and some others) can be found in the `media` module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EX_glc__D_e     7.327496\n",
+       "EX_nh4_e        2.726400\n",
+       "EX_o2_e        10.855375\n",
+       "EX_pi_e         1.839350\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from cobra.media import minimal_medium\n",
+    "\n",
+    "minimal_medium(model, min_growth=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default `minimal_medium` minimizes the total import flux (sum of all import fluxes), but you can also request the minimal medium with the least components."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EX_glc__D_e    10.000000\n",
+       "EX_h2o_e        6.934291\n",
+       "EX_nh4_e        1.151308\n",
+       "EX_pi_e         0.776723\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minimal_medium(model, min_growth=0.2, minimize_components=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -15,7 +15,7 @@ from shutil import copy
 
 def insert_break(lines, break_pos=9):
     """
-    Insert a <!-- more --> tag for larger release notes.
+    Insert a <!--more--> tag for larger release notes.
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ def insert_break(lines, break_pos=9):
         if line_filter(line.strip())]
     if len(newlines) > 0:
         break_pos = newlines[0]
-    lines.insert(break_pos, "<!-- more -->\n")
+    lines.insert(break_pos, "<!--more-->\n")
     return lines
 
 


### PR DESCRIPTION
This is a proposal to add a media module with a few helper functions for media. Major player is the `minimal_medium` function to calculate the smallest total import flux or smallest set of import reactions that allow growth at a specific rate.

This is still missing docs.

## Example:

```Python
In [1]: from cobra.test import create_test_model

In [2]: mod = create_test_model("textbook")

In [3]: from cobra.media import *

In [4]: minimal_medium(mod, min_growth=0.8)
Out[4]: 
EX_glc__D_e    10.000000
EX_nh4_e        4.362240
EX_o2_e        18.579253
EX_pi_e         2.942960
dtype: float64

In [5]: minimal_medium(mod, min_growth=0.1, minimize_components=True)
Out[5]: 
EX_glc__D_e    10.000000
EX_nh4_e        1.042503
EX_pi_e         0.703318
dtype: float64

In [6]: # this is anaerobic growth :D
```

## Discussion points

- this also adds a new `exchanges` function that does some more work to only find exchanges and not demand and sink reactions, so should `model.exchanges` default to that one and `model.boundaries` use the old one?
- currently returns a pandas Series. Is that ok?
