### PR TITLE
Quick fix for summary methods with exchange objective

### DIFF
--- a/cobra/flux_analysis/summary.py
+++ b/cobra/flux_analysis/summary.py
@@ -139,7 +139,7 @@ def model_summary(model, solution=None, threshold=1E-8, fva=None,
     """
     objective_reactions = linear_reaction_coefficients(model)
     boundary_reactions = model.exchanges
-    summary_rxns = set(list(objective_reactions.keys()) + boundary_reactions)
+    summary_rxns = set(objective_reactions.keys()).union(boundary_reactions)
 
     if solution is None:
         model.slim_optimize(error_value=None)

--- a/cobra/flux_analysis/summary.py
+++ b/cobra/flux_analysis/summary.py
@@ -139,7 +139,7 @@ def model_summary(model, solution=None, threshold=1E-8, fva=None,
     """
     objective_reactions = linear_reaction_coefficients(model)
     boundary_reactions = model.exchanges
-    summary_rxns = list(objective_reactions.keys()) + boundary_reactions
+    summary_rxns = set(list(objective_reactions.keys()) + boundary_reactions)
 
     if solution is None:
         model.slim_optimize(error_value=None)

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -620,6 +620,10 @@ class TestCobraFluxAnalysis:
             model.summary()
         self.check_in_line(out.getvalue(), expected_entries)
 
+        with model:
+            model.objective = model.exchanges[0]
+            model.summary()
+
     @pytest.mark.parametrize("fraction", [0.95])
     def test_model_summary_with_fva(self, model, opt_solver, fraction):
         if opt_solver == "optlang-gurobi":


### PR DESCRIPTION
Previously `model.optimize` could get passed a list of reactions in which one reaction was duplicated. This PR fixes #593 by making sure duplicate reactions are dropped prior to calling `model.optimize`.