### PR TITLE
adding reaction `__radd__`

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -608,8 +608,14 @@ class Reaction(Object):
 
         """
         new_reaction = self.copy()
-        new_reaction += other
+        if other == 0:
+            return new_reaction
+        else:
+            new_reaction += other
+
         return new_reaction
+
+    __radd__ = __add__
 
     def __iadd__(self, other):
         self.add_metabolites(other._metabolites, combine=True)

--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -287,6 +287,11 @@ class TestReactions:
             assert gene is not model.genes.get_by_id(gene.id)
             assert gene.model is not model
 
+    def test_radd(self, model):
+        new = sum([model.reactions.PGI, model.reactions.EX_h2o_e])
+        assert new._model is not model
+        assert len(new.metabolites) == 3
+
     def test_mul(self, model):
         new = model.reactions.PGI * 2
         assert set(new.metabolites.values()) == {-2, 2}


### PR DESCRIPTION
Are we still supporting these overloaded methods? If we are, this is a pretty basic change that essentially lets you `sum` an iterable of reactions.

Python's `sum` starts with a 0, and then adds each element in turn. So previously this would fail with
```python
>>> sum(model.metabolites.etoh_c.reactions)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'int' and 'Reaction'
```

This PR
1) allows an `__radd__` function and
2) explicitly allows `reaction + 0`

So now you can 
```python
>>> sum(model.metabolites.etoh_c.reactions).reaction
'etoh_e + h_e + nad_c <=> acald_c + 2.0 h_c + nadh_c'
```
