### PR TITLE
update modify.py for rename_genes

### DIFF
--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -80,8 +80,9 @@ def rename_genes(cobra_model, rename_dict):
         new_gene_present = new_name in cobra_model.genes
         if old_gene_present and new_gene_present:
             old_gene = cobra_model.genes.get_by_id(old_name)
-            remove_genes.append(old_gene)
-            recompute_reactions.update(old_gene._reaction)
+            if old_gene != cobra_model.genes.get_by_id(new_name): # MAC Sept 2017 edit: Added in case not renaming all genes
+                remove_genes.append(old_gene) # indented
+                recompute_reactions.update(old_gene._reaction) # indented
         elif old_gene_present and not new_gene_present:
             # rename old gene to new gene
             gene = cobra_model.genes[gene_index]
@@ -93,7 +94,8 @@ def rename_genes(cobra_model, rename_dict):
             pass
         else:  # not old gene_present and not new_gene_present
             # the new gene's _model will be set by repair
-            cobra_model.genes.append(Gene(new_name))
+            # cobra_model.genes.append(Gene(new_name)) # MAC Sept 2017 edit: Removed, otherwise, adds genes that are unassigned to reactions
+            pass
     cobra_model.repair()
 
     class Renamer(NodeTransformer):

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -541,7 +541,7 @@ class TestCobraFluxAnalysis:
         assert len(result[0]) == 1
         assert len(result[1]) == 1
         assert {i[0].id for i in result} == {"EX_b", "EX_c"}
-
+        
         # somewhat bigger model
         universal = Model("universal_reactions")
         with salmonella as model:

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -6,56 +6,26 @@ import pytest
 from cobra.core import Metabolite, Model, Reaction
 from cobra.manipulation import *
 
-from .conftest import model, salmonella
-
 
 class TestManipulation:
     """Test functions in cobra.manipulation"""
 
-    def test_canonical_form(self, model):
-        solver = 'cglpk'
-        # add G constraint to test
-        g_constr = Metabolite("SUCCt2_2__test_G_constraint")
-        g_constr._constraint_sense = "G"
-        g_constr._bound = 5.0
-        model.reactions.get_by_id("SUCCt2_2").add_metabolites({g_constr: 1})
-        assert abs(model.optimize("maximize", solver=solver).f - 0.855) < 0.001
-        # convert to canonical form
-        model = canonical_form(model)
-        assert abs(
-            model.optimize("maximize", solver=solver).f - 0.855) < 10 ** -3
-
-    def test_canonical_form_minimize(self, model):
-        solver = 'cglpk'
-        # make a minimization problem
-        model.reactions.get_by_id("Biomass_Ecoli_core").lower_bound = 0.5
-        for reaction in model.reactions:
-            reaction.objective_coefficient = reaction.id == "GAPD"
-        assert abs(
-            model.optimize("minimize", solver=solver).f - 6.27) < 10 ** -3
-        # convert to canonical form. Convert minimize to maximize
-        model = canonical_form(model, objective_sense="minimize")
-        assert abs(
-            model.optimize("maximize", solver=solver).f + 6.27) < 10 ** -3
-        # lower bounds should now be <= constraints
-        assert model.reactions.get_by_id(
-            "Biomass_Ecoli_core").lower_bound == 0.0
-
     def test_modify_reversible(self, model):
-        solver = 'cglpk'
+        solver = 'glpk'
+        model.solver = solver
         model1 = model.copy()
-        solution1 = model1.optimize(solver=solver)
+        solution1 = model1.optimize()
         model2 = model.copy()
         convert_to_irreversible(model2)
-        solution2 = model2.optimize(solver=solver)
+        solution2 = model2.optimize()
         assert abs(solution1.f - solution2.f) < 10 ** -3
         revert_to_reversible(model2)
-        solution2_rev = model2.optimize(solver=solver)
+        solution2_rev = model2.optimize()
         assert abs(solution1.f - solution2_rev.f) < 10 ** -3
         # Ensure revert_to_reversible is robust to solutions generated both
         # before and after reversibility conversion, or not solved at all.
         model3 = model.copy()
-        solution3 = model3.optimize(solver=solver)
+        solution3 = model3.optimize()
         convert_to_irreversible(model3)
         revert_to_reversible(model3)
         assert abs(solution1.f - solution3.f) < 10 ** -3
@@ -64,7 +34,7 @@ class TestManipulation:
         glc = model4.reactions.get_by_id("EX_glc__D_e")
         glc.upper_bound = -1
         convert_to_irreversible(model4)
-        solution4 = model4.optimize(solver=solver)
+        solution4 = model4.optimize()
         assert abs(solution1.f - solution4.f) < 10 ** -3
         glc_rev = model4.reactions.get_by_id(glc.notes["reflection"])
         assert glc_rev.lower_bound == 1
@@ -84,7 +54,10 @@ class TestManipulation:
                        "b2465": "b3919", "bar": "2935"}
         modify.rename_genes(model, rename_dict)
         for i in rename_dict:
-            assert i not in model.genes
+            if i == rename_dict[i]:
+                continue
+            else:
+                assert i not in model.genes
         assert "foo" in model.genes
         # make sure the object name was preserved
         assert model.genes.foo.name == original_name
@@ -99,6 +72,8 @@ class TestManipulation:
         assert model.genes.b3919.reactions == {model.reactions.get_by_id(i)
                                                for i in
                                                ("TKT1", "TKT2", "TPI")}
+        assert "world" not in model.genes
+        assert "b1849" in model.genes
 
     def test_gene_knockout_computation(self, salmonella):
         def find_gene_knockout_reactions_fast(cobra_model, gene_list):


### PR DESCRIPTION
updated to permit modifications to a subset of gene ids and to avoid adding genes without GPRs

see below for example motivation:



```python
import cobra
from cobra import Model, Reaction, Metabolite
import os
print cobra.__version__
```

    0.8.2



```python
model = Model()
reaction = Reaction('reaction1')
reaction.name = 'first reaction'
reaction.lower_bound = 0.  # This is the default
reaction.upper_bound = 1000.  # This is the default
met1_c = Metabolite('met1_c', formula='C', name='metabolite 1', compartment='c')
met2_c = Metabolite('met2_c', formula='C', name='metabolite 2', compartment='c')
met3_c = Metabolite('met3_c', formula='C', name='metabolite 3', compartment='c')
met4_c = Metabolite('met4_c', formula='C', name='metabolite 4', compartment='c')
reaction.add_metabolites({met1_c: -1.0, met2_c: 1.0, met3_c: 0, met4_c: 0 })
reaction.gene_reaction_rule = '( old_gene1a and old_gene1b )'
model.add_reactions([reaction])

reaction = Reaction('reaction2')
reaction.name = 'second reaction'
reaction.lower_bound = 0.  # This is the default
reaction.upper_bound = 1000.  # This is the default
reaction.add_metabolites({met1_c: 0, met2_c: -1.0, met3_c: +1.0, met4_c: 0 })
reaction.gene_reaction_rule = '( old_gene2 )'
model.add_reactions([reaction])

reaction = Reaction('reaction3')
reaction.name = 'third reaction'
reaction.lower_bound = 0.  # This is the default
reaction.upper_bound = 1000.  # This is the default
reaction.add_metabolites({met1_c: 0, met2_c: 0, met3_c: -1.0, met4_c: +1.0 })
reaction.gene_reaction_rule = '( old_gene3 )'
model.add_reactions([reaction])

reaction = Reaction('ex1')
reaction.name = 'exchange reaction'
reaction.lower_bound = 0.  # This is the default
reaction.upper_bound = 1000.  # This is the default
reaction.add_metabolites({met1_c: +1.0, met2_c: 0, met3_c: 0, met4_c: 0 })
reaction.gene_reaction_rule = '( old_gene4 or old_gene5 )'
model.add_reactions([reaction])

reaction = Reaction('ex2')
reaction.name = 'exchange reaction'
reaction.lower_bound = 0.  # This is the default
reaction.upper_bound = 1000.  # This is the default
reaction.add_metabolites({met1_c: 0, met2_c: 0, met3_c: 0, met4_c: -1.0 })
model.add_reactions([reaction])

model.objective = 'reaction3'
print "objective reaction:"
print model.objective.expression

print ""
print "Reactions:"
for x in model.reactions:
    print "%s : %s" % (x.id, x.reaction)

print ""
print("Metabolites:")
for x in model.metabolites:
    print '%9s : %s' % (x.id, x.formula)

print ""
print "Genes:"
for x in model.genes:
    associated_ids = (i.id for i in x.reactions)
    print "%s is associated with reactions: %s" %(x.id, "{" + ", ".join(associated_ids) + "}")
```

    objective reaction:
    -1.0*reaction3_reverse_eb091 + 1.0*reaction3
    
    Reactions:
    reaction1 : met1_c --> met2_c
    reaction2 : met2_c --> met3_c
    reaction3 : met3_c --> met4_c
    ex1 :  --> met1_c
    ex2 : met4_c --> 
    
    Metabolites:
       met2_c : C
       met1_c : C
       met3_c : C
       met4_c : C
    
    Genes:
    old_gene1b is associated with reactions: {reaction1}
    old_gene1a is associated with reactions: {reaction1}
    old_gene2 is associated with reactions: {reaction2}
    old_gene3 is associated with reactions: {reaction3}
    old_gene5 is associated with reactions: {ex1}
    old_gene4 is associated with reactions: {ex1}



```python
dictionary = {'old_gene1a':'new_gene1',
              'old_gene1b':'new_gene1',
              'old_gene2':'new_gene2',
              'old_gene3':'new_gene3', 
              'old_gene4':'old_gene4', 
              'old_gene5':'new_gene5',
              'extra':'blahblahblah'}
```


```python
model_change = model.copy()
cobra.manipulation.modify.rename_genes(model_change, dictionary)
```


```python
print 'genes'
print [x.id for x in model_change.genes]
print ''
print 'GPRs'
print [x.gene_reaction_rule for x in model_change.reactions]
# note:
# [1] how blah blah blah was added even though it does not have a reaction association, 
# [2] old_gene_4 was deleted from the gene list even though it DOES have a reaction association, and
# [3] for the first reaction, the GPR is 'gene1 or gene1'.
```

    genes
    ['new_gene1', 'new_gene2', 'new_gene3', 'new_gene5', 'blahblahblah']
    
    GPRs
    ['new_gene1 and new_gene1', 'new_gene2', 'new_gene3', 'old_gene4 or new_gene5', '']



```python
model2 = model_change.copy()
# errors because old_gene4 is in in GPRs but not in gene list
```


    ---------------------------------------------------------------------------

    KeyError                                  Traceback (most recent call last)

    <ipython-input-6-f7cd6c3b56c0> in <module>()
    ----> 1 model2 = model_change.copy()
          2 # errors because old_gene4 is in in GPRs but not in gene list


    /Users/Mo/.virtualenvs/cobra_py2/lib/python2.7/site-packages/cobra/core/model.pyc in copy(self)
        298                 new_met._reaction.add(new_reaction)
        299             for gene in reaction._genes:
    --> 300                 new_gene = new.genes.get_by_id(gene.id)
        301                 new_reaction._genes.add(new_gene)
        302                 new_gene._reaction.add(new_reaction)


    /Users/Mo/.virtualenvs/cobra_py2/lib/python2.7/site-packages/cobra/core/dictlist.pyc in get_by_id(self, id)
         52     def get_by_id(self, id):
         53         """return the element with a matching id"""
    ---> 54         return list.__getitem__(self, self._dict[id])
         55 
         56     def list_attr(self, attribute):


    KeyError: 'old_gene4'



```python
rename_dict = dictionary.copy()
cobra_model = model.copy()

from six import iteritems
from ast import NodeTransformer
from cobra.core import Gene, Metabolite, Reaction
from cobra.core.gene import ast2str
from cobra.manipulation.delete import get_compiled_gene_reaction_rules

recompute_reactions = set()  # need to recomptue related genes
remove_genes = []
for old_name, new_name in iteritems(rename_dict):
    # undefined if there a value matches a different key
    # because dict is unordered
    try:
        gene_index = cobra_model.genes.index(old_name)
    except ValueError:
        gene_index = None
    old_gene_present = gene_index is not None
    new_gene_present = new_name in cobra_model.genes
    if old_gene_present and new_gene_present:
        old_gene = cobra_model.genes.get_by_id(old_name)
        if old_gene != cobra_model.genes.get_by_id(new_name): # Added in case not renaming some
            remove_genes.append(old_gene)
            recompute_reactions.update(old_gene._reaction)
    elif old_gene_present and not new_gene_present:
        # rename old gene to new gene
#         old_gene = cobra_model.genes.get_by_id(old_name) #added
        gene = cobra_model.genes[gene_index]
        # trick DictList into updating index
        cobra_model.genes._dict.pop(gene.id)  # ugh
        gene.id = new_name
        cobra_model.genes[gene_index] = gene
#         recompute_reactions.update(old_gene._reaction) # ADDED
    elif not old_gene_present and new_gene_present:
        pass # already fixed
    else:  # not old gene_present and not new_gene_present
        # the new gene's _model will be set by repair
        # cobra_model.genes.append(Gene(new_name)) # Removed, otherwise, adds genes that are unassigned to reactions
        pass

cobra_model.repair()

class Renamer(NodeTransformer):
    def visit_Name(self, node):
        node.id = rename_dict.get(node.id, node.id)
        return node

gene_renamer = Renamer()
for rxn, rule in iteritems(get_compiled_gene_reaction_rules(cobra_model)):
    if rule is not None:
        rxn._gene_reaction_rule = ast2str(gene_renamer.visit(rule))

for rxn in recompute_reactions:
    rxn.gene_reaction_rule = rxn._gene_reaction_rule
for i in remove_genes:
    cobra_model.genes.remove(i)

```


```python
print 'genes'
print [x.id for x in cobra_model.genes]
print ''
print 'GPRs'
print [x.gene_reaction_rule for x in cobra_model.reactions]
# note problems [3] not fixed (GPR1 is gene1 or gene1)
```

    genes
    ['new_gene1', 'new_gene2', 'new_gene3', 'new_gene5', 'old_gene4']
    
    GPRs
    ['new_gene1 and new_gene1', 'new_gene2', 'new_gene3', 'old_gene4 or new_gene5', '']



