### PR TITLE
feat: auto release to GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ deploy:
       condition: $TRAVIS_OS_NAME == "linux" && $MB_PYTHON_VERSION == "3.6"
   - provider: releases
     api_key: $GITHUB_TOKEN
-    body: "Please see https://github.com/opencobra/cobrapy/tree/devel/release-notes/${TRAVIS_TAG}.md for the full release notes."
+    body: "Please see https://github.com/opencobra/cobrapy/tree/${TRAVIS_TAG}/release-notes/${TRAVIS_TAG}.md for the full release notes."
     on:
       tags: true
       repo: $GITHUB_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,9 @@ script:
     fi
   - ls ${TRAVIS_BUILD_DIR}/wheelhouse/ || echo "no wheelhouse"
 
-before_deploy:
-  - source scripts/prepare_notes.sh
+# N.B.: Currently, Travis mangles (escapes) the tag body badly.
+    #before_deploy:
+    #  - source scripts/prepare_notes.sh
 
 deploy:
   - provider: script
@@ -113,7 +114,7 @@ deploy:
       condition: $TRAVIS_OS_NAME == "linux" && $MB_PYTHON_VERSION == "3.6"
   - provider: releases
     api_key: $GITHUB_TOKEN
-    body: $TAG_NOTES
+    body: "Please see https://github.com/opencobra/cobrapy/tree/devel/release-notes/${TRAVIS_TAG}.md for the full release notes."
     on:
       tags: true
       repo: $GITHUB_REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - secure: "DflyBz+QiyhlhBxn4wN00xu248EJUMjKTxUZQN6wq22qV55xO3ToGJTy9i4D6OBfZGAlSXxjjKCJ2+0sAjsghBSDEK56ud3EEg/08TIo7/T8ex/C58FsGoGFz3yDBATmquClEWN8vAMrLdxwniHmQVCBZCP/phdt5dct0AUuDc8="
     - PLAT=x86_64
     - UNICODE_WIDTH=32
+    - GITHUB_REPO=opencobra/cobrapy
 
 matrix:
   fast_finish: true
@@ -94,18 +95,28 @@ script:
     fi
   - ls ${TRAVIS_BUILD_DIR}/wheelhouse/ || echo "no wheelhouse"
 
+before_deploy:
+  - source scripts/prepare_notes.sh
+
 deploy:
   - provider: script
     skip_cleanup: true
     script: scripts/deploy_cobra.sh
     on:
       tags: true
-      repo: opencobra/cobrapy
+      repo: $GITHUB_REPO
   - provider: script
     script: scripts/deploy_website.sh
     on:
       tags: true
-      repo: opencobra/cobrapy
+      repo: $GITHUB_REPO
+      condition: $TRAVIS_OS_NAME == "linux" && $MB_PYTHON_VERSION == "3.6"
+  - provider: releases
+    api_key: $GITHUB_TOKEN
+    body: $TAG_NOTES
+    on:
+      tags: true
+      repo: $GITHUB_REPO
       condition: $TRAVIS_OS_NAME == "linux" && $MB_PYTHON_VERSION == "3.6"
 
 after_success:

--- a/scripts/prepare_notes.sh
+++ b/scripts/prepare_notes.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -n "${TRAVIS_TAG}" && "${TRAVIS_OS_NAME}" == "linux" && "${MB_PYTHON_VERSION}" == "3.6" ]]; then
+    echo "Parsing ${TRAVIS_BUILD_DIR}/release-notes/${TRAVIS_TAG}.md"
+    export TAG_NOTES=$(cat "${TRAVIS_BUILD_DIR}/release-notes/${TRAVIS_TAG}.md")
+fi
+
+set +e


### PR DESCRIPTION
Upon a tagged Travis will also create a GitHub release. For now the release description is simply a link to our markdown notes because the Travis deploy script badly escapes the string.