### PR TITLE
feat: sort out the ordering issues with round tripping models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
 before_install:
   - if [[ -n "${MB_PYTHON_VERSION}" ]]; then
       (travis_retry git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 37040e31b1044468027bd86991c805006a92bf09);
-      TEST_DEPENDS="swiglpk optlang sympy decorator cython codecov coverage numpy scipy jsonschema six pytest pytest-cov pytest-benchmark tabulate";
+      TEST_DEPENDS="swiglpk optlang sympy decorator cython codecov coverage numpy scipy==0.19.1 jsonschema six pytest pytest-cov pytest-benchmark tabulate";
       BUILD_DEPENDS="swiglpk optlang sympy cython numpy scipy";
       source multibuild/common_utils.sh;
       source multibuild/travis_steps.sh;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ install:
           conda install -q pip } else {
           python -m pip install pip setuptools>=24.0 wheel --upgrade }
   - if not defined CONDA %WITH_COMPILER% python -m pip install --upgrade pytest
-  - if defined CONDA conda install -q setuptools pytest numpy scipy
+  - if defined CONDA conda install -q setuptools pytest numpy scipy==0.19.1
   - python -m pip install pytest-cov pytest-benchmark pandas swiglpk optlang python-libsbml decorator Cython jsonschema twine pypandoc
   - "%WITH_COMPILER% python appveyor/build_glpk.py"
 

--- a/cobra/io/json.py
+++ b/cobra/io/json.py
@@ -15,7 +15,7 @@ from cobra.io.dict import model_to_dict, model_from_dict
 JSON_SPEC = "1"
 
 
-def to_json(model, **kwargs):
+def to_json(model, sort=False, **kwargs):
     """
     Return the model as a JSON document.
 
@@ -25,6 +25,9 @@ def to_json(model, **kwargs):
     ----------
     model : cobra.Model
         The cobra model to represent.
+    sort : bool, optional
+        Whether to sort the metabolites, reactions, and genes or maintain the
+        order defined in the model.
 
     Returns
     -------
@@ -36,7 +39,7 @@ def to_json(model, **kwargs):
     save_json_model : Write directly to a file.
     json.dumps : Base function.
     """
-    obj = model_to_dict(model)
+    obj = model_to_dict(model, sort=sort)
     obj[u"version"] = JSON_SPEC
     return json.dumps(obj, allow_nan=False, **kwargs)
 
@@ -62,7 +65,7 @@ def from_json(document):
     return model_from_dict(json.loads(document))
 
 
-def save_json_model(model, filename, pretty=False, **kwargs):
+def save_json_model(model, filename, sort=False, pretty=False, **kwargs):
     """
     Write the cobra model to a file in JSON format.
 
@@ -75,6 +78,9 @@ def save_json_model(model, filename, pretty=False, **kwargs):
     filename : str or file-like
         File path or descriptor that the JSON representation should be
         written to.
+    sort : bool, optional
+        Whether to sort the metabolites, reactions, and genes or maintain the
+        order defined in the model.
     pretty : bool, optional
         Whether to format the JSON more compactly (default) or in a more
         verbose but easier to read fashion. Can be partially overwritten by the
@@ -85,7 +91,7 @@ def save_json_model(model, filename, pretty=False, **kwargs):
     to_json : Return a string representation.
     json.dump : Base function.
     """
-    obj = model_to_dict(model)
+    obj = model_to_dict(model, sort=sort)
     obj[u"version"] = JSON_SPEC
 
     if pretty:

--- a/cobra/io/yaml.py
+++ b/cobra/io/yaml.py
@@ -12,7 +12,7 @@ from cobra.io.dict import model_to_dict, model_from_dict
 YAML_SPEC = "1"
 
 
-def to_yaml(model, **kwargs):
+def to_yaml(model, sort=False, **kwargs):
     """
     Return the model as a YAML document.
 
@@ -22,6 +22,9 @@ def to_yaml(model, **kwargs):
     ----------
     model : cobra.Model
         The cobra model to represent.
+    sort : bool, optional
+        Whether to sort the metabolites, reactions, and genes or maintain the
+        order defined in the model.
 
     Returns
     -------
@@ -33,7 +36,7 @@ def to_yaml(model, **kwargs):
     save_yaml_model : Write directly to a file.
     ruamel.yaml.dump : Base function.
     """
-    obj = model_to_dict(model)
+    obj = model_to_dict(model, sort=sort)
     obj["version"] = YAML_SPEC
     return yaml.dump(obj, Dumper=yaml.RoundTripDumper, **kwargs)
 
@@ -59,7 +62,7 @@ def from_yaml(document):
     return model_from_dict(yaml.load(document, yaml.RoundTripLoader))
 
 
-def save_yaml_model(model, filename, **kwargs):
+def save_yaml_model(model, filename, sort=False, **kwargs):
     """
     Write the cobra model to a file in YAML format.
 
@@ -72,13 +75,16 @@ def save_yaml_model(model, filename, **kwargs):
     filename : str or file-like
         File path or descriptor that the YAML representation should be
         written to.
+    sort : bool, optional
+        Whether to sort the metabolites, reactions, and genes or maintain the
+        order defined in the model.
 
     See Also
     --------
     to_yaml : Return a string representation.
     ruamel.yaml.dump : Base function.
     """
-    obj = model_to_dict(model)
+    obj = model_to_dict(model, sort=sort)
     obj["version"] = YAML_SPEC
     if isinstance(filename, string_types):
         with io.open(filename, "w") as file_handle:

--- a/cobra/test/test_io.py
+++ b/cobra/test/test_io.py
@@ -185,10 +185,12 @@ class TestCobraIO:
     @classmethod
     def extra_comparisons(cls, name, model1, model2):
         assert model1.compartments == model2.compartments
-        assert model1.metabolites[4].annotation == model2.metabolites[
-            4].annotation
-        assert model1.reactions[4].annotation == model2.reactions[4].annotation
-        assert model1.genes[5].annotation == model2.genes[5].annotation
+        assert dict(model1.metabolites[4].annotation) == dict(
+            model2.metabolites[4].annotation)
+        assert dict(model1.reactions[4].annotation) == dict(
+            model2.reactions[4].annotation)
+        assert dict(model1.genes[5].annotation) == dict(
+            model2.genes[5].annotation)
         for attr in ("id", "name"):
             assert getattr(model1.genes[0], attr) == getattr(model2.genes[0],
                                                              attr)

--- a/cobra/test/test_io_order.py
+++ b/cobra/test/test_io_order.py
@@ -72,8 +72,10 @@ def get_ids(iterable):
 
 @pytest.mark.parametrize("read, write, ext", [
     ("read_sbml_model", "write_sbml_model", ".xml"),
-    ("read_legacy_sbml", "write_legacy_sbml", ".xml"),
-    ("load_matlab_model", "save_matlab_model", ".mat"),
+    pytest.mark.skip(("read_legacy_sbml", "write_legacy_sbml", ".xml"),
+                     reason="Order for legacy SBML I/O is uninteresting."),
+    pytest.mark.skip(("load_matlab_model", "save_matlab_model", ".mat"),
+                     reason="Order for Matlab model I/O is uninteresting."),
     ("load_json_model", "save_json_model", ".json"),
     ("load_yaml_model", "save_yaml_model", ".yml"),
 ])
@@ -88,4 +90,3 @@ def test_io_order(attribute, read, write, ext, template, tmp_path):
     assert len(model_elements) == len(template_elements)
     assert set(model_elements) == set(template_elements)
     assert model_elements == template_elements
-

--- a/cobra/test/test_io_order.py
+++ b/cobra/test/test_io_order.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from operator import attrgetter
+from os.path import join, dirname
+from random import sample
+
+import pytest
+
+import cobra.io as cio
+from cobra import DictList
+
+
+@pytest.fixture(scope="module")
+def tmp_path(tmpdir_factory):
+    return str(tmpdir_factory.mktemp("model_order"))
+
+
+@pytest.fixture(scope="module")
+def minimized_core():
+    model = cio.read_sbml_model(join(dirname(__file__), "data",
+                                "textbook.xml.gz"))
+    model.id = "minimized_core"
+    chosen = sample(model.reactions, 10)
+    model.remove_reactions(set(model.reactions).difference(chosen),
+                           remove_orphans=True)
+    return model
+
+
+@pytest.fixture(scope="module")
+def minimized_sorted(minimized_core):
+    model = minimized_core.copy()
+    model.id = "minimized_sorted"
+    model.metabolites = DictList(
+        sorted(model.metabolites, key=attrgetter("id")))
+    model.genes = DictList(sorted(model.genes, key=attrgetter("id")))
+    model.reactions = DictList(sorted(model.reactions, key=attrgetter("id")))
+    return model
+
+
+@pytest.fixture(scope="module")
+def minimized_reverse(minimized_core):
+    model = minimized_core.copy()
+    model.id = "minimized_reverse"
+    model.metabolites = DictList(
+        sorted(model.metabolites, key=attrgetter("id"), reverse=True))
+    model.genes = DictList(
+        sorted(model.genes, key=attrgetter("id"), reverse=True))
+    model.reactions = DictList(
+        sorted(model.reactions, key=attrgetter("id"), reverse=True))
+    return model
+
+
+@pytest.fixture(scope="module", params=[
+    "minimized_core", "minimized_reverse", "minimized_sorted"])
+def template(request, minimized_core, minimized_reverse, minimized_sorted):
+    return locals()[request.param]
+
+
+def get_attr(iterable, attr="id"):
+    get = attrgetter(attr)
+    return [get(x) for x in iterable]
+
+
+@pytest.mark.parametrize("read, write, ext", [
+    (cio.read_sbml_model, cio.write_sbml_model, ".xml"),
+    (cio.read_legacy_sbml, cio.write_legacy_sbml, ".xml"),
+    (cio.load_matlab_model, cio.save_matlab_model, ".mat"),
+    (cio.load_json_model, cio.save_json_model, ".json"),
+    (cio.load_yaml_model, cio.save_yaml_model, ".yml"),
+])
+def test_io_order(read, write, ext, template, tmp_path):
+    filename = join(tmp_path, "template" + ext)
+    write(template, filename)
+    model = read(filename)
+    # test metabolite order
+    assert len(model.metabolites) == len(template.metabolites)
+    assert set(get_attr(model.metabolites)) == set(
+        get_attr(template.metabolites))
+    assert get_attr(model.metabolites) == get_attr(template.metabolites)
+    # test reaction order
+    assert len(model.reactions) == len(template.reactions)
+    assert set(get_attr(model.reactions)) == set(get_attr(template.reactions))
+    assert get_attr(model.reactions) == get_attr(template.reactions)
+    # test gene order
+    assert len(model.genes) == len(template.genes)
+    assert set(get_attr(model.genes)) == set(get_attr(template.genes))
+    assert get_attr(model.genes) == get_attr(template.genes)
+

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ if {'pytest', 'test', 'ptr'}.intersection(argv):
 extras = {
     'matlab': ["pymatbridge"],
     'sbml': ["python-libsbml", "lxml"],
-    'array': ["scipy>=0.11.0"],
+    'array': ["scipy==0.19.1"],
     'display': ["matplotlib", "palettable"]
 }
 


### PR DESCRIPTION
Currently, the JSON and YAML writers (inheriting from dict) sort the model attributes. This may cause confusion and is unexpected behaviour. This PR aims to improve that situation and starts out with a series of clear test scenarios.