### PR TITLE
Skip tests for ArrayBasedModel with scipy>=1.0.0

### DIFF
--- a/cobra/test/test_model.py
+++ b/cobra/test/test_model.py
@@ -932,7 +932,8 @@ class TestCobraModel:
 class TestStoichiometricMatrix:
     """Test the simple replacement for ArrayBasedModel"""
 
-    @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
+    @pytest.mark.skipif(not scipy or scipy.__version__ >= "0.19",
+                        reason='Sparse array methods require scipy<=0.19')
     def test_array_model(self, model):
         """ legacy test """
         for matrix_type in ["scipy.dok_matrix", "scipy.lil_matrix"]:
@@ -981,7 +982,8 @@ class TestStoichiometricMatrix:
             assert len(array_model.reactions) == array_model.S.shape[1]
             assert array_model.S.shape == (m, n - 1)
 
-    @pytest.mark.skipif(not scipy, reason='Sparse array methods require scipy')
+    @pytest.mark.skipif(not scipy or scipy.__version__ >= "0.19",
+                        reason='Sparse array methods require scipy<=0.19')
     def test_array_based_model_add(self, model):
         """ legacy test """
         array_model = model.to_array_based_model()

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ if {'pytest', 'test', 'ptr'}.intersection(argv):
 extras = {
     'matlab': ["pymatbridge"],
     'sbml': ["python-libsbml", "lxml"],
-    'array': ["scipy==0.19.1"],
+    'array': ["scipy>=0.19.0"],
     'display': ["matplotlib", "palettable"]
 }
 


### PR DESCRIPTION
Workaround in order to not have to pin the scipy version which may cause problems. ArrayBasedModel is deprecated anyways... 