### PR TITLE
Allow underscores in solver names

### DIFF
--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -32,7 +32,7 @@ class SolverNotFound(Exception):
 
 
 # Define all the solvers that are found in optlang.
-solvers = {match.split("_")[0]: getattr(optlang, match)
+solvers = {match.split("_interface")[0]: getattr(optlang, match)
            for match in dir(optlang) if "_interface" in match}
 
 # Defines all the QP solvers implemented in optlang.


### PR DESCRIPTION
Very small change. The following will now work:

```Python
In [1]: from cobra.test import create_test_model
Loading symengine... This feature is in beta testing. Please report any issues you encounter on http://github.com/biosustain/optlang/issues

In [3]: mod = create_test_model("textbook")

In [4]: mod.solver = "glpk_exact"

In [5]: mod.optimize()
Out[5]: <Solution 0.874 at 0x7f24c2624208>
```