### PR TITLE
refactor: use the optlang interface clone method [question]

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -319,11 +319,8 @@ class Model(Object):
                 new_gene = new.genes.get_by_id(gene.id)
                 new_reaction._genes.add(new_gene)
                 new_gene._reaction.add(new_reaction)
-        try:
-            new._solver = deepcopy(self.solver)
-            # Cplex has an issue with deep copies
-        except Exception:  # pragma: no cover
-            new._solver = copy(self.solver)  # pragma: no cover
+
+        new._solver = self._solver.clone(self._solver)
 
         # it doesn't make sense to retain the context of a copied model so
         # assign a new empty context


### PR DESCRIPTION
So I played around a bit with addressing [this problem](https://github.com/opencobra/memote/issues/262) in memote. One way of doing so is by using `optlang.interface.Model.clone` instead of a `copy` or `deepcopy`.

That causes two problems:
1. The times are abysmal in comparison or the names might change.
```python
In [5]: from cobra.io import read_sbml_model   

In [6]: m = read_sbml_model("iJO1366.xml.gz")  

In [7]: %timeit m._solver.clone(m._solver)     
1.35 s ± 6.56 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)                           

In [8]: %timeit m._solver.clone(m._solver, use_json=False)                                    
4.62 s ± 14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)                             

In [9]: %timeit m._solver.clone(m._solver, use_json=False, use_lp=True)                       
/home/moritz/.virtualenvs/testcopy/lib/python3.6/site-packages/optlang/interface.py:1096 UserWarning: Cloning with LP formats can change variable and constraint ID's.                      
291 ms ± 5.55 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [10]: %timeit deepcopy(m._solver)
286 ms ± 3.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

2. It fails one of our tests `test_fixed_seed` because cloning the solver model rather than copying changes the order of variables.

I'm also not sure what really causes this. I was not able to reproduce it with below code. The situation in memote is slightly more complicated but I have made certain that in the fixture in memote the model has variables before copying and no variables on the copy (GLPK), whereas with CPLEX it copies the variables just fine.

```python
import pytest

from cobra.io import read_sbml_model


MODEL = read_sbml_model("iJO1366.xml.gz")


@pytest.fixture(scope="session")
def read_only_model():
    return MODEL


@pytest.fixture(scope="function")
def model(read_only_model):
    return read_only_model.copy()


def test_copy_has_variables(model):
    assert len(model.variables) > 0


def test_copy_has_same_number_variables(read_only_model, model):
    assert len(read_only_model.variables) == len(model.variables)


def test_copy_has_same_variables(read_only_model, model):
    assert set(v.name.split("_rev")[0] for v in read_only_model.variables) == \
        set(v.name.split("_rev")[0] for v in model.variables)
```

I'm not suggesting to merge this but I wanted a place to discuss this issue and make the necessary changes (if any). @KristianJensen any idea under what circumstances the variables of the GLPK interface would not be copied?