### PR TITLE
fix: drop and warn Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ matrix:
       python: 2.7
       env: TOXENV=py27
     - os: linux
-      python: 3.4
-      env: TOXENV=py34
-    - os: linux
       python: 3.5
       env: TOXENV=py35
     - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOXENV: py27
 
-    - PYTHON: "C:\\Python34-x64"
-      TOXENV: py34
-
     - PYTHON: "C:\\Python35-x64"
       TOXENV: py35
 

--- a/release-notes/0.10.1.md
+++ b/release-notes/0.10.1.md
@@ -1,0 +1,8 @@
+# Release notes for cobrapy 0.10.1
+
+## Fixes
+
+* `pandas` has dropped support for Python 3.4 and we are doing the same for our
+  automated tests. If you are running Python 3.4 and have a working installation
+  of numpy and pandas, adding cobrapy on top of that is no problem.
+

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,16 @@
 
 from __future__ import absolute_import
 
-from sys import argv
+from warnings import warn
+from sys import argv, version_info
 
 from setuptools import setup, find_packages
 
+if version_info[:2] == (3, 4):
+    warn("Support for Python 3.4 was dropped by pandas. Since cobrapy is a "
+         "pure Python package you can still install it but will have to "
+         "carefully manage your own pandas and numpy versions. We no longer "
+         "include it in our automatic testing.")
 
 setup_kwargs = dict()
 setup_requirements = []


### PR DESCRIPTION
(@cdiener and @pstjohn I'm not waiting the customary 24 h since this is breaking all our builds. I'm happy to revert the changes later on.)