### PR TITLE
attempts to make reversible reaction deletion work

### DIFF
--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -615,6 +615,8 @@ class Model(Object):
                 reaction._model = None
 
                 if context:
+                    context(self.solver.update)
+                    context(partial(self._populate_solver, [reaction]))
                     context(partial(setattr, reaction, '_model', self))
                     context(partial(self.reactions.add, reaction))
 
@@ -745,16 +747,24 @@ class Model(Object):
 
         for reaction in reaction_list:
 
-            reverse_lb, reverse_ub, forward_lb, forward_ub = \
-                separate_forward_and_reverse_bounds(*reaction.bounds)
+            if reaction.id not in self.variables:
 
-            forward_variable = self.problem.Variable(
-                reaction.id, lb=forward_lb, ub=forward_ub)
-            reverse_variable = self.problem.Variable(
-                reaction.reverse_id, lb=reverse_lb, ub=reverse_ub)
+                reverse_lb, reverse_ub, forward_lb, forward_ub = \
+                    separate_forward_and_reverse_bounds(*reaction.bounds)
 
-            self.add_cons_vars([forward_variable, reverse_variable])
-            self.solver.update()
+                forward_variable = self.problem.Variable(
+                    reaction.id, lb=forward_lb, ub=forward_ub)
+                reverse_variable = self.problem.Variable(
+                    reaction.reverse_id, lb=reverse_lb, ub=reverse_ub)
+
+                self.add_cons_vars([forward_variable, reverse_variable])
+                self.solver.update()
+
+            else:
+
+                reaction = self.reactions.get_by_id(reaction.id)
+                forward_variable = reaction.forward_variable
+                reverse_variable = reaction.reverse_variable
 
             for metabolite, coeff in six.iteritems(reaction.metabolites):
                 if metabolite.id in self.constraints:

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -758,7 +758,6 @@ class Model(Object):
                     reaction.reverse_id, lb=reverse_lb, ub=reverse_ub)
 
                 self.add_cons_vars([forward_variable, reverse_variable])
-                self.solver.update()
 
             else:
 

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -612,7 +612,6 @@ class Model(Object):
                 reverse = reaction.reverse_variable
 
                 if context:
-                    context(self.solver.update)
                     context(partial(self._populate_solver, [reaction]))
                     context(partial(setattr, reaction, '_model', self))
                     context(partial(self.reactions.add, reaction))

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -610,15 +610,16 @@ class Model(Object):
             else:
                 forward = reaction.forward_variable
                 reverse = reaction.reverse_variable
-                self.remove_cons_vars([forward, reverse])
-                self.reactions.remove(reaction)
-                reaction._model = None
 
                 if context:
                     context(self.solver.update)
                     context(partial(self._populate_solver, [reaction]))
                     context(partial(setattr, reaction, '_model', self))
                     context(partial(self.reactions.add, reaction))
+
+                self.remove_cons_vars([forward, reverse])
+                self.reactions.remove(reaction)
+                reaction._model = None
 
                 for met in reaction._metabolites:
                     if reaction in met._reaction:

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -489,6 +489,7 @@ class TestReaction:
         pgi = model.reactions.PGI
         g6p = model.metabolites.g6p_c
         pgi_flux = model.optimize().fluxes['PGI']
+        assert abs(pgi_flux) > 1E-6
 
         with model:
             pgi.remove_from_model()

--- a/cobra/test/test_solver_model.py
+++ b/cobra/test/test_solver_model.py
@@ -488,6 +488,7 @@ class TestReaction:
     def test_remove_from_model(self, model):
         pgi = model.reactions.PGI
         g6p = model.metabolites.g6p_c
+        pgi_flux = model.optimize().fluxes['PGI']
 
         with model:
             pgi.remove_from_model()
@@ -496,6 +497,7 @@ class TestReaction:
             assert pgi.id not in model.variables
             assert pgi.reverse_id not in model.variables
             assert pgi not in g6p.reactions
+            model.optimize()
 
         assert "PGI" in model.reactions
         assert pgi.id in model.variables
@@ -503,6 +505,7 @@ class TestReaction:
         assert pgi.forward_variable.problem is model.solver
         assert pgi in g6p.reactions
         assert g6p in pgi.metabolites
+        assert numpy.isclose(pgi_flux, model.optimize().fluxes['PGI'])
 
     def test_change_id_is_reflected_in_solver(self, model):
         for i, reaction in enumerate(model.reactions):


### PR DESCRIPTION
Some in-progress attempts at fixing `model.remove_reactions` and `model._populate_solver`. Still not working.

Addresses #655 