### PR TITLE
refactor: add or change `num_cpu` argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 *,cover

--- a/cobra/flux_analysis/deletion.py
+++ b/cobra/flux_analysis/deletion.py
@@ -71,7 +71,8 @@ def _init_worker(model):
     _model = model
 
 
-def _multi_deletion(model, entity, element_lists, method="fba", num_proc=None):
+def _multi_deletion(model, entity, element_lists, method="fba",
+                    processes=None):
     """
     Provide a common interface for single or multiple knockouts.
 
@@ -90,7 +91,7 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_proc=None):
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -114,19 +115,19 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_proc=None):
             "Cannot use MOMA since '{}' is not QP-capable."
             "Please choose a different solver or use FBA only.".format(solver))
 
-    if num_proc is None:
+    if processes is None:
         try:
-            num_proc = multiprocessing.cpu_count()
+            processes = multiprocessing.cpu_count()
         except NotImplementedError:
             warn("Number of cores could not be detected - assuming 1.")
-            num_proc = 1
+            processes = 1
 
     with model:
         if "moma" in method:
             add_moma(model, linear="linear" in method)
 
         args = set([frozenset(comb) for comb in product(*element_lists)])
-        num_proc = min(num_proc, len(args))
+        processes = min(processes, len(args))
 
         def extract_knockout_results(result_iter):
             result = pd.DataFrame([
@@ -136,12 +137,12 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_proc=None):
             result.set_index('ids', inplace=True)
             return result
 
-        if num_proc > 1:
+        if processes > 1:
             worker = dict(gene=_gene_deletion_worker,
                           reaction=_reaction_deletion_worker)[entity]
-            chunk_size = len(args) // num_proc
+            chunk_size = len(args) // processes
             pool = multiprocessing.Pool(
-                num_proc, initializer=_init_worker, initargs=(model,)
+                processes, initializer=_init_worker, initargs=(model,)
             )
             results = extract_knockout_results(pool.imap_unordered(
                 worker,
@@ -179,7 +180,7 @@ def _element_lists(entities, *ids):
 
 
 def single_reaction_deletion(model, reaction_list=None, method="fba",
-                             num_proc=None):
+                             processes=None):
     """
     Knock out each reaction from a given list.
 
@@ -195,7 +196,7 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -217,10 +218,10 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     return _multi_deletion(
         model, 'reaction',
         element_lists=_element_lists(model.reactions, reaction_list),
-        method=method, num_proc=num_proc)
+        method=method, processes=processes)
 
 
-def single_gene_deletion(model, gene_list=None, method="fba", num_proc=None):
+def single_gene_deletion(model, gene_list=None, method="fba", processes=None):
     """
     Knock out each gene from a given list.
 
@@ -236,7 +237,7 @@ def single_gene_deletion(model, gene_list=None, method="fba", num_proc=None):
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -257,11 +258,11 @@ def single_gene_deletion(model, gene_list=None, method="fba", num_proc=None):
     """
     return _multi_deletion(
         model, 'gene', element_lists=_element_lists(model.genes, gene_list),
-        method=method, num_proc=num_proc)
+        method=method, processes=processes)
 
 
 def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
-                             method="fba", num_proc=None):
+                             method="fba", processes=None):
     """
     Knock out each reaction pair from the combinations of two given lists.
 
@@ -283,7 +284,7 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -308,11 +309,11 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
                                                     reaction_list2)
     return _multi_deletion(
         model, 'reaction', element_lists=[reaction_list1, reaction_list2],
-        method=method, num_proc=num_proc)
+        method=method, processes=processes)
 
 
 def double_gene_deletion(model, gene_list1=None, gene_list2=None,
-                         method="fba", num_proc=None):
+                         method="fba", processes=None):
     """
     Knock out each gene pair from the combination of two given lists.
 
@@ -334,7 +335,7 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -358,4 +359,4 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
                                             gene_list2)
     return _multi_deletion(
         model, 'gene', element_lists=[gene_list1, gene_list2],
-        method=method, num_proc=num_proc)
+        method=method, processes=processes)

--- a/cobra/flux_analysis/deletion.py
+++ b/cobra/flux_analysis/deletion.py
@@ -71,7 +71,7 @@ def _init_worker(model):
     _model = model
 
 
-def _multi_deletion(model, entity, element_lists, method="fba", num_jobs=None):
+def _multi_deletion(model, entity, element_lists, method="fba", num_cpu=None):
     """
     Provide a common interface for single or multiple knockouts.
 
@@ -90,7 +90,7 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_jobs=None):
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_jobs : int, optional
+    num_cpu : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -114,14 +114,12 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_jobs=None):
             "Cannot use MOMA since '{}' is not QP-capable."
             "Please choose a different solver or use FBA only.".format(solver))
 
-    if num_jobs is None:
+    if num_cpu is None:
         try:
             num_cpu = multiprocessing.cpu_count()
         except NotImplementedError:
             warn("Number of cores could not be detected - assuming 1.")
             num_cpu = 1
-    else:
-        num_cpu = num_jobs
 
     with model:
         if "moma" in method:
@@ -139,7 +137,6 @@ def _multi_deletion(model, entity, element_lists, method="fba", num_jobs=None):
             return result
 
         if num_cpu > 1:
-            num_cpu = min(num_cpu, len(args))
             worker = dict(gene=_gene_deletion_worker,
                           reaction=_reaction_deletion_worker)[entity]
             chunk_size = len(args) // num_cpu
@@ -182,7 +179,7 @@ def _element_lists(entities, *ids):
 
 
 def single_reaction_deletion(model, reaction_list=None, method="fba",
-                             num_jobs=None):
+                             num_cpu=None):
     """
     Knock out each reaction from a given list.
 
@@ -198,7 +195,7 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_jobs : int, optional
+    num_cpu : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -220,10 +217,10 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     return _multi_deletion(
         model, 'reaction',
         element_lists=_element_lists(model.reactions, reaction_list),
-        method=method, num_jobs=num_jobs)
+        method=method, num_cpu=num_cpu)
 
 
-def single_gene_deletion(model, gene_list=None, method="fba", num_jobs=None):
+def single_gene_deletion(model, gene_list=None, method="fba", num_cpu=None):
     """
     Knock out each gene from a given list.
 
@@ -239,7 +236,7 @@ def single_gene_deletion(model, gene_list=None, method="fba", num_jobs=None):
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_jobs : int, optional
+    num_cpu : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -260,11 +257,11 @@ def single_gene_deletion(model, gene_list=None, method="fba", num_jobs=None):
     """
     return _multi_deletion(
         model, 'gene', element_lists=_element_lists(model.genes, gene_list),
-        method=method, num_jobs=num_jobs)
+        method=method, num_cpu=num_cpu)
 
 
 def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
-                             method="fba", num_jobs=None):
+                             method="fba", num_cpu=None):
     """
     Knock out each reaction pair from the combinations of two given lists.
 
@@ -286,7 +283,7 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_jobs : int, optional
+    num_cpu : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -311,11 +308,11 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
                                                     reaction_list2)
     return _multi_deletion(
         model, 'reaction', element_lists=[reaction_list1, reaction_list2],
-        method=method, num_jobs=num_jobs)
+        method=method, num_cpu=num_cpu)
 
 
 def double_gene_deletion(model, gene_list1=None, gene_list2=None,
-                         method="fba", num_jobs=None):
+                         method="fba", num_cpu=None):
     """
     Knock out each gene pair from the combination of two given lists.
 
@@ -337,7 +334,7 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
 
-    num_jobs : int, optional
+    num_cpu : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -361,4 +358,4 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
                                             gene_list2)
     return _multi_deletion(
         model, 'gene', element_lists=[gene_list1, gene_list2],
-        method=method, num_jobs=num_jobs)
+        method=method, num_cpu=num_cpu)

--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -672,11 +672,11 @@ class OptGPSampler(HRSampler):
        https://doi.org/10.1371/journal.pone.0086587
     """
 
-    def __init__(self, model, num_proc, thinning=100, seed=None):
+    def __init__(self, model, processes, thinning=100, seed=None):
         """Initialize a new OptGPSampler."""
         super(OptGPSampler, self).__init__(model, thinning, seed=seed)
         self.generate_fva_warmup()
-        self.num_proc = num_proc
+        self.processes = processes
 
         # This maps our saved center into shared memory,
         # meaning they are synchronized across processes
@@ -715,15 +715,16 @@ class OptGPSampler(HRSampler):
         we recommend to calculate large numbers of samples at once
         (`n` > 1000).
         """
-        if self.num_proc > 1:
-            n_process = np.ceil(n / self.num_proc).astype(int)
-            n = n_process * self.num_proc
+        if self.processes > 1:
+            n_process = np.ceil(n / self.processes).astype(int)
+            n = n_process * self.processes
             # The cast to list is weird but not doing it gives recursion
             # limit errors, something weird going on with multiprocessing
-            args = list(zip([n_process] * self.num_proc, range(self.num_proc)))
+            args = list(zip(
+                [n_process] * self.processes, range(self.processes)))
             # No with statement or starmap here since Python 2.x
             # does not support it :(
-            mp = Pool(self.num_proc, initializer=mp_init, initargs=(self,))
+            mp = Pool(self.processes, initializer=mp_init, initargs=(self,))
             chains = mp.map(_sample_chain, args, chunksize=1)
             mp.close()
             mp.join()
@@ -755,7 +756,7 @@ class OptGPSampler(HRSampler):
         return d
 
 
-def sample(model, n, method="optgp", thinning=100, num_proc=1, seed=None):
+def sample(model, n, method="optgp", thinning=100, processes=1, seed=None):
     """Sample valid flux distributions from a cobra model.
 
     The function samples valid flux distributions from a cobra model.
@@ -785,7 +786,7 @@ def sample(model, n, method="optgp", thinning=100, num_proc=1, seed=None):
         means samples are returned every 10 steps. Defaults to 100 which in
         benchmarks gives approximately uncorrelated samples. If set to one
         will return all iterates.
-    num_proc : int, optional
+    processes : int, optional
         Only used for 'optgp'. The number of processes used to generate
         samples.
     seed : positive integer, optional
@@ -816,7 +817,7 @@ def sample(model, n, method="optgp", thinning=100, num_proc=1, seed=None):
        Operations Research 199846:1 , 84-95
     """
     if method == "optgp":
-        sampler = OptGPSampler(model, num_proc, thinning=thinning, seed=seed)
+        sampler = OptGPSampler(model, processes, thinning=thinning, seed=seed)
     elif method == "achr":
         sampler = ACHRSampler(model, thinning=thinning, seed=seed)
     else:

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -215,7 +215,7 @@ def find_blocked_reactions(model, reaction_list=None,
                 max(abs(min_max)) < zero_cutoff]
 
 
-def find_essential_genes(model, threshold=None, num_proc=None):
+def find_essential_genes(model, threshold=None, processes=None):
     """Return a set of essential genes.
 
     A gene is considered essential if restricting the flux of all reactions
@@ -229,7 +229,7 @@ def find_essential_genes(model, threshold=None, num_proc=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -241,13 +241,13 @@ def find_essential_genes(model, threshold=None, num_proc=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_gene_deletion(model, method='fba', num_proc=num_proc)
+    deletions = single_gene_deletion(model, method='fba', processes=processes)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.genes.get_by_id(g) for ids in essential for g in ids)
 
 
-def find_essential_reactions(model, threshold=None, num_proc=None):
+def find_essential_reactions(model, threshold=None, processes=None):
     """Return a set of essential reactions.
 
     A reaction is considered essential if restricting its flux to zero
@@ -260,7 +260,7 @@ def find_essential_reactions(model, threshold=None, num_proc=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
-    num_proc : int, optional
+    processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -273,7 +273,7 @@ def find_essential_reactions(model, threshold=None, num_proc=None):
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
     deletions = single_reaction_deletion(model, method='fba',
-                                         num_proc=num_proc)
+                                         processes=processes)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.reactions.get_by_id(r) for ids in essential for r in ids)

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -272,7 +272,8 @@ def find_essential_reactions(model, threshold=None, num_proc=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_reaction_deletion(model, method='fba', num_proc=num_proc)
+    deletions = single_reaction_deletion(model, method='fba',
+                                         num_proc=num_proc)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.reactions.get_by_id(r) for ids in essential for r in ids)

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -215,7 +215,7 @@ def find_blocked_reactions(model, reaction_list=None,
                 max(abs(min_max)) < zero_cutoff]
 
 
-def find_essential_genes(model, threshold=None):
+def find_essential_genes(model, threshold=None, num_cpu=None):
     """Return a set of essential genes.
 
     A gene is considered essential if restricting the flux of all reactions
@@ -229,6 +229,10 @@ def find_essential_genes(model, threshold=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
+    num_cpu : int, optional
+        The number of parallel processes to run. Can speed up the computations
+        if the number of knockouts to perform is large. If not passed,
+        will be set to the number of CPUs found.
 
     Returns
     -------
@@ -237,13 +241,13 @@ def find_essential_genes(model, threshold=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_gene_deletion(model, method='fba')
+    deletions = single_gene_deletion(model, method='fba', num_cpu=num_cpu)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.genes.get_by_id(g) for ids in essential for g in ids)
 
 
-def find_essential_reactions(model, threshold=None):
+def find_essential_reactions(model, threshold=None, num_cpu=None):
     """Return a set of essential reactions.
 
     A reaction is considered essential if restricting its flux to zero
@@ -256,6 +260,10 @@ def find_essential_reactions(model, threshold=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
+    num_cpu : int, optional
+        The number of parallel processes to run. Can speed up the computations
+        if the number of knockouts to perform is large. If not passed,
+        will be set to the number of CPUs found.
 
     Returns
     -------
@@ -264,7 +272,7 @@ def find_essential_reactions(model, threshold=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_reaction_deletion(model, method='fba')
+    deletions = single_reaction_deletion(model, method='fba', num_cpu=num_cpu)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.reactions.get_by_id(r) for ids in essential for r in ids)

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -215,7 +215,7 @@ def find_blocked_reactions(model, reaction_list=None,
                 max(abs(min_max)) < zero_cutoff]
 
 
-def find_essential_genes(model, threshold=None, num_cpu=None):
+def find_essential_genes(model, threshold=None, num_proc=None):
     """Return a set of essential genes.
 
     A gene is considered essential if restricting the flux of all reactions
@@ -229,7 +229,7 @@ def find_essential_genes(model, threshold=None, num_cpu=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
-    num_cpu : int, optional
+    num_proc : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -241,13 +241,13 @@ def find_essential_genes(model, threshold=None, num_cpu=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_gene_deletion(model, method='fba', num_cpu=num_cpu)
+    deletions = single_gene_deletion(model, method='fba', num_proc=num_proc)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.genes.get_by_id(g) for ids in essential for g in ids)
 
 
-def find_essential_reactions(model, threshold=None, num_cpu=None):
+def find_essential_reactions(model, threshold=None, num_proc=None):
     """Return a set of essential reactions.
 
     A reaction is considered essential if restricting its flux to zero
@@ -260,7 +260,7 @@ def find_essential_reactions(model, threshold=None, num_cpu=None):
     threshold : float, optional
         Minimal objective flux to be considered viable. By default this is
         0.01 times the growth rate.
-    num_cpu : int, optional
+    num_proc : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
         will be set to the number of CPUs found.
@@ -272,7 +272,7 @@ def find_essential_reactions(model, threshold=None, num_cpu=None):
     """
     if threshold is None:
         threshold = model.slim_optimize(error_value=None) * 1E-02
-    deletions = single_reaction_deletion(model, method='fba', num_cpu=num_cpu)
+    deletions = single_reaction_deletion(model, method='fba', num_proc=num_proc)
     essential = deletions.loc[deletions['growth'].isna() |
                               (deletions['growth'] < threshold), :].index
     return set(model.reactions.get_by_id(r) for ids in essential for r in ids)

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -337,9 +337,9 @@ class TestCobraFluxAnalysis:
                                  'b2935': 0.863,
                                  'b4025': 0.863}}
         solution = double_gene_deletion(
-            model, gene_list1=genes, num_cpu=4)['growth']
+            model, gene_list1=genes, num_proc=4)['growth']
         solution_one_process = double_gene_deletion(
-            model, gene_list1=genes, num_cpu=1)['growth']
+            model, gene_list1=genes, num_proc=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]
@@ -365,9 +365,9 @@ class TestCobraFluxAnalysis:
         }
 
         solution = double_reaction_deletion(
-            model, reaction_list1=reactions, num_cpu=3)['growth']
+            model, reaction_list1=reactions, num_proc=3)['growth']
         solution_one_process = double_reaction_deletion(
-            model, reaction_list1=reactions, num_cpu=1)['growth']
+            model, reaction_list1=reactions, num_proc=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]
@@ -733,11 +733,11 @@ class TestCobraFluxSampling:
         assert s.shape == (10, len(model.reactions))
 
     def test_single_optgp(self, model):
-        s = sample(model, 10, processes=1)
+        s = sample(model, 10, num_proc=1)
         assert s.shape == (10, len(model.reactions))
 
     def test_multi_optgp(self, model):
-        s = sample(model, 10, processes=2)
+        s = sample(model, 10, num_proc=2)
         assert s.shape == (10, len(model.reactions))
 
     def test_wrong_method(self, model):
@@ -779,7 +779,7 @@ class TestCobraFluxSampling:
         assert all(achr.validate(achr.warmup) == "v")
         self.achr = achr
 
-        optgp = OptGPSampler(model, processes=1, thinning=1)
+        optgp = OptGPSampler(model, num_proc=1, thinning=1)
         assert ((optgp.n_warmup > 0) and
                 (optgp.n_warmup <= 2 * len(model.variables)))
         assert all(optgp.validate(optgp.warmup) == "v")
@@ -789,7 +789,7 @@ class TestCobraFluxSampling:
         benchmark(lambda: ACHRSampler(model))
 
     def test_optgp_init_benchmark(self, model, benchmark):
-        benchmark(lambda: OptGPSampler(model, processes=2))
+        benchmark(lambda: OptGPSampler(model, num_proc=2))
 
     def test_sampling(self):
         s = self.achr.sample(10)

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -337,9 +337,9 @@ class TestCobraFluxAnalysis:
                                  'b2935': 0.863,
                                  'b4025': 0.863}}
         solution = double_gene_deletion(
-            model, gene_list1=genes, num_jobs=4)['growth']
+            model, gene_list1=genes, num_cpu=4)['growth']
         solution_one_process = double_gene_deletion(
-            model, gene_list1=genes, num_jobs=1)['growth']
+            model, gene_list1=genes, num_cpu=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]
@@ -365,9 +365,9 @@ class TestCobraFluxAnalysis:
         }
 
         solution = double_reaction_deletion(
-            model, reaction_list1=reactions, num_jobs=3)['growth']
+            model, reaction_list1=reactions, num_cpu=3)['growth']
         solution_one_process = double_reaction_deletion(
-            model, reaction_list1=reactions, num_jobs=1)['growth']
+            model, reaction_list1=reactions, num_cpu=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -337,9 +337,9 @@ class TestCobraFluxAnalysis:
                                  'b2935': 0.863,
                                  'b4025': 0.863}}
         solution = double_gene_deletion(
-            model, gene_list1=genes, num_proc=4)['growth']
+            model, gene_list1=genes, processes=4)['growth']
         solution_one_process = double_gene_deletion(
-            model, gene_list1=genes, num_proc=1)['growth']
+            model, gene_list1=genes, processes=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]
@@ -365,9 +365,9 @@ class TestCobraFluxAnalysis:
         }
 
         solution = double_reaction_deletion(
-            model, reaction_list1=reactions, num_proc=3)['growth']
+            model, reaction_list1=reactions, processes=3)['growth']
         solution_one_process = double_reaction_deletion(
-            model, reaction_list1=reactions, num_proc=1)['growth']
+            model, reaction_list1=reactions, processes=1)['growth']
         for (rxn_a, sub) in iteritems(growth_dict):
             for rxn_b, growth in iteritems(sub):
                 sol = solution[frozenset([rxn_a, rxn_b])]
@@ -733,11 +733,11 @@ class TestCobraFluxSampling:
         assert s.shape == (10, len(model.reactions))
 
     def test_single_optgp(self, model):
-        s = sample(model, 10, num_proc=1)
+        s = sample(model, 10, processes=1)
         assert s.shape == (10, len(model.reactions))
 
     def test_multi_optgp(self, model):
-        s = sample(model, 10, num_proc=2)
+        s = sample(model, 10, processes=2)
         assert s.shape == (10, len(model.reactions))
 
     def test_wrong_method(self, model):
@@ -779,7 +779,7 @@ class TestCobraFluxSampling:
         assert all(achr.validate(achr.warmup) == "v")
         self.achr = achr
 
-        optgp = OptGPSampler(model, num_proc=1, thinning=1)
+        optgp = OptGPSampler(model, processes=1, thinning=1)
         assert ((optgp.n_warmup > 0) and
                 (optgp.n_warmup <= 2 * len(model.variables)))
         assert all(optgp.validate(optgp.warmup) == "v")
@@ -789,7 +789,7 @@ class TestCobraFluxSampling:
         benchmark(lambda: ACHRSampler(model))
 
     def test_optgp_init_benchmark(self, model, benchmark):
-        benchmark(lambda: OptGPSampler(model, num_proc=2))
+        benchmark(lambda: OptGPSampler(model, processes=2))
 
     def test_sampling(self):
         s = self.achr.sample(10)

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,11 @@
 
 ## New features
 
+* Add an argument `num_cpu` to the functions `find_essential_genes` and
+  `find_essential_reactions`.
+
 ## Deprecated features
 
 ## Backwards incompatible changes
+
+* Rename the argument `num_jobs` of the deletion functions to `num_cpu`.


### PR DESCRIPTION
The `find_essential_genes` and reactions functions did not have an argument to set the number of processes thus the underlying functions were always executed with multiprocessing. This PR fixes that. I have (re-)named the argument `num_cpu` everywhere. I found `num_jobs` slightly confusing since it's about the number of processes and not jobs. I chose `num_cpu` since it is closer to `os.` or `multiprocessing.cpu_count` but would be fine with `num_proc`, too.