### PR TITLE
fix: add ruamel back into the mock list

### DIFF
--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -51,7 +51,7 @@ MOCK_MODULES = [
     'optlang', 'optlang.interface', 'optlang.symbolics',
     'optlang.symbolics.core',
     'future', 'future.utils',
-    'ruamel.yaml'
+    'ruamel', 'ruamel.yaml'
 ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()


### PR DESCRIPTION
Necessary to mock `'ruamel'` otherwise rtfd barfs.