### PR TITLE
Fix: capture all optlang exceptions

### DIFF
--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -422,4 +422,5 @@ def assert_optimal(model, message='optimization failed'):
         Message to for the exception if solver status was not optimal.
     """
     if model.solver.status != optlang.interface.OPTIMAL:
-        raise OPTLANG_TO_EXCEPTIONS_DICT[model.solver.status](message)
+        exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(model.solver.status, OptimizationError)
+        raise exception_cls("%s (%s)" % (message, model.solver.status))

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -421,7 +421,8 @@ def assert_optimal(model, message='optimization failed'):
     message : str (optional)
         Message to for the exception if solver status was not optimal.
     """
-    if model.solver.status != optlang.interface.OPTIMAL:
+    status = model.solver.status
+    if status != optlang.interface.OPTIMAL:
         status = model.solver.status
         exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(status, OptimizationError)
-        raise exception_cls("%s (%s)" % (message, status))
+        raise exception_cls("{} ({})".format(message, status))

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -424,5 +424,5 @@ def assert_optimal(model, message='optimization failed'):
     status = model.solver.status
     if status != optlang.interface.OPTIMAL:
         status = model.solver.status
-        exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(status, OptimizationError)
-        raise exception_cls("{} ({})".format(message, status))
+        excep_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(status, OptimizationError)
+        raise excep_cls("{} ({})".format(message, status))

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -423,6 +423,6 @@ def assert_optimal(model, message='optimization failed'):
     """
     status = model.solver.status
     if status != optlang.interface.OPTIMAL:
-        status = model.solver.status
-        excep_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(status, OptimizationError)
-        raise excep_cls("{} ({})".format(message, status))
+        exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(
+            status, OptimizationError)
+        raise exception_cls("{} ({})".format(message, status))

--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -422,5 +422,6 @@ def assert_optimal(model, message='optimization failed'):
         Message to for the exception if solver status was not optimal.
     """
     if model.solver.status != optlang.interface.OPTIMAL:
-        exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(model.solver.status, OptimizationError)
-        raise exception_cls("%s (%s)" % (message, model.solver.status))
+        status = model.solver.status
+        exception_cls = OPTLANG_TO_EXCEPTIONS_DICT.get(status, OptimizationError)
+        raise exception_cls("%s (%s)" % (message, status))


### PR DESCRIPTION
Optlang returns more solver status than the ones mapped in the current implementation.

To address that problem, we raise a cobrapy specific exception if it is mapped or a OptimizationError.

We include the solver status in the message to provide the user with a cause for failure. 