### PR TITLE
refactor: allow an external solution for MOMA

### DIFF
--- a/cobra/flux_analysis/deletion.py
+++ b/cobra/flux_analysis/deletion.py
@@ -110,7 +110,7 @@ def _multi_deletion(model, entity, element_lists, method="fba",
             The solution's status.
     """
     solver = sutil.interface_to_str(model.problem.__name__)
-    if "moma" in method and solver not in sutil.qp_solvers:
+    if "moma" == method and solver not in sutil.qp_solvers:
         raise RuntimeError(
             "Cannot use MOMA since '{}' is not QP-capable."
             "Please choose a different solver or use FBA only.".format(solver))

--- a/cobra/flux_analysis/deletion.py
+++ b/cobra/flux_analysis/deletion.py
@@ -72,7 +72,7 @@ def _init_worker(model):
 
 
 def _multi_deletion(model, entity, element_lists, method="fba",
-                    processes=None):
+                    solution=None, processes=None):
     """
     Provide a common interface for single or multiple knockouts.
 
@@ -80,17 +80,15 @@ def _multi_deletion(model, entity, element_lists, method="fba",
     ----------
     model : cobra.Model
         The metabolic model to perform deletions in.
-
     entity : 'gene' or 'reaction'
         The entity to knockout (``cobra.Gene`` or ``cobra.Reaction``).
-
     element_lists : list
         List of iterables ``cobra.Reaction``s or ``cobra.Gene``s (or their IDs)
         to be deleted.
-
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
-
+    solution : cobra.Solution
+        A previous solution to use as a reference for (linear) MOMA.
     processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
@@ -124,7 +122,7 @@ def _multi_deletion(model, entity, element_lists, method="fba",
 
     with model:
         if "moma" in method:
-            add_moma(model, linear="linear" in method)
+            add_moma(model, solution=solution, linear="linear" in method)
 
         args = set([frozenset(comb) for comb in product(*element_lists)])
         processes = min(processes, len(args))
@@ -180,7 +178,7 @@ def _element_lists(entities, *ids):
 
 
 def single_reaction_deletion(model, reaction_list=None, method="fba",
-                             processes=None):
+                             solution=None, processes=None):
     """
     Knock out each reaction from a given list.
 
@@ -188,14 +186,13 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     ----------
     model : cobra.Model
         The metabolic model to perform deletions in.
-
     reaction_list : iterable
         ``cobra.Reaction``s to be deleted. If not passed,
         all the reactions from the model are used.
-
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
-
+    solution : cobra.Solution
+        A previous solution to use as a reference for (linear) MOMA.
     processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
@@ -218,10 +215,11 @@ def single_reaction_deletion(model, reaction_list=None, method="fba",
     return _multi_deletion(
         model, 'reaction',
         element_lists=_element_lists(model.reactions, reaction_list),
-        method=method, processes=processes)
+        method=method, solution=solution, processes=processes)
 
 
-def single_gene_deletion(model, gene_list=None, method="fba", processes=None):
+def single_gene_deletion(model, gene_list=None, method="fba", solution=None,
+                         processes=None):
     """
     Knock out each gene from a given list.
 
@@ -229,14 +227,13 @@ def single_gene_deletion(model, gene_list=None, method="fba", processes=None):
     ----------
     model : cobra.Model
         The metabolic model to perform deletions in.
-
     gene_list : iterable
         ``cobra.Gene``s to be deleted. If not passed,
         all the genes from the model are used.
-
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
-
+    solution : cobra.Solution
+        A previous solution to use as a reference for (linear) MOMA.
     processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
@@ -258,11 +255,11 @@ def single_gene_deletion(model, gene_list=None, method="fba", processes=None):
     """
     return _multi_deletion(
         model, 'gene', element_lists=_element_lists(model.genes, gene_list),
-        method=method, processes=processes)
+        method=method, solution=solution, processes=processes)
 
 
 def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
-                             method="fba", processes=None):
+                             method="fba", solution=None, processes=None):
     """
     Knock out each reaction pair from the combinations of two given lists.
 
@@ -272,18 +269,16 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
     ----------
     model : cobra.Model
         The metabolic model to perform deletions in.
-
     reaction_list1 : iterable, optional
         First iterable of ``cobra.Reaction``s to be deleted. If not passed,
         all the reactions from the model are used.
-
     reaction_list2 : iterable, optional
         Second iterable of ``cobra.Reaction``s to be deleted. If not passed,
         all the reactions from the model are used.
-
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
-
+    solution : cobra.Solution
+        A previous solution to use as a reference for (linear) MOMA.
     processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
@@ -309,11 +304,11 @@ def double_reaction_deletion(model, reaction_list1=None, reaction_list2=None,
                                                     reaction_list2)
     return _multi_deletion(
         model, 'reaction', element_lists=[reaction_list1, reaction_list2],
-        method=method, processes=processes)
+        method=method, solution=solution, processes=processes)
 
 
 def double_gene_deletion(model, gene_list1=None, gene_list2=None,
-                         method="fba", processes=None):
+                         method="fba", solution=None, processes=None):
     """
     Knock out each gene pair from the combination of two given lists.
 
@@ -323,18 +318,16 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
     ----------
     model : cobra.Model
         The metabolic model to perform deletions in.
-
     gene_list1 : iterable, optional
         First iterable of ``cobra.Gene``s to be deleted. If not passed,
         all the genes from the model are used.
-
     gene_list2 : iterable, optional
         Second iterable of ``cobra.Gene``s to be deleted. If not passed,
         all the genes from the model are used.
-
     method: {"fba", "moma", "linear moma"}, optional
         Method used to predict the growth rate.
-
+    solution : cobra.Solution
+        A previous solution to use as a reference for (linear) MOMA.
     processes : int, optional
         The number of parallel processes to run. Can speed up the computations
         if the number of knockouts to perform is large. If not passed,
@@ -359,4 +352,4 @@ def double_gene_deletion(model, gene_list1=None, gene_list2=None,
                                             gene_list2)
     return _multi_deletion(
         model, 'gene', element_lists=[gene_list1, gene_list2],
-        method=method, processes=processes)
+        method=method, solution=solution, processes=processes)

--- a/cobra/flux_analysis/deletion.py
+++ b/cobra/flux_analysis/deletion.py
@@ -108,7 +108,7 @@ def _multi_deletion(model, entity, element_lists, method="fba",
             The solution's status.
     """
     solver = sutil.interface_to_str(model.problem.__name__)
-    if "moma" == method and solver not in sutil.qp_solvers:
+    if method == "moma" and solver not in sutil.qp_solvers:
         raise RuntimeError(
             "Cannot use MOMA since '{}' is not QP-capable."
             "Please choose a different solver or use FBA only.".format(solver))

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -146,7 +146,7 @@ def flux_variability_analysis(model, reaction_list=None, loopless=False,
                 model.solver.objective.set_linear_coefficients(
                     {rxn.forward_variable: 0, rxn.reverse_variable: 0})
 
-    return fva_results
+    return fva_results[["minimum", "maximum"]]
 
 
 def find_blocked_reactions(model, reaction_list=None,

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -511,7 +511,7 @@ class TestCobraFluxAnalysis:
 
     def test_fva_data_frame(self, model):
         df = flux_variability_analysis(model)
-        assert numpy.all([df.columns.values == ['maximum', 'minimum']])
+        assert numpy.all([df.columns.values == ['minimum', 'maximum']])
 
     def test_fva_infeasible(self, model):
         infeasible_model = model.copy()


### PR DESCRIPTION
* Fix a small bug that required a QP-capable solver even for linear MOMA.
* Allow all relevant functions to accept an external solution to be used as a reference when using MOMA in deletion studies.