### PR TITLE
Quick edit to reaction.add_metabolites

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -743,8 +743,8 @@ class Reaction(Object):
             # Make sure metabolites being added belong to the same model, or
             # else copy them.
             if isinstance(metabolite, Metabolite):
-                if ((metabolite.model is not None) &
-                        (metabolite.model != self._model)):
+                if ((metabolite.model is not None) and
+                        (metabolite.model is not self._model)):
                     metabolite = metabolite.copy()
 
             met_id = str(metabolite)

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -739,6 +739,14 @@ class Reaction(Object):
         _id_to_metabolites = dict([(x.id, x) for x in self._metabolites])
 
         for metabolite, coefficient in iteritems(metabolites_to_add):
+
+            # Make sure metabolites being added belong to the same model, or
+            # else copy them.
+            if isinstance(metabolite, Metabolite):
+                if ((metabolite.model is not None) &
+                        (metabolite.model != self._model)):
+                    metabolite = metabolite.copy()
+
             met_id = str(metabolite)
             # If a metabolite already exists in the reaction then
             # just add them.


### PR DESCRIPTION
Previously calling `model.reactions.rxn1 + model.reactions.rxn2` would cause the metabolites from rxn2 to be added to the new lumped reaction, while the lumped reaction didn't belong to any model.

This ensures that metabolites being added to a reaction belong to the same model, or are duplicated prior to adding.

@cdiener, locally I'm getting an error with the sampling code based on the fixed seed. Any idea why that might be? Should I just change the test to reflect the new value?

```python
    def test_fixed_seed(self, model):
        s = sample(model, 1, seed=42)
>       assert numpy.allclose(s.TPI[0], 9.12037487)
E       assert False
E        +  where False = <function allclose at 0x1159ace18>(9.002806727659744, 9.12037487)
E        +    where <function allclose at 0x1159ace18> = numpy.allclose

cobra/test/test_flux_analysis.py:762: AssertionError
```