### PR TITLE
Drop usage of unsupported pip api

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,9 +20,9 @@ Create a [minimal, complete, verifiable example
 
 #### Expected Output
 
-#### Output of `cobra.show_versions()`
+#### Version information
 
-<details>
-# Paste the output of `import cobra;cobra.show_versions()` here.
+Paste the output of the following commands here:
 
-</details>
+* `import cobra;cobra.show_versions()`
+* `pip list --format=columns`

--- a/cobra/test/test_util.py
+++ b/cobra/test/test_util.py
@@ -9,8 +9,7 @@ import pytest
 from six.moves import range
 
 from cobra import DictList, Object
-from cobra.util.version_info import (
-    get_sys_info, get_pkg_info, show_versions, SYS_ORDER, PKG_ORDER)
+from cobra.util.version_info import get_sys_info, show_versions, SYS_ORDER
 
 
 @pytest.fixture(scope="function")
@@ -306,10 +305,6 @@ class TestVersionInfo:
     def sys_info(self):
         return get_sys_info()
 
-    @pytest.fixture(scope="module")
-    def pkg_info(self):
-        return get_pkg_info()
-
     @pytest.mark.parametrize("key", SYS_ORDER)
     def test_sys_info_key(self, key, sys_info):
         assert key in sys_info
@@ -318,19 +313,7 @@ class TestVersionInfo:
     def test_sys_info_value(self, key, sys_info):
         assert len(sys_info[key]) > 0
 
-    @pytest.mark.parametrize("key", PKG_ORDER)
-    def test_pkg_info_key(self, key, pkg_info):
-        if key in self.SKIP_OPTIONAL:
-            pytest.skip()
-        assert key in pkg_info
-
-    @pytest.mark.parametrize("key", PKG_ORDER)
-    def test_pkg_info_value(self, key, pkg_info):
-        if key in self.SKIP_OPTIONAL:
-            pytest.skip()
-        assert len(pkg_info[key]) > 0
-
-    def test_show_versions(self, sys_info, pkg_info, capsys):
+    def test_show_versions(self, sys_info, capsys):
         show_versions()
         out, err = capsys.readouterr()
         lines = out.split("\n")
@@ -341,12 +324,3 @@ class TestVersionInfo:
             assert line.endswith(sys_info[key])
             i += 1
         i += 3
-        for key in PKG_ORDER:
-            line = lines[i]
-            if key in self.SKIP_OPTIONAL:
-                if line.startswith(key):
-                    i += 1
-                continue
-            assert line.startswith(key)
-            assert line.endswith(pkg_info[key])
-            i += 1

--- a/cobra/util/version_info.py
+++ b/cobra/util/version_info.py
@@ -10,32 +10,12 @@ from builtins import dict
 
 import platform
 
-import pip
-
 __all__ = ("show_versions",)
 
 SYS_ORDER = [
     "OS",
     "OS-release",
     "Python"
-]
-PKG_ORDER = [
-    "pip",
-    "setuptools",
-    "cobra",
-    "future",
-    "swiglpk",
-    "optlang",
-    "ruamel.yaml",
-    "pandas",
-    "numpy",
-    "tabulate",
-    "python-libsbml",
-    "lxml",
-    "scipy",
-    "matplotlib",
-    "palettable",
-    "pymatbridge"
 ]
 
 
@@ -48,32 +28,12 @@ def get_sys_info():
     return blob
 
 
-def get_pkg_info():
-    """Returns Python package information as a dict."""
-    # TODO: Basically copying the requirements from setup.py is brittle,
-    # should come up with a better way in future, for example,
-    # using requirements files that can be read in.
-    dependencies = frozenset(PKG_ORDER)
-    blob = dict()
-    for dist in pip.get_installed_distributions():
-        if dist.project_name in dependencies:
-            blob[dist.project_name] = dist.version
-    return blob
-
-
 def show_versions():
     """Print the formatted information to standard out."""
     info = get_sys_info()
-    info.update(get_pkg_info())
     format_str = "{:<%d} {:>%d}" % (max(map(len, info)),
                                     max(map(len, info.values())))
     print("\nSystem Information")
     print("==================")
     for name in SYS_ORDER:
         print(format_str.format(name, info[name]))
-
-    print("\nPackage Versions")
-    print("================")
-    for name in PKG_ORDER:
-        if name in info:
-            print(format_str.format(name, info[name]))


### PR DESCRIPTION
[From pip v9.0.2, importing pip after certain packages, like requests, fails](https://github.com/pypa/pip/issues/5079). That can cause problems with applications using cobrapy. Additionally, pip now [makes it pretty clear that the internal api is not supported](https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html).

This PR removes package print output from `show_versions` and instead encourages issue reporters to include the output of `pip list`.