### PR TITLE
Fix a regression bug in loopless FVA

### DIFF
--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -228,7 +228,6 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
         reaction.bounds = bounds
         # find the reactions with loops using the current reaction and remove
         # the loops
-        print(ll_sol, almost_ll_sol)
         for rxn in model.reactions:
             rid = rxn.id
             if ((abs(ll_sol[rid]) < zero_cutoff) and

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -221,11 +221,11 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
         # almost loopless solution containing only loops including the current
         # reaction. Than remove all of those loops.
         ll_sol = get_solution(model).fluxes
-        bounds = reaction.bounds
         reaction.bounds = (current, current)
         model.slim_optimize()
         almost_ll_sol = get_solution(model).fluxes
-        reaction.bounds = bounds
+        print(ll_sol, almost_ll_sol)
+    with model:
         # find the reactions with loops using the current reaction and remove
         # the loops
         for rxn in model.reactions:
@@ -234,7 +234,6 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
                     (abs(almost_ll_sol[rid]) > zero_cutoff)):
                 rxn.bounds = max(0, rxn.lower_bound), min(0, rxn.upper_bound)
 
-        model.objective = reaction
         if solution:
             best = model.optimize()
         else:

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -90,10 +90,10 @@ def _add_cycle_free(model, fluxes):
             rxn.bounds = (flux, flux)
             continue
         if flux >= 0:
-            rxn.lower_bound = max(0, rxn.lower_bound)
+            rxn.bounds = max(0, rxn.lower_bound), flux
             objective_vars.append(rxn.forward_variable)
         else:
-            rxn.upper_bound = min(0, rxn.upper_bound)
+            rxn.bounds = flux, min(0, rxn.upper_bound)
             objective_vars.append(rxn.reverse_variable)
 
     model.objective.set_linear_coefficients(dict.fromkeys(objective_vars, 1.0))
@@ -208,11 +208,11 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
 
     with model:
         _add_cycle_free(model, sol.fluxes)
-        flux = model.slim_optimize()
+        model.slim_optimize()
 
         # If the previous optimum is maintained in the loopless solution it was
         # loopless and we are done
-        if abs(flux - current) < zero_cutoff:
+        if abs(reaction.flux - current) < zero_cutoff:
             if solution:
                 return sol
             return current
@@ -228,12 +228,14 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
         reaction.bounds = bounds
         # find the reactions with loops using the current reaction and remove
         # the loops
+        print(ll_sol, almost_ll_sol)
         for rxn in model.reactions:
             rid = rxn.id
             if ((abs(ll_sol[rid]) < zero_cutoff) and
                     (abs(almost_ll_sol[rid]) > zero_cutoff)):
                 rxn.bounds = max(0, rxn.lower_bound), min(0, rxn.upper_bound)
 
+        model.objective = reaction
         if solution:
             best = model.optimize()
         else:

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -90,10 +90,10 @@ def _add_cycle_free(model, fluxes):
             rxn.bounds = (flux, flux)
             continue
         if flux >= 0:
-            rxn.bounds = max(0, rxn.lower_bound), flux
+            rxn.bounds = max(0, rxn.lower_bound), max(flux, rxn.upper_bound)
             objective_vars.append(rxn.forward_variable)
         else:
-            rxn.bounds = flux, min(0, rxn.upper_bound)
+            rxn.bounds = min(flux, rxn.lower_bound), min(0, rxn.upper_bound)
             objective_vars.append(rxn.reverse_variable)
 
     model.objective.set_linear_coefficients(dict.fromkeys(objective_vars, 1.0))

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -224,7 +224,7 @@ def loopless_fva_iter(model, reaction, solution=False, zero_cutoff=1e-6):
         reaction.bounds = (current, current)
         model.slim_optimize()
         almost_ll_sol = get_solution(model).fluxes
-        print(ll_sol, almost_ll_sol)
+
     with model:
         # find the reactions with loops using the current reaction and remove
         # the loops


### PR DESCRIPTION
Used the loopless objective as the target flux. Also there was a missing with block which would not reset the exchange fluxes correctly. Some other small fixes that do not actually affect anything but make the method more explicit.