### PR TITLE
refactor: unify objective creation

### DIFF
--- a/benchmarks/objective_benchmark.ipynb
+++ b/benchmarks/objective_benchmark.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cobra.io import read_sbml_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from optlang.symbolics import Zero, One, add, mul, Add, Mul, Real"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one = Real(1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = read_sbml_model(\"/home/moritz/Projects/memote/Models/iJO1366.xml.gz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cobra.util.solver as sutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from itertools import chain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.solver = \"glpk\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction_variables = ((rxn.forward_variable, rxn.reverse_variable)\n",
+    "                      for rxn in model.reactions)\n",
+    "variables = list(chain(*reaction_variables))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "146 ms ± 3.94 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        Zero, direction='min', sloppy=True,\n",
+    "        name=\"_pfba_objective\")\n",
+    "    model.objective.set_linear_coefficients({v: 1.0 for v in variables})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "149 ms ± 2.13 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        add([mul(one, v) for v in variables]),\n",
+    "        direction='min', sloppy=True, name=\"_pfba_objective\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.solver = \"gurobi\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction_variables = ((rxn.forward_variable, rxn.reverse_variable)\n",
+    "                      for rxn in model.reactions)\n",
+    "variables = list(chain(*reaction_variables))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13.7 ms ± 269 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        Zero, direction='min', sloppy=True,\n",
+    "        name=\"_pfba_objective\")\n",
+    "    model.objective.set_linear_coefficients({v: 1.0 for v in variables})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "218 ms ± 2.55 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        add([mul(one, v) for v in variables]),\n",
+    "        direction='min', sloppy=True, name=\"_pfba_objective\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.solver = \"cplex\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction_variables = ((rxn.forward_variable, rxn.reverse_variable)\n",
+    "                      for rxn in model.reactions)\n",
+    "variables = list(chain(*reaction_variables))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.04 s ± 32.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        Zero, direction='min', sloppy=True,\n",
+    "        name=\"_pfba_objective\")\n",
+    "    model.objective.set_linear_coefficients({v: 1.0 for v in variables})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "183 ms ± 5.28 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "with model:\n",
+    "    model.objective = model.problem.Objective(\n",
+    "        add([mul(one, v) for v in variables]),\n",
+    "        direction='min', sloppy=True, name=\"_pfba_objective\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cobra/flux_analysis/gapfilling.py
+++ b/cobra/flux_analysis/gapfilling.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from optlang.symbolics import Add
+from optlang.symbolics import add, Zero
 
 from optlang.interface import OPTIMAL
 from cobra.core import Model
@@ -183,7 +183,9 @@ class GapFiller(object):
         self.model.add_cons_vars(self.indicators)
         self.model.add_cons_vars(constraints, sloppy=True)
         self.model.objective = prob.Objective(
-            Add(*self.indicators), direction='min')
+            Zero, direction='min', sloppy=True)
+        self.model.objective.set_linear_coefficients({
+            i: 1 for i in self.indicators})
         self.update_costs()
 
     def fill(self, iterations=1):

--- a/cobra/flux_analysis/loopless.py
+++ b/cobra/flux_analysis/loopless.py
@@ -82,7 +82,8 @@ def add_loopless(model, zero_cutoff=1e-12):
 
 def _add_cycle_free(model, fluxes):
     """Add constraints for CycleFreeFlux."""
-    model.objective = Zero
+    model.objective = model.solver.interface.Objective(
+        Zero, direction="min", sloppy=True)
     objective_vars = []
     for rxn in model.reactions:
         flux = fluxes[rxn.id]
@@ -96,8 +97,7 @@ def _add_cycle_free(model, fluxes):
             rxn.bounds = min(flux, rxn.lower_bound), min(0, rxn.upper_bound)
             objective_vars.append(rxn.reverse_variable)
 
-    model.objective.set_linear_coefficients(dict.fromkeys(objective_vars, 1.0))
-    model.objective.direction = "min"
+    model.objective.set_linear_coefficients({v: 1.0 for v in objective_vars})
 
 
 def loopless_solution(model, fluxes=None):

--- a/cobra/flux_analysis/parsimonious.py
+++ b/cobra/flux_analysis/parsimonious.py
@@ -100,6 +100,5 @@ def add_pfba(model, objective=None, fraction_of_optimum=1.0):
                           for rxn in model.reactions)
     variables = chain(*reaction_variables)
     model.objective = model.problem.Objective(
-        Zero, direction='min', sloppy=True,
-        name="_pfba_objective")
-    model.objective.set_linear_coefficients(dict.fromkeys(variables, 1.0))
+        Zero, direction='min', sloppy=True, name="_pfba_objective")
+    model.objective.set_linear_coefficients({v: 1.0 for v in variables})

--- a/cobra/flux_analysis/room.py
+++ b/cobra/flux_analysis/room.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import
 
-from optlang.symbolics import Zero, NegativeOne, Add, Mul
+from optlang.symbolics import Zero, add, mul
 
 
 def add_room(model, solution=None, linear=False, delta=0.03, epsilon=1E-03):
@@ -65,53 +65,39 @@ def add_room(model, solution=None, linear=False, delta=0.03, epsilon=1E-03):
     if solution is None:
         solution = model.optimize()
 
-    problem = model.problem
-    variable = problem.Variable("room_old_objective",
-                                ub=solution.objective_value)
-    constraint = problem.Constraint(
+    prob = model.problem
+    variable = prob.Variable("room_old_objective", ub=solution.objective_value)
+    constraint = prob.Constraint(
         model.solver.objective.expression - variable,
         ub=0.0,
         lb=0.0,
         name="room_old_objective_constraint"
     )
-    new_objective = Zero
+    model.objective = prob.Objective(Zero, direction="min", sloppy=True)
     vars_and_cons = [variable, constraint]
+    obj_vars = []
 
     for rxn in model.reactions:
         flux = solution.fluxes[rxn.id]
 
         if linear:
-            y = problem.Variable("y_" + rxn.id, lb=0, ub=1)
+            y = prob.Variable("y_" + rxn.id, lb=0, ub=1)
             delta = epsilon = Zero
         else:
-            y = problem.Variable("y_" + rxn.id, type="binary")
+            y = prob.Variable("y_" + rxn.id, type="binary")
 
         # upper constraint
         w_u = flux + (delta * abs(flux)) + epsilon
-        upper_const = problem.Constraint(
-            Add(rxn.flux_expression,
-                Mul(NegativeOne,
-                    y,
-                    Add(rxn.upper_bound,
-                        Mul(NegativeOne,
-                            w_u)))),
-            ub=w_u,
-            name="room_constraint_upper_" + rxn.id
-        )
+        upper_const = prob.Constraint(
+            rxn.flux_expression - y * (rxn.upper_bound - w_u),
+            ub=w_u, name="room_constraint_upper_" + rxn.id)
         # lower constraint
         w_l = flux - (delta * abs(flux)) - epsilon
-        lower_const = problem.Constraint(
-            Add(rxn.flux_expression,
-                Mul(NegativeOne,
-                    y,
-                    Add(rxn.lower_bound,
-                        Mul(NegativeOne,
-                            w_l)))),
-            lb=w_l,
-            name="room_constraint_lower_" + rxn.id,
-        )
+        lower_const = prob.Constraint(
+            rxn.flux_expression - y * (rxn.lower_bound - w_l),
+            lb=w_l, name="room_constraint_lower_" + rxn.id)
         vars_and_cons.extend([y, upper_const, lower_const])
-        new_objective += y
+        obj_vars.append(y)
 
     model.add_cons_vars(vars_and_cons)
-    model.objective = problem.Objective(new_objective, direction="min")
+    model.objective.set_linear_coefficients({v: 1.0 for v in obj_vars})

--- a/cobra/flux_analysis/variability.py
+++ b/cobra/flux_analysis/variability.py
@@ -128,6 +128,7 @@ def flux_variability_analysis(model, reaction_list=None, loopless=False,
         model.objective = Zero  # This will trigger the reset as well
         for what in ("minimum", "maximum"):
             sense = "min" if what == "minimum" else "max"
+            model.solver.objective.direction = sense
             for rxn in reaction_list:
                 # The previous objective assignment already triggers a reset
                 # so directly update coefs here to not trigger redundant resets
@@ -135,7 +136,6 @@ def flux_variability_analysis(model, reaction_list=None, loopless=False,
                 # FVA for small models
                 model.solver.objective.set_linear_coefficients(
                     {rxn.forward_variable: 1, rxn.reverse_variable: -1})
-                model.solver.objective.direction = sense
                 model.slim_optimize()
                 sutil.check_solver_status(model.solver.status)
                 if loopless:

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -204,12 +204,6 @@ class TestCobraFluxAnalysis:
                   method="moma", processes=1)
 
     def test_single_deletion_linear_moma_benchmark(self, model, benchmark):
-        try:
-            solver = sutil.get_solver_name(qp=True)
-            model.solver = solver
-        except sutil.SolverNotFound:
-            pytest.skip("no qp support")
-
         genes = ['b0008', 'b0114', 'b2276', 'b1779']
         benchmark(single_gene_deletion, model=model, gene_list=genes,
                   method="linear moma", processes=1)
@@ -293,12 +287,6 @@ class TestCobraFluxAnalysis:
 
     def test_linear_moma_sanity(self, model):
         """Test optimization criterion and optimality."""
-        try:
-            solver = sutil.get_solver_name(qp=True)
-            model.solver = solver
-        except sutil.SolverNotFound:
-            pytest.skip("no qp support")
-
         sol = model.optimize()
         with model:
             model.reactions.PFK.knock_out()
@@ -330,12 +318,6 @@ class TestCobraFluxAnalysis:
                 add_moma(model)
 
     def test_single_gene_deletion_linear_moma(self, model):
-        try:
-            solver = sutil.get_solver_name(qp=True)
-            model.solver = solver
-        except sutil.SolverNotFound:
-            pytest.skip("no qp support")
-
         # expected knockouts for textbook model
         growth_dict = {"b0008": 0.87, "b0114": 0.76, "b0116": 0.65,
                        "b2276": 0.08, "b1779": 0.00}
@@ -397,6 +379,7 @@ class TestCobraFluxAnalysis:
     @pytest.mark.parametrize("solver", optlang_solvers)
     def test_linear_room_sanity(self, model, solver):
         sol = model.optimize()
+        model.solver = solver
         with model:
             model.reactions.PFK.knock_out()
             knock_sol = model.optimize()

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -371,6 +371,7 @@ class TestCobraFluxAnalysis:
     @pytest.mark.parametrize("solver", optlang_solvers)
     def test_room_sanity(self, solver):
         model = construct_papin_2003_model()
+        model.solver = solver
         sol = model.optimize()
         with model:
             model.reactions.v3.knock_out()

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -345,7 +345,8 @@ class TestCobraFluxAnalysis:
         benchmark(single_gene_deletion, model=model, gene_list=genes,
                   method="room", processes=1)
 
-    def test_single_gene_deletion_linear_room_benchmark(self, model, benchmark):
+    def test_single_gene_deletion_linear_room_benchmark(self, model,
+                                                        benchmark):
         genes = ['b0008', 'b0114', 'b2276', 'b1779']
         benchmark(single_gene_deletion, model=model, gene_list=genes,
                   method="linear room", processes=1)

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -358,6 +358,16 @@ class TestCobraFluxAnalysis:
         model.solver = solver
         benchmark(single_reaction_deletion, model=model, processes=1)
 
+    def test_single_gene_deletion_room_benchmark(self, model, benchmark):
+        genes = ['b0008', 'b0114', 'b2276', 'b1779']
+        benchmark(single_gene_deletion, model=model, gene_list=genes,
+                  method="room", processes=1)
+
+    def test_single_gene_deletion_linear_room_benchmark(self, model, benchmark):
+        genes = ['b0008', 'b0114', 'b2276', 'b1779']
+        benchmark(single_gene_deletion, model=model, gene_list=genes,
+                  method="linear room", processes=1)
+
     @pytest.mark.parametrize("solver", optlang_solvers)
     def test_room_sanity(self, solver):
         model = construct_papin_2003_model()


### PR DESCRIPTION
This pull request:

* add benchmarks for ROOM
* fix some solver argument usage to test cases
* in most cases makes use of `Objective.set_linear_coefficients`
* brings down the time for `add_moma` and `add_room` for iML1515 from ~5 min to ~6 s