### PR TITLE
ROOM sanity check fix

### DIFF
--- a/cobra/flux_analysis/moma.py
+++ b/cobra/flux_analysis/moma.py
@@ -11,7 +11,7 @@ import cobra.util.solver as sutil
 from cobra.flux_analysis.parsimonious import pfba
 
 
-def moma(model, solution, linear=True):
+def moma(model, solution=None, linear=True):
     """
     Compute a single solution based on (linear) MOMA.
 
@@ -25,7 +25,7 @@ def moma(model, solution, linear=True):
     ----------
     model : cobra.Model
         The model state to compute a MOMA-based solution for.
-    solution : cobra.Solution
+    solution : cobra.Solution, optional
         A (wildtype) reference solution.
     linear : bool, optional
         Whether to use the linear MOMA formulation or not (default True).

--- a/cobra/flux_analysis/room.py
+++ b/cobra/flux_analysis/room.py
@@ -9,7 +9,7 @@ from optlang.symbolics import Zero
 from cobra.flux_analysis.parsimonious import pfba
 
 
-def room(model, solution, linear=False, delta=0.03, epsilon=1E-03):
+def room(model, solution=None, linear=False, delta=0.03, epsilon=1E-03):
     """
     Compute a single solution based on regulatory on/off minimization (ROOM).
 
@@ -28,11 +28,9 @@ def room(model, solution, linear=False, delta=0.03, epsilon=1E-03):
     linear : bool, optional
         Whether to use the linear ROOM formulation or not (default False).
     delta: float, optional
-        The relative tolerance range which is additive in nature
-        (default 0.03).
+        The relative tolerance range (additive) (default 0.03).
     epsilon: float, optional
-        The absolute range of tolerance which is multiplicative
-        (default 0.001).
+        The absolute tolerance range (multiplicative) (default 0.001).
 
     Returns
     -------

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -444,10 +444,11 @@ class TestCobraFluxAnalysis:
         flux_change = (sol.fluxes - knock_sol.fluxes).abs().sum()
         flux_change_room = (sol.fluxes - room_sol.fluxes).abs().sum()
         flux_change_room_ref = (sol.fluxes - room_sol_ref.fluxes).abs().sum()
-        # Expect the ROOM solution to have smaller flux changes in 
+        # Expect the ROOM solution to have smaller flux changes in
         # reactions compared to a normal FBA.
-        assert flux_change_room <=flux_change 
-        # Expect the FBA-based reference to have less change in flux distribution.
+        assert flux_change_room <= flux_change
+        # Expect the FBA-based reference to have less change in
+        # flux distribution.
         assert flux_change_room_ref >= flux_room_ref
 
     @pytest.mark.parametrize("solver", optlang_solvers)


### PR DESCRIPTION
Aim:
1. This PR addresses the issue of the ROOM sanity check issue with default model. 
2. It also modifies the existing tests just to be close to the aim of the method.

Modifications:
1. The knock-out reaction has been taken as PYK as the paper states it is a better candidate for this purpose. This solves the GLPK solution issue.
2. The assertions have been changed to fit the proper criteria.
3. The ROOM and MOMA methods have been modified so as to make the solution being optional as opposed to the positional (previously).

@Midnighter please review the changes!