### PR TITLE
Some proposed changes to the solver utilities

### DIFF
--- a/cobra/util/solver.py
+++ b/cobra/util/solver.py
@@ -407,7 +407,7 @@ def check_solver_status(status, raise_error=False):
     elif (status in has_primals) and not raise_error:
         warn("solver status is '{}'".format(status), UserWarning)
     elif status is None:
-        raise RuntimeError(
+        raise OptimizationError(
             "model was not optimized yet or solver context switched")
     else:
         raise OptimizationError("solver status is '{}'".format(status))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "ruamel.yaml<0.15",
         "numpy>=1.13",
         "pandas>=0.17.0",
-        "optlang>=1.2.5",
+        "optlang>=1.4.2",
         "tabulate",
         "depinfo"
     ],


### PR DESCRIPTION
This fixes some smaller issues with the solver utilities.

### check_solver_status

The only states currently allowed are OPTIMAL and INFEASIBLE (which throws a warning). However, there are many states that also allow returning fluxes (primal values) and are actually less problematic than INFEASIBLE. For larger models there is FEASIBLE, SUBOPTIMAL or NUMERIC which indicate that the solver found a feasible solution but is not sure whether it is really an optimum (it usually is). I think it should at least be possible to obtain the fluxes from those solver states but currently this is prohibited.

### Gurobi compatibility

optlang has implemented the QP solver for Gurobi since some time now and it seems to work well in my tests (better numerical stability than the cplex one). So I enabled it for the QP problems.

### Bump optlang version

Bumped the optlang version to 1.4.2 to have the QP solver for Gurobi and to avoid the Gurobi bug from 1.4.1 .

*Those changes are not backwards compatible.*