### PR TITLE
fix tests for MOMA and make geometric FBA work with cplex and gurobi

### DIFF
--- a/cobra/flux_analysis/geometric.py
+++ b/cobra/flux_analysis/geometric.py
@@ -79,7 +79,7 @@ def geometric_fba(model, epsilon=1E-06, max_tries=200):
         # minimize distance between flux and centre
         model.objective = prob.Objective(Zero, sloppy=True, direction="min")
         model.objective.set_linear_coefficients({v: 1.0 for v in obj_vars})
-        model.optimize()
+        sol = model.optimize()
 
         # further iterations
         while delta > epsilon and count <= max_tries:
@@ -90,7 +90,7 @@ def geometric_fba(model, epsilon=1E-06, max_tries=200):
                 var.ub = mean_flux[rxn_id]
                 u_c.ub = mean_flux[rxn_id]
                 l_c.lb = fva_sol.at[rxn_id, "minimum"]
-            model.optimize()
+            sol = model.optimize()
             delta = (fva_sol["maximum"] - fva_sol["minimum"]).max()
 
             count += 1
@@ -103,4 +103,4 @@ def geometric_fba(model, epsilon=1E-06, max_tries=200):
                     "maximum iterations".format(max_tries)
                 )
 
-    return get_solution(model)
+    return sol

--- a/cobra/test/test_flux_analysis.py
+++ b/cobra/test/test_flux_analysis.py
@@ -261,14 +261,14 @@ class TestCobraFluxAnalysis:
             ssq = (knock_sol.fluxes - sol.fluxes).pow(2).sum()
 
         with model:
-            add_moma(model)
+            add_moma(model, linear=False)
             model.reactions.PFK.knock_out()
             moma_sol = model.optimize()
             moma_ssq = (moma_sol.fluxes - sol.fluxes).pow(2).sum()
 
         # Use normal FBA as reference solution.
         with model:
-            add_moma(model, solution=sol)
+            add_moma(model, solution=sol, linear=False)
             model.reactions.PFK.knock_out()
             moma_ref_sol = model.optimize()
             moma_ref_ssq = (moma_ref_sol.fluxes - sol.fluxes).pow(2).sum()


### PR DESCRIPTION
As the title says. Small changes to fix the MOMA tests and avoid #715 in geometric FBA.

Fixes #715.