### PR TITLE
fix: restore automatic building of documentation

### DIFF
--- a/documentation_builder/Makefile
+++ b/documentation_builder/Makefile
@@ -44,7 +44,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	sphinx-apidoc -f -d 2 -e -o $(AUTODIR) ../cobra
+#	sphinx-apidoc -f -d 2 -e -o $(AUTODIR) ../cobra
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/documentation_builder/Makefile
+++ b/documentation_builder/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = ../documentation
+AUTODIR       = _autogen
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -39,9 +40,11 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
+	-rm -rf $(AUTODIR)
 	-rm -rf $(BUILDDIR)/*
 
 html:
+	sphinx-apidoc -f -d 2 -e -o $(AUTODIR) ../cobra
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -148,13 +148,13 @@ intersphinx_cache_limit = 10  # days to keep the cached inventories
 # -- sphinx-apidoc calling ---------------------------------------------
 
 
-def run_apidoc(_):
-    from sphinx.apidoc import main
+# def run_apidoc(_):
+#     from sphinx.apidoc import main
 
-    mod_path = join(PROJECT_ROOT, 'cobra')
-    auto_path = join(DOCS_ROOT, '_autogen')
-    main([None, '-f', '-d', '2', '-e', '-o', auto_path, mod_path])
+    # mod_path = join(PROJECT_ROOT, 'cobra')
+    # auto_path = join(DOCS_ROOT, '_autogen')
+    # main([None, '-f', '-d', '2', '-e', '-o', auto_path, mod_path])
 
 
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
+# def setup(app):
+#     app.connect('builder-inited', run_apidoc)

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -70,7 +70,8 @@ extensions = [
 ]
 # Document Python Code
 autoapi_type = 'python'
-autoapi_dirs = ['../cobra']
+autoapi_dirs = ['..']
+autoapi_ignore = ['.tox', '.pytest_cache', 'scripts', 'benchmarks']
 
 # Napoleon settings
 napoleon_numpy_docstring = True

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -18,7 +18,7 @@ from os.path import dirname
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, dirname(dirname(__file__)))
+sys.path.insert(0, dirname(dirname(__file__)))
 
 
 # In order to build documentation that requires libraries to import

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -42,6 +42,7 @@ class Mock(object):
 
 # These modules should correspond to the importable Python packages.
 MOCK_MODULES = [
+    'depinfo',
     'numpy',
     'scipy', 'scipy.optimize', 'scipy.sparse', 'scipy.io', 'scipy.stats',
     'pp',
@@ -101,7 +102,7 @@ mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -13,15 +13,12 @@
 # serve to show the default.
 
 import sys
-from os.path import dirname, join
+from os.path import dirname
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-DOCS_ROOT = dirname(__file__)
-PROJECT_ROOT = dirname(DOCS_ROOT)
-
-sys.path.insert(0, PROJECT_ROOT)
+# sys.path.insert(0, dirname(dirname(__file__)))
 
 
 # In order to build documentation that requires libraries to import
@@ -68,8 +65,12 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
+    'autoapi.extension',
     'nbsphinx'
 ]
+# Document Python Code
+autoapi_type = 'python'
+autoapi_dirs = ['../cobra']
 
 # Napoleon settings
 napoleon_numpy_docstring = True
@@ -144,17 +145,3 @@ intersphinx_mapping = {"http://docs.python.org/": None,
                        "http://docs.scipy.org/doc/numpy/": None,
                        "http://docs.scipy.org/doc/scipy/reference": None}
 intersphinx_cache_limit = 10  # days to keep the cached inventories
-
-# -- sphinx-apidoc calling ---------------------------------------------
-
-
-# def run_apidoc(_):
-#     from sphinx.apidoc import main
-
-    # mod_path = join(PROJECT_ROOT, 'cobra')
-    # auto_path = join(DOCS_ROOT, '_autogen')
-    # main([None, '-f', '-d', '2', '-e', '-o', auto_path, mod_path])
-
-
-# def setup(app):
-#     app.connect('builder-inited', run_apidoc)

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
 sphinxcontrib-napoleon
+sphinx-autoapi
 nbsphinx>=0.2.4
 ipykernel

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx==1.7.0
 sphinxcontrib-napoleon
 nbsphinx>=0.2.4
 ipykernel

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==1.7.0
+Sphinx
 sphinxcontrib-napoleon
 nbsphinx>=0.2.4
 ipykernel

--- a/setup.py
+++ b/setup.py
@@ -34,61 +34,62 @@ try:
 except IOError:
     setup_kwargs["long_description"] = ''
 
-setup(
-    name="cobra",
-    version="0.12.0",
-    packages=find_packages(),
-    setup_requires=setup_requirements,
-    install_requires=[
-        "six",
-        "future",
-        "swiglpk",
-        "ruamel.yaml<0.15",
-        "numpy>=1.13",
-        "pandas>=0.17.0",
-        "optlang>=1.4.2",
-        "tabulate",
-        "depinfo"
-    ],
-    tests_require=[
-        "jsonschema > 2.5",
-        "pytest",
-        "pytest-benchmark"
-    ],
-    extras_require=extras,
-    package_data={
-         '': [
-             'test/data/*',
-             'mlab/matlab_scripts/*m'
-         ]
-    },
-    author="The cobrapy core team",
-    author_email="cobra-pie@googlegroups.com",
-    description="COBRApy is a package for constraints-based modeling of "
-    "biological networks",
-    license="LGPL/GPL v2+",
-    keywords=("metabolism biology linear programming optimization flux"
-              " balance analysis fba"),
-    url="https://opencobra.github.io/cobrapy",
-    test_suite="cobra.test.suite",
-    download_url='https://pypi.python.org/pypi/cobra',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU Lesser General Public License v2'
-            ' or later (LGPLv2+)',
-        'License :: OSI Approved :: GNU General Public License v2'
-            ' or later (GPLv2+)',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Bio-Informatics'
-    ],
-    platforms="GNU/Linux, Mac OS X >= 10.7, Microsoft Windows >= 7",
-    **setup_kwargs
-)
+if __name__ == "__main__":
+    setup(
+        name="cobra",
+        version="0.12.0",
+        packages=find_packages(),
+        setup_requires=setup_requirements,
+        install_requires=[
+            "six",
+            "future",
+            "swiglpk",
+            "ruamel.yaml<0.15",
+            "numpy>=1.13",
+            "pandas>=0.17.0",
+            "optlang>=1.4.2",
+            "tabulate",
+            "depinfo"
+        ],
+        tests_require=[
+            "jsonschema > 2.5",
+            "pytest",
+            "pytest-benchmark"
+        ],
+        extras_require=extras,
+        package_data={
+             '': [
+                 'test/data/*',
+                 'mlab/matlab_scripts/*m'
+             ]
+        },
+        author="The cobrapy core team",
+        author_email="cobra-pie@googlegroups.com",
+        description="COBRApy is a package for constraints-based modeling of "
+        "biological networks",
+        license="LGPL/GPL v2+",
+        keywords=("metabolism biology linear programming optimization flux"
+                  " balance analysis fba"),
+        url="https://opencobra.github.io/cobrapy",
+        test_suite="cobra.test.suite",
+        download_url='https://pypi.python.org/pypi/cobra',
+        classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'Environment :: Console',
+            'Intended Audience :: Science/Research',
+            'License :: OSI Approved :: GNU Lesser General Public License v2'
+                ' or later (LGPLv2+)',
+            'License :: OSI Approved :: GNU General Public License v2'
+                ' or later (GPLv2+)',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Topic :: Scientific/Engineering',
+            'Topic :: Scientific/Engineering :: Bio-Informatics'
+        ],
+        platforms="GNU/Linux, Mac OS X >= 10.7, Microsoft Windows >= 7",
+        **setup_kwargs
+    )


### PR DESCRIPTION
This is a quick fix that restores documentation building. It seems Sphinx, apidoc, and readthedocs have gone through several iterations and our build pipeline should be updated. I will have to do that for memote anyway, so after I learn how to do it properly, I will make another PR here.