### PR TITLE
fix: skip determination of boundary types when no boundary rxns exist

### DIFF
--- a/cobra/medium/boundary_types.py
+++ b/cobra/medium/boundary_types.py
@@ -49,14 +49,23 @@ def find_external_compartment(model):
     str
         The putative external compartment.
     """
+    if not model.boundary:
+        LOGGER.error("The heuristic for discovering an external compartment "
+                     "relies on boundary reactions. Yet, there are no "
+                     "boundary reactions in this model.")
+        raise RuntimeError(
+            "The external compartment cannot be identified. "
+            "The heuristic for discovering an external compartment "
+            "relies on boundary reactions. Yet, there are no "
+            "boundary reactions in this model.")
     counts = Counter(tuple(r.compartments)[0] for r in model.boundary)
     most = counts.most_common(1)[0][0]
     if "e" in model.compartments:
         if most == "e":
             return "e"
         else:
-            LOGGER.warn("There is an `e` compartment but it does not look "
-                        "like it is the actual external compartment.")
+            LOGGER.warning("There is an `e` compartment but it does not look "
+                           "like it is the actual external compartment.")
         return most
     return most
 

--- a/cobra/medium/boundary_types.py
+++ b/cobra/medium/boundary_types.py
@@ -105,7 +105,7 @@ def is_boundary_type(reaction, boundary_type, external_compartment):
 
 
 def find_boundary_types(model, boundary_type, external_compartment=None):
-    """Find exchange reactions.
+    """Find specific boundary reactions.
 
     Arguments
     ---------
@@ -121,8 +121,13 @@ def find_boundary_types(model, boundary_type, external_compartment=None):
     Returns
     -------
     list of cobra.reaction
-        A list of likely exchange reactions.
+        A list of likely boundary reactions of a user defined type.
     """
+    if not model.boundary:
+        LOGGER.warning("There are no boundary reactions in this model. "
+                    "Therefore specific types of boundary reactions such as "
+                    "'exchanges', 'demands' or 'sinks' cannot be identified.")
+        return []
     if external_compartment is None:
         external_compartment = find_external_compartment(model)
     return model.reactions.query(

--- a/cobra/medium/boundary_types.py
+++ b/cobra/medium/boundary_types.py
@@ -125,8 +125,9 @@ def find_boundary_types(model, boundary_type, external_compartment=None):
     """
     if not model.boundary:
         LOGGER.warning("There are no boundary reactions in this model. "
-                    "Therefore specific types of boundary reactions such as "
-                    "'exchanges', 'demands' or 'sinks' cannot be identified.")
+                       "Therefore specific types of boundary reactions such "
+                       "as 'exchanges', 'demands' or 'sinks' cannot be "
+                       "identified.")
         return []
     if external_compartment is None:
         external_compartment = find_external_compartment(model)

--- a/cobra/test/conftest.py
+++ b/cobra/test/conftest.py
@@ -34,6 +34,16 @@ def data_directory():
 
 
 @pytest.fixture(scope="session")
+def empty_once():
+    return Model()
+
+
+@pytest.fixture(scope="function")
+def empty_model(empty_once):
+    return empty_once.copy()
+
+
+@pytest.fixture(scope="session")
 def small_model():
     return create_test_model("textbook")
 

--- a/cobra/test/test_medium.py
+++ b/cobra/test/test_medium.py
@@ -141,7 +141,7 @@ class TestMinimalMedia:
 class TestErrorsAndExceptions:
 
     def test_no_boundary_reactions(self, empty_model):
-        assert find_boundary_types(empty_model, 'e', None) == []
+        assert medium.find_boundary_types(empty_model, 'e', None) == []
 
     def test_no_boundary_reactions(self, empty_model):
         with pytest.raises(RuntimeError):

--- a/cobra/test/test_medium.py
+++ b/cobra/test/test_medium.py
@@ -137,6 +137,7 @@ class TestMinimalMedia:
         med = medium.minimal_medium(model, 0.8, open_exchanges=100)
         assert len(med) >= 3
 
+
 class TestErrorsAndExceptions:
 
     def test_no_boundary_reactions(self, empty_model):
@@ -144,4 +145,4 @@ class TestErrorsAndExceptions:
 
     def test_no_boundary_reactions(self, empty_model):
         with pytest.raises(RuntimeError):
-            medium.find_external_compartment(empty_model)clear
+            medium.find_external_compartment(empty_model)

--- a/cobra/test/test_medium.py
+++ b/cobra/test/test_medium.py
@@ -136,3 +136,12 @@ class TestMinimalMedia:
         assert len(med) >= 3
         med = medium.minimal_medium(model, 0.8, open_exchanges=100)
         assert len(med) >= 3
+
+class TestErrorsAndExceptions:
+
+    def test_no_boundary_reactions(self, empty_model):
+        assert find_boundary_types(empty_model, 'e', None) == []
+
+    def test_no_boundary_reactions(self, empty_model):
+        with pytest.raises(RuntimeError):
+            medium.find_external_compartment(empty_model)clear


### PR DESCRIPTION
Fixes #732 