### PR TITLE
Gapfill bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+python: 3.5
 sudo: false
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
-python: 3.5
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 sudo: false
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
  only:
  - master
  - devel
- - gapfill_bugfix
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
  only:
  - master
  - devel
+ - gapfill_bugfix
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/cobra/test/test_flux_analysis/test_gapfilling.py
+++ b/cobra/test/test_flux_analysis/test_gapfilling.py
@@ -51,6 +51,34 @@ def test_gapfilling(salmonella):
     assert len(result[1]) == 1
     assert {i[0].id for i in result} == {"EX_b", "EX_c"}
 
+    # # Gapfilling solution adds metabolites not present in original model
+    # test for when demand = T
+    # a demand reaction must be added to clear new metabolite
+    universal_noDM = Model()
+    a2b = Reaction("a2b")
+    universal_noDM.add_reactions([a2b])
+    a2b.build_reaction_from_string("a --> b + d", verbose=False)
+    result = gapfill(m, universal_noDM,
+                     exchange_reactions=False,
+                     demand_reactions=True)[0]
+    # add reaction a2b and demand reaction to clear met d
+    assert len(result) == 2
+    assert "a2b" in [x.id for x in result]
+
+    # test for when demand = False
+    # test for when metabolites are added to the model and
+    # must be cleared by other reactions in universal model
+    # (i.e. not necessarily a demand reaction)
+    universal_withDM = universal_noDM.copy()
+    d_dm = Reaction("d_dm")
+    universal_withDM.add_reactions([d_dm])
+    d_dm.build_reaction_from_string("d -->", verbose=False)
+    result = gapfill(m, universal_withDM,
+                     exchange_reactions=False,
+                     demand_reactions=False)[0]
+    assert len(result) == 2
+    assert "a2b" in [x.id for x in result]
+
     # somewhat bigger model
     universal = Model("universal_reactions")
     with salmonella as model:


### PR DESCRIPTION
bug fix referenced in Pull Request #687 (Gapfill fix to support new metabolites) using latest devel branch

Updated flux_analysis/gapfilling to support gapfill solutions that add metabolites; tests modified to highlight this case. So, if a gapfill solution adds a reaction that contains metabolites not in the original model, corresponding demand or other reactions will also be added to clear the new metabolites. 

Also updated flux_analysis/gapfilling to check if universal model contains exchange reactions. If exchange_reactions = TRUE, the model is only extended by exchange reactions not already in the universal model.