### PR TITLE
Bug/prune unused metabolites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
  only:
  - master
  - devel
+ - bug/prune_unused_metabolites
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
  only:
  - master
  - devel
- - bug/prune_unused_metabolites
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/cobra/manipulation/delete.py
+++ b/cobra/manipulation/delete.py
@@ -12,12 +12,12 @@ from cobra.core import Model
 
 def prune_unused_metabolites(cobra_model):
     """Remove metabolites that are not involved in any reactions
-        
+
     Parameters
     ----------
     cobra_model: cobra.Model
     the model to remove unused metabolites from
-    
+
     Returns
     -------
     model
@@ -39,12 +39,12 @@ def prune_unused_metabolites(cobra_model):
 
 def prune_unused_reactions(cobra_model):
     """Remove reactions that have no assigned metabolites
-        
+
     Parameters
     ----------
     cobra_model: cobra.Model
     the model to remove unused reactions from
-    
+
     Returns
     -------
     model

--- a/cobra/manipulation/delete.py
+++ b/cobra/manipulation/delete.py
@@ -11,55 +11,50 @@ from cobra.core import Model
 
 
 def prune_unused_metabolites(cobra_model):
-    """Remove metabolites that are not involved in any reactions
+    """Remove metabolites that are not involved in any reactions and
+    returns pruned model
 
     Parameters
     ----------
-    cobra_model: cobra.Model
-    the model to remove unused metabolites from
+    cobra_model: class:`~cobra.core.Model.Model` object
+        the model to remove unused metabolites from
 
     Returns
     -------
-    model
-    input model with unused metabolites removed
-    list
-    list of metabolites that were removed
+    output_model: class:`~cobra.core.Model.Model` object
+        input model with unused metabolites removed
+    inactive_metabolites: list of class:`~cobra.core.reaction.Reaction`
+        list of metabolites that were removed
     """
-    inactive_metabolites = []
-    active_metabolites = []
+
     output_model = cobra_model.copy()
-    for the_metabolite in output_model.metabolites:
-        if len(the_metabolite._reaction) == 0:
-            inactive_metabolites.append(the_metabolite)
-        else:
-            active_metabolites.append(the_metabolite)
+    inactive_metabolites = [m for m in output_model.metabolites
+                            if len(m.reactions) == 0]
     output_model.remove_metabolites(inactive_metabolites)
     return output_model, inactive_metabolites
 
 
 def prune_unused_reactions(cobra_model):
-    """Remove reactions that have no assigned metabolites
+    """Remove reactions with no assigned metabolites, returns pruned model
 
     Parameters
     ----------
-    cobra_model: cobra.Model
-    the model to remove unused reactions from
+    cobra_model: class:`~cobra.core.Model.Model` object
+        the model to remove unused reactions from
 
     Returns
     -------
-    model
-    input model with unused reactions removed
-    list
-    list of reactions that were removed
+    output_model: class:`~cobra.core.Model.Model` object
+        input model with unused reactions removed
+    reactions_to_prune: list of class:`~cobra.core.reaction.Reaction`
+        list of reactions that were removed
     """
-    pruned_reactions = []
+
     output_model = cobra_model.copy()
-    reactions_to_prune = [x for x in output_model.reactions
-                          if len(x._metabolites) == 0]
-    for the_reaction in reactions_to_prune:
-        pruned_reactions.append(the_reaction)
-    output_model.remove_reactions(pruned_reactions)
-    return output_model, pruned_reactions
+    reactions_to_prune = [r for r in output_model.reactions
+                          if len(r.metabolites) == 0]
+    output_model.remove_reactions(reactions_to_prune)
+    return output_model, reactions_to_prune
 
 
 def undelete_model_genes(cobra_model):

--- a/cobra/manipulation/delete.py
+++ b/cobra/manipulation/delete.py
@@ -7,52 +7,59 @@ from ast import And, NodeTransformer
 from six import iteritems, string_types
 
 from cobra.core.gene import ast2str, eval_gpr, parse_gpr
+from cobra.core import Model
 
 
 def prune_unused_metabolites(cobra_model):
     """Remove metabolites that are not involved in any reactions
-
+        
     Parameters
     ----------
     cobra_model: cobra.Model
-        the model to remove unused metabolites from
-
+    the model to remove unused metabolites from
+    
     Returns
     -------
+    model
+    input model with unused metabolites removed
     list
-        list of metabolites that were removed
+    list of metabolites that were removed
     """
     inactive_metabolites = []
     active_metabolites = []
-    for the_metabolite in cobra_model.metabolites:
+    output_model = cobra_model.copy()
+    for the_metabolite in output_model.metabolites:
         if len(the_metabolite._reaction) == 0:
-            the_metabolite.remove_from_model()
             inactive_metabolites.append(the_metabolite)
         else:
             active_metabolites.append(the_metabolite)
-    return inactive_metabolites
+    output_model.remove_metabolites(inactive_metabolites)
+    return output_model, inactive_metabolites
 
 
 def prune_unused_reactions(cobra_model):
     """Remove reactions that have no assigned metabolites
-
+        
     Parameters
     ----------
     cobra_model: cobra.Model
-        the model to remove unused reactions from
-
+    the model to remove unused reactions from
+    
     Returns
     -------
+    model
+    input model with unused reactions removed
     list
-        list of reactions that were removed
+    list of reactions that were removed
     """
     pruned_reactions = []
-    reactions_to_prune = [x for x in cobra_model.reactions
+    output_model = cobra_model.copy()
+    reactions_to_prune = [x for x in output_model.reactions
                           if len(x._metabolites) == 0]
     for the_reaction in reactions_to_prune:
-        the_reaction.remove_from_model()
         pruned_reactions.append(the_reaction)
-    return pruned_reactions
+    output_model.remove_reactions(pruned_reactions)
+    return output_model, pruned_reactions
 
 
 def undelete_model_genes(cobra_model):

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -216,12 +216,47 @@ class TestManipulation:
             r1.check_mass_balance()
 
     def test_prune_unused(self, model):
-        metabolite = model.metabolites.ru5p__D_c
-        [model.reactions.get_by_id(x).remove_from_model() for x in
-         ['RPI', 'RPE', 'GND']]
-        unused = delete.prune_unused_metabolites(model)
-        assert unused[0] is metabolite
+
+#        # test that the output contains metabolite objects
+#        metabolite = model.metabolites.ru5p__D_c
+#        [model.reactions.get_by_id(x).remove_from_model() for x in
+#         ['RPI', 'RPE', 'GND']]
+#        model_pruned, unused = delete.prune_unused_metabolites(model)
+#        assert isinstance(model_pruned,Model)
+#        assert isinstance(unused[0],Metabolite)
+#
+#        # test that the unused metabolites are not used in the model
+#        metabolite1 = model.metabolites.ru5p__D_c
+#        metabolite2 = model.metabolites.akg_e
+#        metabolite3 = model.metabolites.akg_c
+#        reactions = list(set([x for sublist in
+#                               [metabolite1._reaction, metabolite2._reaction, metabolite3._reaction]
+#                               for x in sublist]))
+#        [rxn.remove_from_model() for rxn in reactions]
+#        model_pruned, unused = delete.prune_unused_metabolites(model)
+#        assert metabolite1 in model.metabolites
+#        assert metabolite2 in model.metabolites
+#        assert metabolite3 in model.metabolites
+#        assert metabolite1 not in model_pruned.metabolites
+#        assert metabolite2 not in model_pruned.metabolites
+#        assert metabolite3 not in model_pruned.metabolites
+
+        # test that the output contains reaction objects
         reaction = Reaction('foo')
         model.add_reaction(reaction)
-        unused = delete.prune_unused_reactions(model)
-        assert unused[0] is reaction
+        model_pruned, unused = delete.prune_unused_reactions(model)
+        assert isinstance(model_pruned,Model)
+        assert isinstance(unused[0],Reaction)
+
+
+        # test that the unused reactions are not used in the model
+        for x in ['foo1','foo2','foo3']:
+            model.add_reaction(Reaction(x))
+        model_pruned, unused = delete.prune_unused_reactions(model)
+        assert 'foo1'in [x.id for x in model.reactions]
+        assert 'foo2'in [x.id for x in model.reactions]
+        assert 'foo3'in [x.id for x in model.reactions]
+        assert 'foo1' not in [x.id for x in model_pruned.reactions]
+        assert 'foo2' not in [x.id for x in model_pruned.reactions]
+        assert 'foo3' not in [x.id for x in model_pruned.reactions]
+

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -217,46 +217,46 @@ class TestManipulation:
 
     def test_prune_unused(self, model):
 
-#        # test that the output contains metabolite objects
-#        metabolite = model.metabolites.ru5p__D_c
-#        [model.reactions.get_by_id(x).remove_from_model() for x in
-#         ['RPI', 'RPE', 'GND']]
-#        model_pruned, unused = delete.prune_unused_metabolites(model)
-#        assert isinstance(model_pruned,Model)
-#        assert isinstance(unused[0],Metabolite)
-#
-#        # test that the unused metabolites are not used in the model
-#        metabolite1 = model.metabolites.ru5p__D_c
-#        metabolite2 = model.metabolites.akg_e
-#        metabolite3 = model.metabolites.akg_c
-#        reactions = list(set([x for sublist in
-#                               [metabolite1._reaction, metabolite2._reaction, metabolite3._reaction]
-#                               for x in sublist]))
-#        [rxn.remove_from_model() for rxn in reactions]
-#        model_pruned, unused = delete.prune_unused_metabolites(model)
-#        assert metabolite1 in model.metabolites
-#        assert metabolite2 in model.metabolites
-#        assert metabolite3 in model.metabolites
-#        assert metabolite1 not in model_pruned.metabolites
-#        assert metabolite2 not in model_pruned.metabolites
-#        assert metabolite3 not in model_pruned.metabolites
+        # test that the output contains metabolite objects
+        metabolite = model.metabolites.ru5p__D_c
+        [model.reactions.get_by_id(x).remove_from_model() for x in
+         ['RPI', 'RPE', 'GND']]
+        model_pruned, unused = delete.prune_unused_metabolites(model)
+        assert isinstance(model_pruned, Model)
+        assert isinstance(unused[0], Metabolite)
+
+        # test that the unused metabolites are not used in the model
+        metabolite1 = model.metabolites.ru5p__D_c
+        metabolite2 = model.metabolites.akg_e
+        metabolite3 = model.metabolites.akg_c
+        reactions = list(set([x for sublist in
+                              [metabolite1._reaction,
+                               metabolite2._reaction,
+                               metabolite3._reaction]
+                              for x in sublist]))
+        [rxn.remove_from_model() for rxn in reactions]
+        model_pruned, unused = delete.prune_unused_metabolites(model)
+        assert metabolite1 in model.metabolites
+        assert metabolite2 in model.metabolites
+        assert metabolite3 in model.metabolites
+        assert metabolite1 not in model_pruned.metabolites
+        assert metabolite2 not in model_pruned.metabolites
+        assert metabolite3 not in model_pruned.metabolites
 
         # test that the output contains reaction objects
         reaction = Reaction('foo')
         model.add_reaction(reaction)
         model_pruned, unused = delete.prune_unused_reactions(model)
-        assert isinstance(model_pruned,Model)
-        assert isinstance(unused[0],Reaction)
-
+        assert isinstance(model_pruned, Model)
+        assert isinstance(unused[0], Reaction)
 
         # test that the unused reactions are not used in the model
-        for x in ['foo1','foo2','foo3']:
+        for x in ['foo1', 'foo2', 'foo3']:
             model.add_reaction(Reaction(x))
         model_pruned, unused = delete.prune_unused_reactions(model)
-        assert 'foo1'in [x.id for x in model.reactions]
-        assert 'foo2'in [x.id for x in model.reactions]
-        assert 'foo3'in [x.id for x in model.reactions]
+        assert 'foo1' in [x.id for x in model.reactions]
+        assert 'foo2' in [x.id for x in model.reactions]
+        assert 'foo3' in [x.id for x in model.reactions]
         assert 'foo1' not in [x.id for x in model_pruned.reactions]
         assert 'foo2' not in [x.id for x in model_pruned.reactions]
         assert 'foo3' not in [x.id for x in model_pruned.reactions]
-


### PR DESCRIPTION
Updated manipulation/delete.py to make output of prune_unused_metabolites and prune_unused_reactions explicitly a list of pruned features and a pruned model. Also updated prune_unused_metabolites to permit the removal of multiple metabolites. Updated associated test (test_prune_unused).