### PR TITLE
Bug/rename genes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
  only:
  - master
  - devel
- - bug/rename_genes
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
  only:
  - master
  - devel
+ - bug/rename_genes
  - /^[0-9]+\.[0-9]+\.[0-9]+[.0-9ab]*$/
 
 env:

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -80,8 +80,10 @@ def rename_genes(cobra_model, rename_dict):
         new_gene_present = new_name in cobra_model.genes
         if old_gene_present and new_gene_present:
             old_gene = cobra_model.genes.get_by_id(old_name)
-            remove_genes.append(old_gene)
-            recompute_reactions.update(old_gene._reaction)
+            # Added in case not renaming some genes:
+            if old_gene != cobra_model.genes.get_by_id(new_name):
+                remove_genes.append(old_gene)
+                recompute_reactions.update(old_gene._reaction)
         elif old_gene_present and not new_gene_present:
             # rename old gene to new gene
             gene = cobra_model.genes[gene_index]
@@ -93,7 +95,10 @@ def rename_genes(cobra_model, rename_dict):
             pass
         else:  # not old gene_present and not new_gene_present
             # the new gene's _model will be set by repair
-            cobra_model.genes.append(Gene(new_name))
+            # This would add genes from rename_dict
+            # that are not associated with a rxn
+            # cobra_model.genes.append(Gene(new_name))
+            pass
     cobra_model.repair()
 
     class Renamer(NodeTransformer):

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -81,7 +81,7 @@ def rename_genes(cobra_model, rename_dict):
         if old_gene_present and new_gene_present:
             old_gene = cobra_model.genes.get_by_id(old_name)
             # Added in case not renaming some genes:
-            if old_gene != cobra_model.genes.get_by_id(new_name):
+            if old_gene is not cobra_model.genes.get_by_id(new_name):
                 remove_genes.append(old_gene)
                 recompute_reactions.update(old_gene._reaction)
         elif old_gene_present and not new_gene_present:

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -93,7 +93,7 @@ def rename_genes(cobra_model, rename_dict):
             cobra_model.genes[gene_index] = gene
         elif not old_gene_present and new_gene_present:
             pass
-        else:  # not old gene_present and not new_gene_present
+        else:  # if not old gene_present and not new_gene_present
             # the new gene's _model will be set by repair
             # This would add genes from rename_dict
             # that are not associated with a rxn

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -50,12 +50,15 @@ class TestManipulation:
 
     def test_rename_gene(self, model):
         original_name = model.genes.b1241.name
-        rename_dict = {"b1241": "foo", "hello": "world",
+        rename_dict = {"b1241": "foo", "hello": "world", "b3115": "b3115",
                        "b2465": "b3919", "bar": "2935"}
         modify.rename_genes(model, rename_dict)
-        for i in rename_dict:
-            assert i not in model.genes
+        for i in rename_dict.keys():
+            if i not in rename_dict.values():
+                assert i not in [x.id for x in model.genes]
+        assert "b3115" in model.genes
         assert "foo" in model.genes
+        assert "world" not in model.genes
         # make sure the object name was preserved
         assert model.genes.foo.name == original_name
         # make sure the reactions are correct

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -55,7 +55,7 @@ class TestManipulation:
         modify.rename_genes(model, rename_dict)
         for i in rename_dict.keys():
             if i not in rename_dict.values():
-                assert i not in [x.id for x in model.genes]
+                assert i not in model.genes
         assert "b3115" in model.genes
         assert "foo" in model.genes
         assert "world" not in model.genes


### PR DESCRIPTION
Addressing the issues originally brought up in closed PR #601. modify/rename_genes and associate test have been updated to permit the renaming of only a subset of genes and to avoid adding genes without GPRs