### PR TITLE
Improve docs for growth media and silence pandas warning

### DIFF
--- a/cobra/medium/minimal_medium.py
+++ b/cobra/medium/minimal_medium.py
@@ -214,7 +214,7 @@ def minimal_medium(model, min_objective_value=0.1, exports=False,
                 media.append(medium)
                 seen.update(medium[medium > 0].index)
             if len(media) > 1:
-                medium = pd.concat(media, axis=1).fillna(0.0)
+                medium = pd.concat(media, axis=1, sort=True).fillna(0.0)
                 medium.sort_index(axis=1, inplace=True)
             else:
                 medium = media[0]

--- a/documentation_builder/media.ipynb
+++ b/documentation_builder/media.ipynb
@@ -6,9 +6,11 @@
    "source": [
     "# Growth media\n",
     "\n",
-    "The availability of nutrients has a major impact on metabolic fluxes and `cobrapy` provides some helpers to manage the exchanges between the external environment and your metabolic model. In experimental settings the \"environment\" is usually constituted by the growth medium, ergo the concentrations of all metabolites and co-factors available to the modeled organism. However, constraint-based metabolic models only consider fluxes. Thus, you will first have to translate your concentrations into fluxes. For instance by assuming that 1 gDW of your organism cannot consume the entire concentration of a metabolite in 24h which gives you an estimate of the upper exchange flux of `concentration / (1 gDW * 24 h)`. If you have direct measurement of exchange fluxes you can of course use those as well (and those will be much more accurate). \n",
+    "The availability of nutrients has a major impact on metabolic fluxes and `cobrapy` provides some helpers to manage the exchanges between the external environment and your metabolic model. In experimental settings the \"environment\" is usually constituted by the growth medium, ergo the concentrations of all metabolites and co-factors available to the modeled organism. However, constraint-based metabolic models only consider fluxes. Thus, you can not simply use concentrations since fluxes have the unit `mmol / [gDW h]` (concentration per gram dry weight of cells and hour). \n",
     "\n",
-    "The current growth medium of a model is managed by the `medium` attribute.  "
+    "Also, you are setting an upper bound for the particular import flux and not the flux itself. There are some crude approximations. For instance, if you supply 1 mol of glucose every 24h to 1 gram of bacteria you might set the upper exchange flux for glucose to `1 mol / [1 gDW * 24 h]` since that is the nominal maximum that can be imported. There is no guarantee however that glucose will be consumed with that flux. Thus, the preferred data for exchange fluxes are direct flux measurements as the ones obtained from timecourse exa-metabolome measurements for instance. \n",
+    "\n",
+    "So how does that look in COBRApy? The current growth medium of a model is managed by the `medium` attribute.  "
    ]
   },
   {
@@ -21,8 +23,8 @@
       "text/plain": [
        "{'EX_co2_e': 1000.0,\n",
        " 'EX_glc__D_e': 10.0,\n",
-       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_h_e': 1000.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_nh4_e': 1000.0,\n",
        " 'EX_o2_e': 1000.0,\n",
        " 'EX_pi_e': 1000.0}"
@@ -44,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This will return a dictionary that contains all active exchange fluxes (the ones having non-zero flux bounds). Right now we see that we have enabled aerobic growth. You can modify a growth medium of a model by assigning a dictionary to `model.medium` that maps exchange reactions to their respective upper import bounds. For now let us enforce anaerobic growth by shutting off the oxygen import."
+    "This will return a dictionary that contains the upper flux bounds for all active exchange fluxes (the ones having non-zero flux bounds). Right now we see that we have enabled aerobic growth. You can modify a growth medium of a model by assigning a dictionary to `model.medium` that maps exchange reactions to their respective upper import bounds. For now let us enforce anaerobic growth by shutting off the oxygen import."
    ]
   },
   {
@@ -57,8 +59,8 @@
       "text/plain": [
        "{'EX_co2_e': 1000.0,\n",
        " 'EX_glc__D_e': 10.0,\n",
-       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_h_e': 1000.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_nh4_e': 1000.0,\n",
        " 'EX_pi_e': 1000.0}"
       ]
@@ -107,12 +109,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Setting the growth medium also connects to the context manager, so you can set a specific growth medium in a reversible manner."
+    "There is a small trap here. `model.medium` can not be assigned to directly. So the following will not work:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'EX_co2_e': 1000.0,\n",
+       " 'EX_glc__D_e': 10.0,\n",
+       " 'EX_h_e': 1000.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
+       " 'EX_nh4_e': 1000.0,\n",
+       " 'EX_pi_e': 1000.0}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.medium[\"EX_co2_e\"] = 0.0\n",
+    "model.medium"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see `EX_co2_e` is not set to zero. This is because model.medium is just a copy of the current exchange fluxes. Assigning to it directly with `model.medium[...] = ...` will **not** change the model. You have to assign an entire dictionary with the changed import flux upper bounds:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'EX_glc__D_e': 10.0,\n",
+       " 'EX_h_e': 1000.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
+       " 'EX_nh4_e': 1000.0,\n",
+       " 'EX_pi_e': 1000.0}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "medium = model.medium\n",
+    "medium[\"EX_co2_e\"] = 0.0\n",
+    "model.medium = medium\n",
+    "\n",
+    "model.medium  # now it worked"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting the growth medium also connects to the context manager, so you can set a specific growth medium in a reversible manner."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -128,14 +198,14 @@
       "text/plain": [
        "{'EX_co2_e': 1000.0,\n",
        " 'EX_glc__D_e': 10.0,\n",
-       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_h_e': 1000.0,\n",
+       " 'EX_h2o_e': 1000.0,\n",
        " 'EX_nh4_e': 1000.0,\n",
        " 'EX_o2_e': 1000.0,\n",
        " 'EX_pi_e': 1000.0}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -183,7 +253,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -218,7 +288,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -236,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -264,17 +334,13 @@
        "      <th>1</th>\n",
        "      <th>2</th>\n",
        "      <th>3</th>\n",
-       "      <th>4</th>\n",
-       "      <th>5</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>EX_fru_e</th>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>523.104557</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>521.357767</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
@@ -283,35 +349,27 @@
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>523.104557</td>\n",
-       "      <td>521.357767</td>\n",
        "      <td>519.750758</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_gln__L_e</th>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
        "      <td>40.698058</td>\n",
+       "      <td>18.848678</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_glu__L_e</th>\n",
-       "      <td>23.468185</td>\n",
        "      <td>348.101944</td>\n",
-       "      <td>83.995843</td>\n",
-       "      <td>83.995843</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_mal__L_e</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>1000.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -319,26 +377,20 @@
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
        "      <td>81.026921</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_o2_e</th>\n",
-       "      <td>0.000000</td>\n",
        "      <td>500.000000</td>\n",
-       "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>EX_pi_e</th>\n",
-       "      <td>15.667461</td>\n",
        "      <td>66.431529</td>\n",
-       "      <td>56.667310</td>\n",
-       "      <td>56.667310</td>\n",
        "      <td>54.913419</td>\n",
+       "      <td>12.583458</td>\n",
        "      <td>54.664344</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -346,28 +398,18 @@
        "</div>"
       ],
       "text/plain": [
-       "                       0           1           2           3           4  \\\n",
-       "EX_fru_e        0.000000    0.000000  523.104557    0.000000    0.000000   \n",
-       "EX_glc__D_e     0.000000    0.000000    0.000000  523.104557  521.357767   \n",
-       "EX_gln__L_e     0.000000    0.000000    0.000000    0.000000   40.698058   \n",
-       "EX_glu__L_e    23.468185  348.101944   83.995843   83.995843    0.000000   \n",
-       "EX_mal__L_e  1000.000000    0.000000    0.000000    0.000000    0.000000   \n",
-       "EX_nh4_e        0.000000    0.000000    0.000000    0.000000    0.000000   \n",
-       "EX_o2_e         0.000000  500.000000    0.000000    0.000000    0.000000   \n",
-       "EX_pi_e        15.667461   66.431529   56.667310   56.667310   54.913419   \n",
-       "\n",
-       "                      5  \n",
-       "EX_fru_e       0.000000  \n",
-       "EX_glc__D_e  519.750758  \n",
-       "EX_gln__L_e    0.000000  \n",
-       "EX_glu__L_e    0.000000  \n",
-       "EX_mal__L_e    0.000000  \n",
-       "EX_nh4_e      81.026921  \n",
-       "EX_o2_e        0.000000  \n",
-       "EX_pi_e       54.664344  "
+       "                      0           1            2           3\n",
+       "EX_fru_e       0.000000  521.357767     0.000000    0.000000\n",
+       "EX_glc__D_e    0.000000    0.000000     0.000000  519.750758\n",
+       "EX_gln__L_e    0.000000   40.698058    18.848678    0.000000\n",
+       "EX_glu__L_e  348.101944    0.000000     0.000000    0.000000\n",
+       "EX_mal__L_e    0.000000    0.000000  1000.000000    0.000000\n",
+       "EX_nh4_e       0.000000    0.000000     0.000000   81.026921\n",
+       "EX_o2_e      500.000000    0.000000     0.000000    0.000000\n",
+       "EX_pi_e       66.431529   54.913419    12.583458   54.664344"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -396,20 +438,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Reaction EX_12ppd__R_e at 0x7f3921088fd0>,\n",
-       " <Reaction EX_12ppd__S_e at 0x7f3921078fd0>,\n",
-       " <Reaction EX_14glucan_e at 0x7f3921078f98>,\n",
-       " <Reaction EX_15dap_e at 0x7f3921078eb8>,\n",
-       " <Reaction EX_23camp_e at 0x7f392107e2b0>]"
+       "[<Reaction EX_12ppd__R_e at 0x131b4a58d0>,\n",
+       " <Reaction EX_12ppd__S_e at 0x131b471c50>,\n",
+       " <Reaction EX_14glucan_e at 0x131b471e10>,\n",
+       " <Reaction EX_15dap_e at 0x131b471e48>,\n",
+       " <Reaction EX_23camp_e at 0x131b471f98>]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,21 +470,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Reaction DM_4CRSOL at 0x7f3921144b70>,\n",
-       " <Reaction DM_5DRIB at 0x7f3921078b38>,\n",
-       " <Reaction DM_AACALD at 0x7f3921078be0>,\n",
-       " <Reaction DM_AMOB at 0x7f3921078c50>,\n",
-       " <Reaction DM_MTHTHF at 0x7f3921078cf8>,\n",
-       " <Reaction DM_OXAM at 0x7f3921078d68>]"
+       "[<Reaction DM_4CRSOL at 0x131b3162b0>,\n",
+       " <Reaction DM_5DRIB at 0x131b4712e8>,\n",
+       " <Reaction DM_AACALD at 0x131b471400>,\n",
+       " <Reaction DM_AMOB at 0x131b4714e0>,\n",
+       " <Reaction DM_MTHTHF at 0x131b4715f8>,\n",
+       " <Reaction DM_OXAM at 0x131b4716d8>]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -469,7 +511,7 @@
        "[]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -487,25 +529,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Reaction DM_4CRSOL at 0x7f3921144b70>,\n",
-       " <Reaction DM_5DRIB at 0x7f3921078b38>,\n",
-       " <Reaction DM_AACALD at 0x7f3921078be0>,\n",
-       " <Reaction DM_AMOB at 0x7f3921078c50>,\n",
-       " <Reaction DM_MTHTHF at 0x7f3921078cf8>,\n",
-       " <Reaction DM_OXAM at 0x7f3921078d68>,\n",
-       " <Reaction EX_12ppd__R_e at 0x7f3921088fd0>,\n",
-       " <Reaction EX_12ppd__S_e at 0x7f3921078fd0>,\n",
-       " <Reaction EX_14glucan_e at 0x7f3921078f98>,\n",
-       " <Reaction EX_15dap_e at 0x7f3921078eb8>]"
+       "[<Reaction DM_4CRSOL at 0x131b3162b0>,\n",
+       " <Reaction DM_5DRIB at 0x131b4712e8>,\n",
+       " <Reaction DM_AACALD at 0x131b471400>,\n",
+       " <Reaction DM_AMOB at 0x131b4714e0>,\n",
+       " <Reaction DM_MTHTHF at 0x131b4715f8>,\n",
+       " <Reaction DM_OXAM at 0x131b4716d8>,\n",
+       " <Reaction EX_12ppd__R_e at 0x131b4a58d0>,\n",
+       " <Reaction EX_12ppd__S_e at 0x131b471c50>,\n",
+       " <Reaction EX_14glucan_e at 0x131b471e10>,\n",
+       " <Reaction EX_15dap_e at 0x131b471e48>]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -531,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This improves the docs as discussed in #762 and also provides a better clarification for the difference between concentrations and the growth media in cobrapy. Also avoids a pandas deprecation warning.

Fixes #762.