### PR TITLE
Fix inf bounds

### DIFF
--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -184,20 +184,6 @@ class Reaction(Object):
         cop = deepcopy(super(Reaction, self), memo)
         return cop
 
-    @property
-    def lower_bound(self):
-        """Get or set the lower bound
-
-        Setting the lower bound (float) will also adjust the associated optlang
-        variables associated with the reaction. Infeasible combinations,
-        such as a lower bound higher than the current upper bound will
-        update the other bound.
-
-        When using a `HistoryManager` context, this attribute can be set
-        temporarily, reversed when the exiting the context.
-        """
-        return self._lower_bound
-
     @staticmethod
     def _check_bounds(lb, ub):
         if lb > ub:
@@ -231,10 +217,30 @@ class Reaction(Object):
                 ub=None if isinf(self._lower_bound) else -self._lower_bound
             )
 
+    @property
+    def lower_bound(self):
+        """Get or set the lower bound
+
+        Setting the lower bound (float) will also adjust the associated optlang
+        variables associated with the reaction. Infeasible combinations,
+        such as a lower bound higher than the current upper bound will
+        update the other bound.
+
+        When using a `HistoryManager` context, this attribute can be set
+        temporarily, reversed when the exiting the context.
+        """
+        return self._lower_bound
+
     @lower_bound.setter
     @resettable
     def lower_bound(self, value):
         if self._upper_bound < value:
+            warn("You are constraining the reaction '{}' to a fixed flux "
+                 "value of {}. Did you intend to do this? We are planning to "
+                 "remove this behavior in a future release. Please let us "
+                 "know your opinion at "
+                 "https://github.com/opencobra/cobrapy/issues/793."
+                 "".format(self.id, value), DeprecationWarning)
             self.upper_bound = value
         # Validate bounds before setting them.
         self._check_bounds(value, self._upper_bound)
@@ -259,6 +265,12 @@ class Reaction(Object):
     @resettable
     def upper_bound(self, value):
         if self._lower_bound > value:
+            warn("You are constraining the reaction '{}' to a fixed flux "
+                 "value of {}. Did you intend to do this? We are planning to "
+                 "remove this behavior in a future release. Please let us "
+                 "know your opinion at "
+                 "https://github.com/opencobra/cobrapy/issues/793."
+                 "".format(self.id, value), DeprecationWarning)
             self.lower_bound = value
         # Validate bounds before setting them.
         self._check_bounds(self._lower_bound, value)

--- a/cobra/core/reaction.py
+++ b/cobra/core/reaction.py
@@ -202,8 +202,8 @@ class Reaction(Object):
     def _check_bounds(lb, ub):
         if lb > ub:
             raise ValueError(
-                "The lower bound must be less than or equal to the upper bound "
-                "({} <= {}).".format(lb, ub))
+                "The lower bound must be less than or equal to the upper "
+                "bound ({} <= {}).".format(lb, ub))
 
     def update_variable_bounds(self):
         if self.model is None:

--- a/cobra/manipulation/__init__.py
+++ b/cobra/manipulation/__init__.py
@@ -7,8 +7,6 @@ from cobra.manipulation.delete import (
     delete_model_genes, find_gene_knockout_reactions, remove_genes,
     undelete_model_genes)
 from cobra.manipulation.modify import (
-    convert_to_irreversible, escape_ID, get_compiled_gene_reaction_rules,
-    revert_to_reversible)
+    escape_ID, get_compiled_gene_reaction_rules)
 from cobra.manipulation.validate import (
-    check_mass_balance, check_metabolite_compartment_formula,
-    check_reaction_bounds)
+    check_mass_balance, check_metabolite_compartment_formula)

--- a/cobra/manipulation/delete.py
+++ b/cobra/manipulation/delete.py
@@ -6,7 +6,6 @@ from ast import And, NodeTransformer
 
 from six import iteritems, string_types
 
-from cobra.core import Model
 from cobra.core.gene import ast2str, eval_gpr, parse_gpr
 
 

--- a/cobra/manipulation/modify.py
+++ b/cobra/manipulation/modify.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 from six import iteritems
 
-from cobra.core import Gene, Reaction
+from cobra.core import Reaction
 from cobra.core.gene import ast2str
 from cobra.manipulation.delete import get_compiled_gene_reaction_rules
 from cobra.util.solver import set_objective
@@ -116,78 +116,3 @@ def rename_genes(cobra_model, rename_dict):
         rxn.gene_reaction_rule = rxn._gene_reaction_rule
     for i in remove_genes:
         cobra_model.genes.remove(i)
-
-
-def convert_to_irreversible(cobra_model):
-    """Split reversible reactions into two irreversible reactions
-
-    These two reactions will proceed in opposite directions. This
-    guarentees that all reactions in the model will only allow
-    positive flux values, which is useful for some modeling problems.
-
-    cobra_model: A Model object which will be modified in place.
-
-    """
-    warn("deprecated, not applicable for optlang solvers", DeprecationWarning)
-    reactions_to_add = []
-    coefficients = {}
-    for reaction in cobra_model.reactions:
-        # If a reaction is reverse only, the forward reaction (which
-        # will be constrained to 0) will be left in the model.
-        if reaction.lower_bound < 0:
-            reverse_reaction = Reaction(reaction.id + "_reverse")
-            reverse_reaction.lower_bound = max(0, -reaction.upper_bound)
-            reverse_reaction.upper_bound = -reaction.lower_bound
-            coefficients[
-                reverse_reaction] = reaction.objective_coefficient * -1
-            reaction.lower_bound = max(0, reaction.lower_bound)
-            reaction.upper_bound = max(0, reaction.upper_bound)
-            # Make the directions aware of each other
-            reaction.notes["reflection"] = reverse_reaction.id
-            reverse_reaction.notes["reflection"] = reaction.id
-            reaction_dict = {k: v * -1
-                             for k, v in iteritems(reaction._metabolites)}
-            reverse_reaction.add_metabolites(reaction_dict)
-            reverse_reaction._model = reaction._model
-            reverse_reaction._genes = reaction._genes
-            for gene in reaction._genes:
-                gene._reaction.add(reverse_reaction)
-            reverse_reaction.subsystem = reaction.subsystem
-            reverse_reaction._gene_reaction_rule = reaction._gene_reaction_rule
-            reactions_to_add.append(reverse_reaction)
-    cobra_model.add_reactions(reactions_to_add)
-    set_objective(cobra_model, coefficients, additive=True)
-
-
-def revert_to_reversible(cobra_model, update_solution=True):
-    """This function will convert an irreversible model made by
-    convert_to_irreversible into a reversible model.
-
-    cobra_model : cobra.Model
-        A model which will be modified in place.
-    update_solution: bool
-        This option is ignored since `model.solution` was removed.
-    """
-    warn("deprecated, not applicable for optlang solvers", DeprecationWarning)
-    reverse_reactions = [x for x in cobra_model.reactions
-                         if "reflection" in x.notes and
-                         x.id.endswith('_reverse')]
-
-    # If there are no reverse reactions, then there is nothing to do
-    if len(reverse_reactions) == 0:
-        return
-
-    for reverse in reverse_reactions:
-        forward_id = reverse.notes.pop("reflection")
-        forward = cobra_model.reactions.get_by_id(forward_id)
-        forward.lower_bound = -reverse.upper_bound
-        if forward.upper_bound == 0:
-            forward.upper_bound = -reverse.lower_bound
-
-        if "reflection" in forward.notes:
-            forward.notes.pop("reflection")
-
-    # Since the metabolites and genes are all still in
-    # use we can do this faster removal step.  We can
-    # probably speed things up here.
-    cobra_model.remove_reactions(reverse_reactions)

--- a/cobra/manipulation/validate.py
+++ b/cobra/manipulation/validate.py
@@ -2,9 +2,6 @@
 
 from __future__ import absolute_import
 
-from math import isinf, isnan
-from warnings import warn
-
 
 NOT_MASS_BALANCED_TERMS = {"SBO:0000627",  # EXCHANGE
                            "SBO:0000628",  # DEMAND
@@ -22,30 +19,6 @@ def check_mass_balance(model):
             if balance:
                 unbalanced[reaction] = balance
     return unbalanced
-
-
-# no longer strictly necessary, done by optlang solver interfaces
-def check_reaction_bounds(model):
-    warn("no longer necessary, done by optlang solver interfaces",
-         DeprecationWarning)
-    errors = []
-    for reaction in model.reactions:
-        if reaction.lower_bound > reaction.upper_bound:
-            errors.append("Reaction '%s' has lower bound > upper bound" %
-                          reaction.id)
-        if isinf(reaction.lower_bound):
-            errors.append("Reaction '%s' has infinite lower_bound" %
-                          reaction.id)
-        elif isnan(reaction.lower_bound):
-            errors.append("Reaction '%s' has NaN for lower_bound" %
-                          reaction.id)
-        if isinf(reaction.upper_bound):
-            errors.append("Reaction '%s' has infinite upper_bound" %
-                          reaction.id)
-        elif isnan(reaction.upper_bound):
-            errors.append("Reaction '%s' has NaN for upper_bound" %
-                          reaction.id)
-    return errors
 
 
 def check_metabolite_compartment_formula(model):

--- a/cobra/test/test_core/test_core_reaction.py
+++ b/cobra/test/test_core/test_core_reaction.py
@@ -272,7 +272,7 @@ def test_build_from_string(model):
 
 def test_bounds_setter(model):
     rxn = model.reactions.get_by_id("PGI")
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         rxn.bounds = (1, 0)
 
 

--- a/cobra/test/test_manipulation.py
+++ b/cobra/test/test_manipulation.py
@@ -12,43 +12,6 @@ from cobra.manipulation import *
 class TestManipulation:
     """Test functions in cobra.manipulation"""
 
-    def test_modify_reversible(self, model):
-        solver = 'glpk'
-        model.solver = solver
-        model1 = model.copy()
-        solution1 = model1.optimize()
-        model2 = model.copy()
-        convert_to_irreversible(model2)
-        solution2 = model2.optimize()
-        assert abs(
-            solution1.objective_value - solution2.objective_value) < 10 ** -3
-        revert_to_reversible(model2)
-        solution2_rev = model2.optimize()
-        assert abs(
-            solution1.objective_value - solution2_rev.objective_value
-        ) < 10 ** -3
-        # Ensure revert_to_reversible is robust to solutions generated both
-        # before and after reversibility conversion, or not solved at all.
-        model3 = model.copy()
-        solution3 = model3.optimize()
-        convert_to_irreversible(model3)
-        revert_to_reversible(model3)
-        assert abs(
-            solution1.objective_value - solution3.objective_value) < 10 ** -3
-        # test reaction where both bounds are negative
-        model4 = model.copy()
-        glc = model4.reactions.get_by_id("EX_glc__D_e")
-        glc.upper_bound = -1
-        convert_to_irreversible(model4)
-        solution4 = model4.optimize()
-        assert abs(
-            solution1.objective_value - solution4.objective_value) < 10 ** -3
-        glc_rev = model4.reactions.get_by_id(glc.notes["reflection"])
-        assert glc_rev.lower_bound == 1
-        assert glc.upper_bound == 0
-        revert_to_reversible(model4)
-        assert glc.upper_bound == -1
-
     def test_escape_ids(self, model):
         model.reactions.PGI.gene_reaction_rule = "a.b or c"
         assert "a.b" in model.genes

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps=
     pytest-cov
     jsonschema
 commands =
-    pytest -W ignore::DeprecationWarning --cov={toxinidir}/cobra {posargs: --benchmark-skip}
+    pytest -W ignore::DeprecationWarning:libsbml --cov={toxinidir}/cobra {posargs: --benchmark-skip}
 
 [testenv:py37]
 extras =


### PR DESCRIPTION
Fix #784 

While trying to handle infinite values for bounds, I tripped over the behavior that adjusts both bounds when the lower bound is larger than the upper bound or vice versa. Is this something people use a lot? To me that seems like trying to be too smart for the user's own good.