### PR TITLE
Write xml declaration in temporary xml file

### DIFF
--- a/cobra/io/sbml3.py
+++ b/cobra/io/sbml3.py
@@ -580,7 +580,7 @@ def read_sbml_model(filename, number=float, **kwargs):
         # libsbml needs a file string, so write to temp file if a file handle
         if hasattr(filename, "read"):
             with NamedTemporaryFile(suffix=".xml", delete=False) as outfile:
-                xmlfile.write(outfile, encoding="UTF-8")
+                xmlfile.write(outfile, encoding="UTF-8", xml_declaration=True)
             filename = outfile.name
         return read_sbml2(filename, **kwargs)
     try:

--- a/cobra/test/test_io/test_sbml.py
+++ b/cobra/test/test_io/test_sbml.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+from io import BytesIO
 from os.path import getsize, join
 
 import pytest
@@ -37,6 +38,15 @@ def test_read_sbml_model(data_directory, mini_fbc1_model, mini_cobra_model):
     mini_cobra = io.read_legacy_sbml(join(data_directory, "mini_cobra.xml"))
     assert compare_models(mini_fbc1_model, mini_fbc1) is None
     assert compare_models(mini_cobra_model, mini_cobra) is None
+
+
+@pytest.mark.skipif(libsbml is None, reason="libsbml unavailable.")
+def test_read_file_handle(data_directory, mini_model):
+    """Test the reading of a model passed as a file handle."""
+    with open(join(data_directory, "mini_cobra.xml"), "rb") as file_:
+        model_stream = BytesIO(file_.read())
+    read_model = io.read_sbml_model(model_stream)
+    assert compare_models(mini_model, read_model) is None
 
 
 # TODO: parametrize the arguments after pytest.fixture_request()


### PR DESCRIPTION
libsbml will fail parsing the file if the xml declaration is missing,
so make sure it is always included. The declaration is by default
not written unless a non-standard encoding is used[1].

This is only relevant when a file-like stream object is passed to
`read_sbml_model`.

[1] https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.ElementTree.write