### PR TITLE
chore: fix extras dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
     'array': ["scipy"],
     'sbml': ["python-libsbml", "lxml"]
 }
-extras["all"] = sorted(list(extras))
+extras["all"] = sorted(extras.values())
 
 try:
     with open('README.rst') as handle:


### PR DESCRIPTION
Fix a bug with `pip install cobra[all]` that was reported on the mailing list.