### PR TITLE
Fix sampling in Gurobi

### DIFF
--- a/cobra/flux_analysis/sampling.py
+++ b/cobra/flux_analysis/sampling.py
@@ -221,11 +221,11 @@ class HRSampler(object):
         self.retries = 0
         self.problem = self.__build_problem()
         # Set up a map from reaction -> forward/reverse variable
-        var_idx = {v: idx for idx, v in enumerate(model.variables)}
+        var_idx = {v: idx for idx, v in enumerate(self.model.variables)}
         self.fwd_idx = np.array([var_idx[r.forward_variable]
-                                 for r in model.reactions])
+                                 for r in self.model.reactions])
         self.rev_idx = np.array([var_idx[r.reverse_variable]
-                                 for r in model.reactions])
+                                 for r in self.model.reactions])
         self.warmup = None
         if seed is None:
             self._seed = int(time())


### PR DESCRIPTION
So GLPK in optlang preserves the order of variables and constraints when pickling but Gurobi does not. This exposed a bug in the variable mapping in the sampler (order was assumed to be the same when copying model).

## Confirmation of fix

```python3
Python 3.6.8 |Anaconda custom (64-bit)| (default, Dec 29 2018, 19:04:46)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cobra.test import create_test_model

In [2]: from cobra.flux_analysis.sampling import OptGPSampler

In [3]: mod = create_test_model("textbook")

In [4]: mod.solver = "gurobi"

In [5]: mod.solver
Out[5]: <optlang.gurobi_interface.Model at 0x11a150a90>

In [6]: opt = OptGPSampler(mod, processes=4)
Read LP format model from file /var/folders/55/dv0p21y96g1cq84sr1zd3kym0000gr/T/tmp1hcp9_qy.lp
Reading time = 0.00 seconds
: 72 rows, 190 columns, 720 nonzeros

In [7]: s = opt.sample(1000)

In [8]: sum(opt.validate(s) == "v")
Out[8]: 1000
```
This returned zero before.

Fixes #807. 