### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,10 +43,10 @@ install:
         conda config --set always_yes yes --set changeps1 no;
         conda config --add channels conda-forge
         conda install -q pip setuptools wheel numpy scipy;
-        pip install -r develop-requirements.txt;
-        pip install .
+        pip install -qq -r develop-requirements.txt;
+        pip install -qq .
       } else {
-        pip install --upgrade setuptools wheel tox
+        pip install -qq --upgrade setuptools wheel tox
       }
 
 build: off


### PR DESCRIPTION
This is a bit of a hack which should make appveyor work again. 

I looked around a bit in other larger packages (pandas, matplotlib, etc.) and all of them have dropped Python 2 from the tests...