### PR TITLE
fix: limit the number of loops correctly

### DIFF
--- a/cobra/flux_analysis/geometric.py
+++ b/cobra/flux_analysis/geometric.py
@@ -92,7 +92,7 @@ def geometric_fba(model, epsilon=1E-06, max_tries=200):
                      count, delta, sol.status)
 
         # Following iterations that minimize the distance below threshold.
-        while delta > epsilon and count <= max_tries:
+        while delta > epsilon and count < max_tries:
             for rxn_id, var, u_c, l_c in updating_vars_cons:
                 var.ub = mean_flux[rxn_id]
                 u_c.ub = mean_flux[rxn_id]


### PR DESCRIPTION
Since the counter is incremented at the end of the loop, the check needs to be changed. Otherwise there will be `max_tries + 1` iterations.