### PR TITLE
Fix isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]*)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 tag_name = {new_version}
@@ -14,7 +14,7 @@ tag_name = {new_version}
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 
@@ -29,10 +29,6 @@ replace = __version__ = "{new_version}"
 [wheel]
 universal = 1
 
-[flake8]
-max-line-length = 79
-exclude = __init__.py,docs
-
 [pydocstyle]
 match_dir = cobra
 convention = numpy
@@ -43,22 +39,3 @@ test = pytest
 
 [tool:pytest]
 testpaths = cobra/test
-
-[isort]
-indent = 4
-line_length = 80
-multi_line_output = 4
-lines_after_imports = 2
-known_first_party = cobra
-known_third_party = 
-	depinfo
-	future
-	numpy
-	optlang
-	pandas
-	pytest
-	ruamel.yaml
-	swiglpk
-	six
-	tabulate
-

--- a/tox.ini
+++ b/tox.ini
@@ -46,3 +46,26 @@ deps=
     isort
 commands=
     isort --check-only --diff --recursive {toxinidir}/cobra
+
+[tool:isort]
+indent = 4
+line_length = 80
+multi_line_output = 4
+lines_after_imports = 2
+known_first_party = cobra
+known_third_party =
+    depinfo
+    future
+    numpy
+    optlang
+    pandas
+    pytest
+    ruamel.yaml
+    swiglpk
+    six
+    tabulate
+
+[flake8]
+max-line-length = 80
+exclude =
+    __init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands=
     isort --check-only --diff --recursive {toxinidir}/cobra
 
 [tool:isort]
+skip = __init__.py
 indent = 4
 line_length = 80
 multi_line_output = 4


### PR DESCRIPTION
With a recent update of isort the default configuration options were changed. This PR moves the configuration sections and ignores `__init__.py` files again. This PR is required for any other PR to succeed on Travis CI.