### PR TITLE
fix: remove bug in copying models with groups

### DIFF
--- a/cobra/core/group.py
+++ b/cobra/core/group.py
@@ -54,6 +54,9 @@ class Group(Object):
         # contains self
         self._model = None
 
+    def __len__(self):
+        return len(self._members)
+
     # read-only
     @property
     def members(self):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -374,14 +374,14 @@ class Model(Object):
         # Groups can be members of other groups. We initialize them first and
         # then update their members.
         for group in self.groups:
-            new_group = group.__class__()
+            new_group = group.__class__(group.id)
             for attr, value in iteritems(group.__dict__):
                 if attr not in do_not_copy_by_ref:
                     new_group.__dict__[attr] = copy(value)
             new_group._model = new
             new.groups.append(new_group)
         for group in self.groups:
-            new_group = new.groups[group.id]
+            new_group = new.groups.get_by_id(group.id)
             # update awareness, as in the reaction copies
             new_objects = []
             for member in group.members:

--- a/cobra/test/test_core/test_model.py
+++ b/cobra/test/test_core/test_model.py
@@ -485,6 +485,15 @@ def test_copy(model):
     assert 'ACALD' not in cp_model.reactions
 
 
+def test_copy_with_groups(model):
+    sub = Group("pathway", members=[model.reactions.PFK, model.reactions.FBA])
+    model.add_groups([sub])
+    copy = model.copy()
+    assert len(copy.groups) == len(model.groups)
+    assert len(copy.groups.get_by_id("pathway")) == len(
+        model.groups.get_by_id("pathway"))
+
+
 def test_deepcopy_benchmark(model, benchmark):
     benchmark(deepcopy, model)
 


### PR DESCRIPTION
Also add a test case and the dunder len method to `Group`.