### PR TITLE
Added processes to geometric_fba signature.

### DIFF
--- a/cobra/test/test_flux_analysis/test_geometric.py
+++ b/cobra/test/test_flux_analysis/test_geometric.py
@@ -59,13 +59,13 @@ def geometric_fba_model():
 def test_geometric_fba_benchmark(model, benchmark, all_solvers):
     """Benchmark geometric_fba."""
     model.solver = all_solvers
-    benchmark(geometric_fba, model)
+    benchmark(geometric_fba, model, processes=1)
 
 
 def test_geometric_fba(geometric_fba_model, all_solvers):
     """Test geometric_fba."""
     geometric_fba_model.solver = all_solvers
-    geometric_fba_sol = geometric_fba(geometric_fba_model)
+    geometric_fba_sol = geometric_fba(geometric_fba_model, processes=1)
     expected = Series({'v1': 1.0, 'v2': 0.33, 'v3': 0.33, 'v4': 0.33,
                        'v5': 1.0}, index=['v1', 'v2', 'v3', 'v4', 'v5'])
     assert np.allclose(geometric_fba_sol.fluxes, expected, atol=1E-02)


### PR DESCRIPTION
Added `processes` to `geometric_fba` signature and exposed the `processes` argument in the underlying `flux_variability_analysis` calls as discussed in #823. 

Previously, the `processes` value was linked solely to the configuration object, which has a default value equal to the number of CPUs on the machine. This change will allow for the user to override the value in the configuration object. The default value is `None`, which mirrors the default value in `flux_variability_analysis`.

