### PR TITLE
Pinning dependency to fix wheel issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
             "optlang>=1.4.2",
             "tabulate",
             "depinfo",
-            "python-libsbml-experimental>=5.18.0",
+            "python-libsbml-experimental==5.18.0",
         ],
         tests_require=[
             "jsonschema > 2.5",


### PR DESCRIPTION
This is fixing the SBML issues for now. 
Main issue is that there is a delay between python releases and the availability of wheels.
Pinning the dependencies fixes this. I will update the version when wheels are available.