### PR TITLE
chore: remove sbml extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ if {'pytest', 'test', 'ptr'}.intersection(argv):
 
 extras = {
     'array': ["scipy"],
-    'sbml': ["python-libsbml", "lxml"]
 }
 extras["all"] = sorted(extras.values())
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ python =
 
 [testenv]
 extras =
-    sbml
     array
 deps=
     pytest


### PR DESCRIPTION
Since libsbml (experimental) is now a permanent dependency, we don't need the sbml extras any longer.