### PR TITLE
Chain the original SBML exception

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -39,7 +39,7 @@ from copy import deepcopy
 from sys import platform
 
 import libsbml
-from six import iteritems, string_types
+from six import iteritems, raise_from, string_types
 
 import cobra
 from cobra.core import Gene, Group, Metabolite, Model, Reaction
@@ -211,8 +211,8 @@ def read_sbml_model(filename, number=float, f_replace=F_REPLACE,
     except IOError as e:
         raise e
 
-    except Exception:
-        raise CobraSBMLError(
+    except Exception as original_error:
+        cobra_error = CobraSBMLError(
             "Something went wrong reading the SBML model. Most likely the SBML"
             " model is not valid. Please check that your model is valid using "
             "the `cobra.io.sbml.validate_sbml_model` function or via the "
@@ -220,6 +220,7 @@ def read_sbml_model(filename, number=float, f_replace=F_REPLACE,
             "\t`(model, errors) = validate_sbml_model(filename)`"
             "\nIf the model is valid and cannot be read please open an issue "
             "at https://github.com/opencobra/cobrapy/issues .")
+        raise_from(cobra_error, original_error)
 
 
 def _get_doc_from_filename(filename):

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -212,7 +212,6 @@ def read_sbml_model(filename, number=float, f_replace=F_REPLACE,
         raise e
 
     except Exception:
-        LOGGER.error(traceback.print_exc())
         raise CobraSBMLError(
             "Something went wrong reading the SBML model. Most likely the SBML"
             " model is not valid. Please check that your model is valid using "


### PR DESCRIPTION
Hi all, in our application we saw cobrapy logging an error with message "None", in addition to a stacktrace for a _handled_ exception being printed to console. The cause is that `traceback.print_exc()` is assumed to return a string, but it only _prints_ an exception to console and returns nothing.

In this fix, I suggest to use [exception chaining](https://legacy.python.org/dev/peps/pep-3134/) instead of logging. This gives the calling context access to everything needed to investigate the root cause if wanted, and decide whether or not to log events and/or print anything to console.