### PR TITLE
Make tests compatible with optional dependencies

### DIFF
--- a/cobra/test/test_core/test_model.py
+++ b/cobra/test/test_core/test_model.py
@@ -669,13 +669,14 @@ def test_change_objective(model):
 def test_problem_properties(model):
     new_variable = model.problem.Variable("test_variable")
     new_constraint = model.problem.Constraint(Zero,
-                                              name="test_constraint")
+                                              name="test_constraint",
+                                              lb=0)
     model.add_cons_vars([new_variable, new_constraint])
-    assert "test_variable" in model.variables.keys()
-    assert "test_constraint" in model.constraints.keys()
+    assert "test_variable" in model.variables
+    assert "test_constraint" in model.constraints
     model.remove_cons_vars([new_constraint, new_variable])
-    assert "test_variable" not in model.variables.keys()
-    assert "test_constraint" not in model.variables.keys()
+    assert "test_variable" not in model.variables
+    assert "test_constraint" not in model.variables
 
 
 def test_solution_data_frame(model):
@@ -912,16 +913,20 @@ def test_change_objective(model):
 
 def test_set_reaction_objective(model):
     model.objective = model.reactions.ACALD
-    assert str(model.objective.expression) == str(
+    assert same_ex(
+        model.objective.expression,
         1.0 * model.reactions.ACALD.forward_variable -
-        1.0 * model.reactions.ACALD.reverse_variable)
+        1.0 * model.reactions.ACALD.reverse_variable
+    )
 
 
 def test_set_reaction_objective_str(model):
     model.objective = model.reactions.ACALD.id
-    assert str(model.objective.expression) == str(
+    assert same_ex(
+        model.objective.expression,
         1.0 * model.reactions.ACALD.forward_variable -
-        1.0 * model.reactions.ACALD.reverse_variable)
+        1.0 * model.reactions.ACALD.reverse_variable
+    )
 
 
 def test_invalid_objective_raises(model):
@@ -933,6 +938,7 @@ def test_invalid_objective_raises(model):
 
 @pytest.mark.skipif("cplex" not in solvers, reason="need cplex")
 def test_solver_change(model):
+    model.solver = "glpk"
     solver_id = id(model.solver)
     problem_id = id(model.solver.problem)
     solution = model.optimize().fluxes
@@ -944,6 +950,7 @@ def test_solver_change(model):
 
 
 def test_no_change_for_same_solver(model):
+    model.solver = "glpk"
     solver_id = id(model.solver)
     problem_id = id(model.solver.problem)
     model.solver = "glpk"

--- a/cobra/test/test_core/test_summary/test_metabolite_summary.py
+++ b/cobra/test/test_core/test_summary/test_metabolite_summary.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import
 
-import pytest
 import numpy as np
+import pytest
 
 from cobra.flux_analysis.parsimonious import pfba
 from cobra.test.test_core.test_summary import (

--- a/cobra/test/test_core/test_summary/test_metabolite_summary.py
+++ b/cobra/test/test_core/test_summary/test_metabolite_summary.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import
 
 import pytest
+import numpy as np
 
 from cobra.flux_analysis.parsimonious import pfba
 from cobra.test.test_core.test_summary import (
@@ -105,4 +106,7 @@ def test_metabolite_summary_to_frame_with_fva(model, opt_solver, fraction,
 
     out_df = model.metabolites.get_by_id(met).summary(fva=fraction).to_frame()
 
-    assert out_df['PERCENT'].tolist() == expected_percent
+    assert np.allclose(
+        out_df['PERCENT'].tolist(),
+        expected_percent,
+        1e-6, 1e-6)


### PR DESCRIPTION
Some tests would currently fail for cplex, gurobi and symengine. For instance here a recent test run from my machine

<details>

```bash
Test session starts (platform: linux, Python 3.7.5, pytest 5.2.1, pytest-sugar 0.9.2)
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/cdiener/code/cobrapy, inifile: setup.cfg, testpaths: cobra/test
plugins: cov-2.6.1, sugar-0.9.2, dash-1.4.1, benchmark-3.2.2, mock-1.10.4
collecting ... 
 cobra/test/test_manipulation.py ✓✓✓✓✓✓✓✓✓✓✓                                                                                                                     2% ▎         
 cobra/test/test_medium.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                     6% ▋         
 cobra/test/test_core/test_configuration.py ✓✓✓✓✓✓                                                                                                               8% ▊         
 cobra/test/test_core/test_core_reaction.py ✓✓✓✓✓✓✓s✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓x✓✓✓✓                                                               20% ██        
 cobra/test/test_core/test_dictlist.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                   25% ██▌       
 cobra/test/test_core/test_gene.py ✓                                                                                                                            25% ██▌       
 cobra/test/test_core/test_group.py ✓✓                                                                                                                          25% ██▌       
 cobra/test/test_core/test_metabolite.py ✓✓✓✓s✓✓s✓                                                                                                              27% ██▊       
 cobra/test/test_core/test_model.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                             38% ███▊      

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_problem_properties ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e88603150>

    def test_problem_properties(model):
        new_variable = model.problem.Variable("test_variable")
        new_constraint = model.problem.Constraint(Zero,
                                                  name="test_constraint")
        model.add_cons_vars([new_variable, new_constraint])
>       assert "test_variable" in model.variables.keys()

cobra/test/test_core/test_model.py:674: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cobra/core/model.py:931: in variables
    return self.solver.variables
../../.local/lib/python3.7/site-packages/optlang/interface.py:1203: in variables
    self.update()
../../.local/lib/python3.7/site-packages/optlang/interface.py:1428: in update
    self._add_constraints(add_constr)
../../.local/lib/python3.7/site-packages/optlang/cplex_interface.py:864: in _add_constraints
    constraint.ub
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

lb = None, ub = None

    def _constraint_lb_and_ub_to_cplex_sense_rhs_and_range_value(lb, ub):
        """Helper function used by Constraint and Model"""
        if lb is None and ub is None:
>           raise Exception("Free constraint ...")
E           Exception: Free constraint ...

../../.local/lib/python3.7/site-packages/optlang/cplex_interface.py:144: Exception

 cobra/test/test_core/test_model.py ⨯✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                            42% ████▎     

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_set_reaction_objective ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e880ab610>

    def test_set_reaction_objective(model):
        model.objective = model.reactions.ACALD
>       assert str(model.objective.expression) == str(
            1.0 * model.reactions.ACALD.forward_variable -
            1.0 * model.reactions.ACALD.reverse_variable)
E       AssertionError: assert '0.0 + 1.0*AC...reverse_fda2b' == '1.0*ACALD - ...reverse_fda2b'
E         - 0.0 + 1.0*ACALD - 1.0*ACALD_reverse_fda2b
E         ? ------
E         + 1.0*ACALD - 1.0*ACALD_reverse_fda2b

cobra/test/test_core/test_model.py:915: AssertionError

 cobra/test/test_core/test_model.py ⨯                                                                                                                           42% ████▎     

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_set_reaction_objective_str ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e87dbeb10>

    def test_set_reaction_objective_str(model):
        model.objective = model.reactions.ACALD.id
>       assert str(model.objective.expression) == str(
            1.0 * model.reactions.ACALD.forward_variable -
            1.0 * model.reactions.ACALD.reverse_variable)
E       AssertionError: assert '0.0 + 1.0*AC...reverse_fda2b' == '1.0*ACALD - ...reverse_fda2b'
E         - 0.0 + 1.0*ACALD - 1.0*ACALD_reverse_fda2b
E         ? ------
E         + 1.0*ACALD - 1.0*ACALD_reverse_fda2b

cobra/test/test_core/test_model.py:922: AssertionError

 cobra/test/test_core/test_model.py ⨯✓                                                                                                                          42% ████▎     

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_solver_change ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e87cc4e10>

    @pytest.mark.skipif("cplex" not in solvers, reason="need cplex")
    def test_solver_change(model):
        solver_id = id(model.solver)
        problem_id = id(model.solver.problem)
        solution = model.optimize().fluxes
        model.solver = "cplex"
>       assert id(model.solver) != solver_id
E       assert 140250140662864 != 140250140662864
E        +  where 140250140662864 = id(<optlang.cplex_interface.Model object at 0x7f8e87d05c50>)
E        +    where <optlang.cplex_interface.Model object at 0x7f8e87d05c50> = <Model e_coli_core at 0x7f8e87cc4e10>.solver

cobra/test/test_core/test_model.py:940: AssertionError

 cobra/test/test_core/test_model.py ⨯                                                                                                                           43% ████▍     

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_no_change_for_same_solver ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e87d38510>

    def test_no_change_for_same_solver(model):
        solver_id = id(model.solver)
        problem_id = id(model.solver.problem)
        model.solver = "glpk"
>       assert id(model.solver) == solver_id
E       assert 140250141652816 == 140250141651152
E        +  where 140250141652816 = id(<optlang.glpk_interface.Model object at 0x7f8e87df7750>)
E        +    where <optlang.glpk_interface.Model object at 0x7f8e87df7750> = <Model e_coli_core at 0x7f8e87d38510>.solver

cobra/test/test_core/test_model.py:950: AssertionError

 cobra/test/test_core/test_model.py ⨯✓✓✓✓s✓                                                                                                                     44% ████▌     
 cobra/test/test_core/test_solution.py ✓✓s                                                                                                                      45% ████▌     
 cobra/test/test_core/test_summary/test_metabolite_summary.py ✓✓✓✓✓✓✓                                                                                           46% ████▋     

――――――――――――――――――――――――――――――――――――――――――――――――――――― test_metabolite_summary_to_frame_with_fva[optlang-glpk-0.99-fdp_c] ―――――――――――――――――――――――――――――――――――――――――――――――――――――

model = <Model e_coli_core at 0x7f8e8b92de10>, opt_solver = 'optlang-glpk', fraction = 0.99, met = 'fdp_c'

    @pytest.mark.parametrize("fraction, met", [(0.99, "fdp_c")])
    def test_metabolite_summary_to_frame_with_fva(model, opt_solver, fraction,
                                                  met):
        """Test metabolite summary.to_frame() (using FVA)."""
    
        model.solver = opt_solver
        model.optimize()
    
        expected_percent = [100.0, 100.0, 0.0]
    
        out_df = model.metabolites.get_by_id(met).summary(fva=fraction).to_frame()
    
>       assert out_df['PERCENT'].tolist() == expected_percent
E       assert [100.0, 100.0...00000002, 0.0] == [100.0, 100.0, 0.0]
E         At index 1 diff: 100.0000000000002 != 100.0
E         Use -v to get the full diff

cobra/test/test_core/test_summary/test_metabolite_summary.py:108: AssertionError

 cobra/test/test_core/test_summary/test_metabolite_summary.py ⨯✓✓✓✓✓✓✓✓                                                                                         51% █████▏    
 cobra/test/test_core/test_summary/test_model_summary.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                   53% █████▍    
 cobra/test/test_core/test_summary/test_reaction_summary.py ss✓✓                                                                                                54% █████▍    
 cobra/test/test_flux_analysis/test_deletion.py ✓✓✓✓s✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                     69% ██████▉   
 cobra/test/test_flux_analysis/test_fastcc.py ✓✓✓✓✓✓✓✓                                                                                                          64% ██████▍   
 cobra/test/test_flux_analysis/test_geometric.py ✓✓✓✓                                                                                                           64% ██████▌   
 cobra/test/test_flux_analysis/test_moma.py ✓✓✓                                                                                                                 68% ██████▊   
 cobra/test/test_flux_analysis/test_parsimonious.py ✓✓✓✓                                                                                                        65% ██████▌   
 cobra/test/test_flux_analysis/test_reaction.py ✓✓                                                                                                              65% ██████▌   
 cobra/test/test_flux_analysis/test_room.py ✓✓✓✓                                                                                                                65% ██████▋   
 cobra/test/test_flux_analysis/test_variability.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                        74% ███████▍  
 cobra/test/test_flux_analysis/test_gapfilling.py ✓                                                                                                             69% ██████▉   
 cobra/test/test_flux_analysis/test_loopless.py ✓✓✓✓✓✓✓                                                                                                         71% ███████▏  
 cobra/test/test_flux_analysis/test_phenotype_phase_plane.py ✓✓✓✓✓✓                                                                                             72% ███████▎  
 cobra/test/test_io/test_annotation.py ✓✓                                                                                                                       74% ███████▌  
 cobra/test/test_io/test_io_order.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                80% ████████  
 cobra/test/test_io/test_json.py x✓x                                                                                                                            81% ████████▏ 
 cobra/test/test_io/test_mat.py ✓✓                                                                                                                              81% ████████▎ 
 cobra/test/test_io/test_pickle.py ✓s✓s                                                                                                                         82% ████████▎ 
 cobra/test/test_io/test_sbml.py ✓✓✓✓✓✓✓✓✓✓✓✓xxxx✓x✓x✓✓s✓✓✓✓✓✓✓✓✓✓                                                                                              90% ████████▉ 
 cobra/test/test_io/test_yaml.py ✓x                                                                                                                             90% █████████ 
 cobra/test/test_sampling/test_achr.py ✓✓✓✓✓✓                                                                                                                   91% █████████▎
 cobra/test/test_sampling/test_optgp.py ✓✓✓✓✓✓                                                                                                                  93% █████████▍
 cobra/test/test_sampling/test_sampling.py ✓✓✓✓✓✓✓✓✓✓                                                                                                           95% █████████▌
 cobra/test/test_util/test_array.py ✓✓                                                                                                                          95% █████████▋
 cobra/test/test_util/test_solver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                        99% ██████████

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_show_versions ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

self = setuptools 41.4.0 (/home/cdiener/.local/lib/python3.7/site-packages)

    @property
    def _dep_map(self):
        try:
>           return self.__dep_map

../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:3021: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = setuptools 41.4.0 (/home/cdiener/.local/lib/python3.7/site-packages), attr = '_DistInfoDistribution__dep_map'

    def __getattr__(self, attr):
        """Delegate all unrecognized public attributes to .metadata provider"""
        if attr.startswith('_'):
>           raise AttributeError(attr)
E           AttributeError: _DistInfoDistribution__dep_map

../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:2815: AttributeError

During handling of the above exception, another exception occurred:

self = setuptools 41.4.0 (/home/cdiener/.local/lib/python3.7/site-packages)

    @property
    def _parsed_pkg_info(self):
        """Parse and cache metadata"""
        try:
>           return self._pkg_info

../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:3012: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = setuptools 41.4.0 (/home/cdiener/.local/lib/python3.7/site-packages), attr = '_pkg_info'

    def __getattr__(self, attr):
        """Delegate all unrecognized public attributes to .metadata provider"""
        if attr.startswith('_'):
>           raise AttributeError(attr)
E           AttributeError: _pkg_info

../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:2815: AttributeError

During handling of the above exception, another exception occurred:

capsys = <_pytest.capture.CaptureFixture object at 0x7f8e80bb4650>

    def test_show_versions(capsys):
>       show_versions()

cobra/test/test_util/test_util.py:11: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cobra/util/util.py:29: in show_versions
    print_dependencies("cobra")
../../.local/lib/python3.7/site-packages/depinfo/info.py:75: in print_dependencies
    info = get_pkg_info(package_name)
../../.local/lib/python3.7/site-packages/depinfo/info.py:45: in get_pkg_info
    tree = construct_tree(dist_index)
../../.local/lib/python3.7/site-packages/pipdeptree.py:57: in construct_tree
    for p in index.values())
../../.local/lib/python3.7/site-packages/pipdeptree.py:57: in <genexpr>
    for p in index.values())
../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:2736: in requires
    dm = self._dep_map
../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:3023: in _dep_map
    self.__dep_map = self._compute_dependencies()
../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:3032: in _compute_dependencies
    for req in self._parsed_pkg_info.get_all('Requires-Dist') or []:
../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:3014: in _parsed_pkg_info
    metadata = self.get_metadata(self.PKG_INFO)
../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:1420: in get_metadata
    value = self._get(path)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pkg_resources.PathMetadata object at 0x7f8eb1aa3510>, path = '/home/cdiener/.local/lib/python3.7/site-packages/setuptools-41.4.0.dist-info/METADATA'

    def _get(self, path):
>       with open(path, 'rb') as stream:
E       FileNotFoundError: [Errno 2] No such file or directory: '/home/cdiener/.local/lib/python3.7/site-packages/setuptools-41.4.0.dist-info/METADATA'

../../.local/lib/python3.7/site-packages/pkg_resources/__init__.py:1616: FileNotFoundError
---------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------

System Information
==================
OS                 Linux
OS-release 5.3.0-1-amd64
Python             3.7.5

 cobra/test/test_util/test_util.py ⨯                                                                                                                           100% ██████████

----------------------------------------------------------------------------------------------------------------------------- benchmark: 49 tests -----------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                      Min                        Max                       Mean                    StdDev                     Median                       IQR            Outliers           OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_subtract_metabolite_benchmark[cplex]                           4.4740 (1.0)              35.4440 (1.0)               4.6753 (1.0)              0.5904 (1.0)               4.6490 (1.0)              0.0790 (1.0)         19;62  213,889.4045 (1.0)        3730           1
test_subtract_metabolite_benchmark[gurobi]                          4.5020 (1.01)             35.6770 (1.01)              4.7496 (1.02)             0.8961 (1.52)              4.6720 (1.00)             0.0830 (1.05)       60;111  210,545.2946 (0.98)       3926           1
test_subtract_metabolite_benchmark[glpk]                            4.5830 (1.02)             39.6510 (1.12)              4.8003 (1.03)             0.7907 (1.34)              4.7710 (1.03)             0.0830 (1.05)        10;46  208,318.1569 (0.97)       3729           1
test_achr_sample_benchmark                                        355.5860 (79.48)           700.7330 (19.77)           414.9064 (88.74)          111.7148 (189.21)          360.6670 (77.58)            6.8582 (86.81)     144;152    2,410.1822 (0.01)        765           1
test_change_objective_benchmark[cplex]                            388.1860 (86.76)           728.8160 (20.56)           397.1989 (84.96)           17.4119 (29.49)           394.2340 (84.80)            2.8608 (36.21)     145;292    2,517.6306 (0.01)       2545           1
test_change_objective_benchmark[gurobi]                           390.1080 (87.19)           713.6960 (20.14)           400.1998 (85.60)           24.6351 (41.72)           395.6420 (85.10)            2.9588 (37.45)      67;305    2,498.7517 (0.01)       2507           1
test_change_objective_benchmark[glpk]                             393.8800 (88.04)           686.1180 (19.36)           402.1988 (86.03)           16.7280 (28.33)           399.2350 (85.88)            2.8480 (36.05)     126;302    2,486.3325 (0.01)       2579           1
test_optgp_sample_benchmark                                       496.4370 (110.96)        1,233.4420 (34.80)           551.9951 (118.07)         128.2600 (217.24)          503.9305 (108.40)           5.7380 (72.63)      99;134    1,811.6103 (0.01)        838           1
test_add_remove_reaction_benchmark[cplex]                         591.5700 (132.22)        2,167.8910 (61.16)           615.0040 (131.54)          58.4389 (98.98)           607.1950 (130.61)           8.3630 (105.86)      25;77    1,626.0057 (0.01)        953           1
test_add_remove_reaction_benchmark[glpk]                          597.2970 (133.50)        1,184.2060 (33.41)           616.9411 (131.96)          38.8846 (65.86)           609.9810 (131.21)           9.0918 (115.09)      31;73    1,620.9002 (0.01)        951           1
test_add_remove_reaction_benchmark[gurobi]                        597.8590 (133.63)        1,432.7420 (40.42)           621.9521 (133.03)          62.9746 (106.66)          608.7870 (130.95)           9.4600 (119.75)      26;61    1,607.8408 (0.01)        634           1
test_loopless_benchmark_after                                   1,631.6690 (364.70)        3,168.2850 (89.39)         1,731.0834 (370.26)         203.8864 (345.32)        1,673.0595 (359.88)          50.7085 (641.88)      32;61      577.6729 (0.00)        520           1
test_loopless_benchmark_before                                  1,772.6090 (396.20)        4,272.6270 (120.55)        2,058.4756 (440.29)         458.4478 (776.48)        1,877.9460 (403.95)         201.7192 (>1000.0)     60;84      485.7964 (0.00)        543           1
test_copy_benchmark[glpk]                                      10,395.0400 (>1000.0)     182,977.0290 (>1000.0)      14,864.3744 (>1000.0)     23,994.4145 (>1000.0)      10,787.9110 (>1000.0)      1,212.6528 (>1000.0)       2;4       67.2749 (0.00)         89           1
test_copy_benchmark[cplex]                                     10,425.1810 (>1000.0)     213,878.1960 (>1000.0)      13,276.5194 (>1000.0)     20,597.4717 (>1000.0)      10,777.4350 (>1000.0)      1,313.7820 (>1000.0)       1;3       75.3209 (0.00)         97           1
test_copy_benchmark[gurobi]                                    10,465.2700 (>1000.0)     245,315.6810 (>1000.0)      13,778.4099 (>1000.0)     24,285.7759 (>1000.0)      10,820.7330 (>1000.0)      1,321.0790 (>1000.0)       1;3       72.5773 (0.00)         93           1
test_benchmark_medium_mip                                      12,464.3480 (>1000.0)      14,499.5380 (409.08)       12,688.2393 (>1000.0)        367.8310 (623.00)       12,569.3250 (>1000.0)        112.6665 (>1000.0)      5;10       78.8131 (0.00)         72           1
test_benchmark_medium_linear                                   12,941.1250 (>1000.0)      19,416.1790 (547.80)       13,302.8065 (>1000.0)      1,001.0058 (>1000.0)      13,049.2720 (>1000.0)        118.7395 (>1000.0)       5;9       75.1721 (0.00)         71           1
test_deepcopy_benchmark                                        18,659.1880 (>1000.0)      20,006.4690 (564.45)       19,316.2300 (>1000.0)        445.4484 (754.46)       19,509.6470 (>1000.0)        910.6455 (>1000.0)      22;0       51.7699 (0.00)         47           1
test_fastcc_benchmark[glpk]                                    31,209.6020 (>1000.0)      37,051.1200 (>1000.0)      31,952.7773 (>1000.0)      1,199.3102 (>1000.0)      31,409.6810 (>1000.0)      1,123.9330 (>1000.0)       2;2       31.2962 (0.00)         30           1
test_single_gene_deletion_moma_benchmark[cplex]                41,832.4140 (>1000.0)      71,848.8950 (>1000.0)      54,932.7562 (>1000.0)     10,961.8665 (>1000.0)      54,441.3885 (>1000.0)     18,855.9030 (>1000.0)       5;0       18.2041 (0.00)         14           1
test_fastcc_benchmark[cplex]                                   44,624.1270 (>1000.0)      55,377.4190 (>1000.0)      49,018.9278 (>1000.0)      4,822.4552 (>1000.0)      47,293.6070 (>1000.0)      8,524.3130 (>1000.0)       1;0       20.4003 (0.00)          5           1
test_single_reaction_deletion_benchmark[glpk]                  46,628.6900 (>1000.0)      51,401.6160 (>1000.0)      48,872.2664 (>1000.0)      1,395.1985 (>1000.0)      48,856.8530 (>1000.0)      2,342.5840 (>1000.0)       7;0       20.4615 (0.00)         20           1
test_single_gene_deletion_linear_room_benchmark[cplex]         52,621.9490 (>1000.0)      58,797.7140 (>1000.0)      54,371.7596 (>1000.0)      1,764.9227 (>1000.0)      53,891.4900 (>1000.0)      2,610.1240 (>1000.0)       2;0       18.3919 (0.00)         14           1
test_single_gene_deletion_linear_room_benchmark[glpk]          60,039.5480 (>1000.0)      62,410.5290 (>1000.0)      60,691.4350 (>1000.0)        665.6077 (>1000.0)      60,542.3890 (>1000.0)        355.4953 (>1000.0)       3;3       16.4768 (0.00)         17           1
test_single_gene_deletion_linear_moma_benchmark[cplex]         60,711.8130 (>1000.0)      64,109.6060 (>1000.0)      61,548.8678 (>1000.0)        821.8491 (>1000.0)      61,322.0885 (>1000.0)        375.5515 (>1000.0)       3;2       16.2473 (0.00)         16           1
test_single_gene_deletion_linear_moma_benchmark[glpk]          67,509.6370 (>1000.0)      68,543.7480 (>1000.0)      67,981.7976 (>1000.0)        311.1783 (527.05)       67,937.7480 (>1000.0)        392.2155 (>1000.0)       5;0       14.7098 (0.00)         15           1
test_single_reaction_deletion_benchmark[cplex]                 70,374.8000 (>1000.0)     112,917.6900 (>1000.0)      79,157.4108 (>1000.0)     12,215.0694 (>1000.0)      73,532.5450 (>1000.0)      7,941.6055 (>1000.0)       2;2       12.6331 (0.00)         13           1
test_add_metabolite_benchmark[gurobi]                          76,702.6410 (>1000.0)      78,539.7120 (>1000.0)      77,066.5299 (>1000.0)        554.1885 (938.63)       76,887.1290 (>1000.0)        154.8240 (>1000.0)       2;3       12.9758 (0.00)         14           1
test_add_metabolite_benchmark[cplex]                           76,966.7160 (>1000.0)      80,055.5790 (>1000.0)      77,718.5438 (>1000.0)      1,066.6899 (>1000.0)      77,244.6185 (>1000.0)        551.6480 (>1000.0)       3;3       12.8669 (0.00)         14           1
test_add_metabolite_benchmark[glpk]                            77,497.3390 (>1000.0)      80,049.6840 (>1000.0)      77,990.6336 (>1000.0)        691.1187 (>1000.0)      77,774.7160 (>1000.0)        196.5320 (>1000.0)       2;2       12.8221 (0.00)         14           1
test_pfba_benchmark[cplex]                                    115,131.3450 (>1000.0)     123,296.9490 (>1000.0)     118,700.3488 (>1000.0)      3,208.1877 (>1000.0)     118,047.2280 (>1000.0)      4,808.6205 (>1000.0)       2;0        8.4246 (0.00)          5           1
test_geometric_fba_benchmark[glpk]                            175,836.4960 (>1000.0)     180,873.4790 (>1000.0)     177,055.9713 (>1000.0)      1,898.4879 (>1000.0)     176,353.8945 (>1000.0)        685.0340 (>1000.0)       1;1        5.6479 (0.00)          6           1
test_single_gene_deletion_fba_benchmark[glpk]                 187,013.3710 (>1000.0)     320,136.8240 (>1000.0)     237,116.2440 (>1000.0)     57,697.4099 (>1000.0)     207,611.5240 (>1000.0)     99,012.9942 (>1000.0)       2;0        4.2173 (0.00)          7           1
test_single_gene_deletion_fba_benchmark[cplex]                188,631.4110 (>1000.0)     321,126.1380 (>1000.0)     225,352.7460 (>1000.0)     48,101.8115 (>1000.0)     211,145.6105 (>1000.0)     16,190.7560 (>1000.0)       1;1        4.4375 (0.00)          6           1
test_copy_benchmark_large_model[cplex]                        198,094.8450 (>1000.0)     594,713.4250 (>1000.0)     265,296.8952 (>1000.0)    161,382.7409 (>1000.0)     199,842.0815 (>1000.0)      1,671.3620 (>1000.0)       1;1        3.7694 (0.00)          6           1
test_copy_benchmark_large_model[gurobi]                       198,473.8820 (>1000.0)     643,421.3200 (>1000.0)     273,158.7813 (>1000.0)    181,391.9850 (>1000.0)     199,235.1600 (>1000.0)      1,467.7440 (>1000.0)       1;1        3.6609 (0.00)          6           1
test_copy_benchmark_large_model[glpk]                         199,040.2640 (>1000.0)     496,831.2760 (>1000.0)     249,842.8745 (>1000.0)    121,012.9411 (>1000.0)     199,968.2560 (>1000.0)      4,772.4210 (>1000.0)       1;1        4.0025 (0.00)          6           1
test_geometric_fba_benchmark[cplex]                           247,270.9160 (>1000.0)     251,598.2180 (>1000.0)     249,062.3424 (>1000.0)      1,847.5792 (>1000.0)     249,002.9140 (>1000.0)      3,142.9380 (>1000.0)       1;0        4.0151 (0.00)          5           1
test_flux_variability_loopless_benchmark[glpk]                313,196.4780 (>1000.0)     613,563.0970 (>1000.0)     459,624.4030 (>1000.0)    142,332.3036 (>1000.0)     460,389.6580 (>1000.0)    275,948.4542 (>1000.0)       2;0        2.1757 (0.00)          5           1
test_double_gene_deletion_benchmark                           337,319.6890 (>1000.0)     372,518.6210 (>1000.0)     351,896.8482 (>1000.0)     13,360.2710 (>1000.0)     350,976.4900 (>1000.0)     17,168.8878 (>1000.0)       2;0        2.8417 (0.00)          5           1
test_pfba_benchmark[glpk]                                     419,748.1820 (>1000.0)     480,281.1750 (>1000.0)     443,401.6072 (>1000.0)     22,365.9508 (>1000.0)     438,173.2270 (>1000.0)     20,112.4712 (>1000.0)       2;0        2.2553 (0.00)          5           1
test_optgp_init_benchmark                                     466,205.0220 (>1000.0)     496,992.6770 (>1000.0)     478,787.5264 (>1000.0)     11,749.3061 (>1000.0)     479,730.8930 (>1000.0)     14,404.4172 (>1000.0)       2;0        2.0886 (0.00)          5           1
test_achr_init_benchmark                                      468,466.5170 (>1000.0)     473,853.9040 (>1000.0)     470,570.3338 (>1000.0)      2,168.1143 (>1000.0)     469,500.1820 (>1000.0)      3,004.9302 (>1000.0)       1;0        2.1251 (0.00)          5           1
test_flux_variability_loopless_benchmark[cplex]               975,903.0730 (>1000.0)   1,178,959.5510 (>1000.0)   1,057,760.0590 (>1000.0)     79,087.5303 (>1000.0)   1,029,532.7790 (>1000.0)    106,596.7040 (>1000.0)       2;0        0.9454 (0.00)          5           1
test_flux_variability_benchmark[cplex]                      2,157,792.7700 (>1000.0)   2,436,472.5290 (>1000.0)   2,314,716.2868 (>1000.0)    129,746.1537 (>1000.0)   2,358,813.3790 (>1000.0)    240,374.4893 (>1000.0)       1;0        0.4320 (0.00)          5           1
test_double_reaction_deletion_benchmark                     2,720,554.0550 (>1000.0)   2,841,392.3010 (>1000.0)   2,780,877.8574 (>1000.0)     52,627.7083 (>1000.0)   2,803,784.3940 (>1000.0)     88,171.4568 (>1000.0)       2;0        0.3596 (0.00)          5           1
test_flux_variability_benchmark[glpk]                       4,206,126.1460 (>1000.0)   4,213,016.2740 (>1000.0)   4,209,718.9366 (>1000.0)      2,977.2432 (>1000.0)   4,210,262.1090 (>1000.0)      5,295.8095 (>1000.0)       2;0        0.2375 (0.00)          5           1
test_single_gene_deletion_room_benchmark[cplex]            14,049,408.0670 (>1000.0)  23,835,902.8230 (>1000.0)  19,646,024.4662 (>1000.0)  3,760,690.6045 (>1000.0)  21,062,119.3620 (>1000.0)  4,976,384.0277 (>1000.0)       2;0        0.0509 (0.00)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean

Results (339.12s):
     414 passed
       7 failed
         - cobra/test/test_core/test_model.py:669 test_problem_properties
         - cobra/test/test_core/test_model.py:913 test_set_reaction_objective
         - cobra/test/test_core/test_model.py:920 test_set_reaction_objective_str
         - cobra/test/test_core/test_model.py:934 test_solver_change
         - cobra/test/test_core/test_model.py:946 test_no_change_for_same_solver
         - cobra/test/test_core/test_summary/test_metabolite_summary.py:96 test_metabolite_summary_to_frame_with_fva[optlang-glpk-0.99-fdp_c]
         - cobra/test/test_util/test_util.py:10 test_show_versions
      10 xfailed
      11 skipped
```

</details>

This was mainly due to the following:

- incorrect comparison operator for sympy/symengine expressions (used string comparison which is not a valid test for equality of expression since for instance `x + 0.0 == x`)
- testing for exact equality in floats in some tests (should test for equality within solver tolerance)

The provided fixes now make all tests pass on alternative configurations.