### PR TITLE
[feat] add allow_nan to to_json

### DIFF
--- a/cobra/io/json.py
+++ b/cobra/io/json.py
@@ -42,7 +42,11 @@ def to_json(model, sort=False, **kwargs):
     """
     obj = model_to_dict(model, sort=sort)
     obj[u"version"] = JSON_SPEC
-    return json.dumps(obj, allow_nan=False, **kwargs)
+
+    dump_opts = { "allow_nan": False }
+    dump_opts.update(**kwargs)
+
+    return json.dumps(obj, **kwargs)
 
 
 def from_json(document):


### PR DESCRIPTION
By default, `cobra.io.to_json` dumps json with `allow_nan` as `False`. Allow overriding the same. This behaviour happens to be available within the `save_json_model` function.