### PR TITLE
fix: switch group type from set to DictList

### DIFF
--- a/cobra/core/group.py
+++ b/cobra/core/group.py
@@ -28,7 +28,7 @@ class Group(Object):
     name : str, optional
         A human readable name for the group
     members : iterable, optional
-        A list object containing references to cobra.Model-associated objects
+        A DictList containing references to cobra.Model-associated objects
         that belong to the group.
     kind : {"collection", "classification", "partonomy"}, optional
         The kind of group, as specified for the Groups feature in the SBML

--- a/cobra/core/group.py
+++ b/cobra/core/group.py
@@ -8,6 +8,8 @@ from warnings import warn
 
 from six import string_types
 
+from cobra.core.dictlist import DictList
+
 from cobra.core.object import Object
 
 
@@ -47,7 +49,7 @@ class Group(Object):
     def __init__(self, id, name='', members=None, kind=None):
         Object.__init__(self, id, name)
 
-        self._members = set() if members is None else set(members)
+        self._members = DictList() if members is None else DictList(members)
         self._kind = None
         self.kind = "collection" if kind is None else kind
         # self.model is None or refers to the cobra.Model that
@@ -92,7 +94,7 @@ class Group(Object):
             warn("need to pass in a list")
             new_members = [new_members]
 
-        self._members.update(new_members)
+        self._members.union(new_members)
 
     def remove_members(self, to_remove):
         """
@@ -109,4 +111,5 @@ class Group(Object):
             warn("need to pass in a list")
             to_remove = [to_remove]
 
-        self._members.difference_update(to_remove)
+        for member_to_remove in to_remove:
+            self._members.remove(member_to_remove)

--- a/cobra/core/group.py
+++ b/cobra/core/group.py
@@ -9,7 +9,6 @@ from warnings import warn
 from six import string_types
 
 from cobra.core.dictlist import DictList
-
 from cobra.core.object import Object
 
 

--- a/cobra/test/test_core/test_group.py
+++ b/cobra/test/test_core/test_group.py
@@ -24,6 +24,10 @@ def test_group_add_elements(model):
     group.add_members(reactions_for_larger_group)
     assert len(group.members) == num_total_members
 
+    # the order of members should be the same as the loaded one
+    for i in range(num_total_members):
+        assert group.members[i] == model.reactions[i]
+
 
 def test_group_kind():
     group = Group("arbitrary_group1")


### PR DESCRIPTION
Following the discussion in #923, groups members are now stored in DictLists instead of sets, to keep order in I/O cycles