### PR TITLE
Handle repeated infeasible MIP optimization in minimal_medium

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PYTHON%\Library\bin;%PATH%"
   - "ECHO %PYTHON%"
   - python --version
-  - python -m pip install --upgrade --disable-pip-version-check pip setuptools wheel tox
+  - python -m pip install --upgrade --disable-pip-version-check pip setuptools wheel tox six>=1.14.0
 
 test_script:
   - tox

--- a/cobra/medium/minimal_medium.py
+++ b/cobra/medium/minimal_medium.py
@@ -161,9 +161,8 @@ def minimal_medium(model, min_objective_value=0.1, exports=False,
     minimize the number of "large" import fluxes. Specifically, the detection
     limit is given by ``integrality_tolerance * max_bound`` where ``max_bound``
     is the largest bound on an import reaction. Thus, if you are interested
-    in small import fluxes as well you may have to adjust the integrality
-    tolerance at first with
-    `model.solver.configuration.tolerances.integrality = 1e-7` for instance.
+    in small import fluxes as well you may have to adjust the solver
+    tolerance at first with `model.tolerance = 1e-7` for instance.
     However, this will be *very* slow for large models especially with GLPK.
 
     """
@@ -218,7 +217,9 @@ def minimal_medium(model, min_objective_value=0.1, exports=False,
                             "This is usually due to numerical instability. "
                             "Possible remedies are relaoding the model "
                             "from scratch, switching to a different solver, "
-                            "or decreasing the solver tolerance."
+                            "or decreasing the solver tolerance. Please, "
+                            "carefully read the note on numerical instability "
+                            "in the function documentation."
                         )
                         return None
                     break

--- a/cobra/medium/minimal_medium.py
+++ b/cobra/medium/minimal_medium.py
@@ -202,6 +202,7 @@ def minimal_medium(model, min_objective_value=0.1, exports=False,
             mod.add_cons_vars([exclusion])
             mod.solver.update()
             media = []
+
             for i in range(minimize_components):
                 LOGGER.info("Finding alternative medium #%d.", (i + 1))
                 vars = [mod.variables["ind_" + s] for s in seen]
@@ -211,6 +212,15 @@ def minimal_medium(model, min_objective_value=0.1, exports=False,
                     exclusion.ub = best - 1
                 num_components = mod.slim_optimize()
                 if mod.solver.status != OPTIMAL or num_components > best:
+                    if i == 0:
+                        LOGGER.warning(
+                            "Could not get an optimal solution. "
+                            "This is usually due to numerical instability. "
+                            "Possible remedies are relaoding the model "
+                            "from scratch, switching to a different solver, "
+                            "or decreasing the solver tolerance."
+                        )
+                        return None
                     break
                 medium = _as_medium(exchange_rxns, tol, exports=exports)
                 media.append(medium)

--- a/cobra/test/test_core/test_summary/test_metabolite_summary.py
+++ b/cobra/test/test_core/test_summary/test_metabolite_summary.py
@@ -19,7 +19,7 @@ def test_metabolite_summary_to_table_previous_solution(model, opt_solver, met):
     solution = pfba(model)
 
     expected_entry = ['PRODUCING CYTBD     100    43.6  2.0 h_c + 0.5 o2_c + '
-                      'q8h2_c --> h2o_c + 2.0 h_...']
+                      'q8h2_c --> h2o_c + 2.0 h_']
 
     with captured_output() as (out, _):
         print(model.metabolites.get_by_id(met).summary(solution))
@@ -51,10 +51,10 @@ def test_metabolite_summary_to_table(model, opt_solver, met, names):
     if names:
         expected_entry = ['PRODUCING cytochrome oxidase bd '
                           '(ubiquinol-8: 2 protons)    100    43.6  '
-                          '2.0 H+ + 0.5 O2 + Ubiquinol-8 --> H2O + 2.0 H+...']
+                          '2.0 H+ + 0.5 O2 + Ubiquinol-8 --> H2O + 2.0 H+']
     else:
         expected_entry = ['PRODUCING CYTBD     100    43.6  2.0 h_c + '
-                          '0.5 o2_c + q8h2_c --> h2o_c + 2.0 h_...']
+                          '0.5 o2_c + q8h2_c --> h2o_c + 2.0 h_']
 
     with captured_output() as (out, _):
         print(model.metabolites.get_by_id(met).summary(names=names))


### PR DESCRIPTION
Similar to FVA this adds a warning and `None` return for cases where the repeated optimization of the same objective with the same model suddenly leads to a non-optimal solution. This is only the case for numerically unstable models so it is hard to add a test for this case since none of the test models included in cobrapy will ever run into this case.

Related to #928 