### PR TITLE
feat: set interface to solver timeout in configuration

### DIFF
--- a/cobra/core/configuration.py
+++ b/cobra/core/configuration.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 import logging
 import types
 from multiprocessing import cpu_count
-from warnings import warn
 
 from six import string_types, with_metaclass
 

--- a/cobra/core/configuration.py
+++ b/cobra/core/configuration.py
@@ -53,7 +53,7 @@ class BaseConfiguration(object):
     def __init__(self):
         self._solver = None
         self.tolerance = 1E-07
-        self.timeout = None
+        self.solver_timeout = None
         self.lower_bound = None
         self.upper_bound = None
 

--- a/cobra/core/configuration.py
+++ b/cobra/core/configuration.py
@@ -53,6 +53,7 @@ class BaseConfiguration(object):
     def __init__(self):
         self._solver = None
         self.tolerance = 1E-07
+        self.timeout = None
         self.lower_bound = None
         self.upper_bound = None
 

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -121,6 +121,9 @@ class Model(Object):
             self._tolerance = None
             self.tolerance = configuration.tolerance
 
+            self._timeout= None
+            self.timeout = configuration.timeout
+
     @property
     def solver(self):
         """Get or set the attached solver instance.
@@ -191,6 +194,20 @@ class Model(Object):
                         "integrality tolerance.")
 
         self._tolerance = value
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        try:
+            self._solver.configuration.timeout = value
+        except AttributeError:
+            logger.info("The current solver doesn't allow setting"
+                        "timeout.")
+
+        self._timeout = value
 
     @property
     def description(self):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -121,7 +121,7 @@ class Model(Object):
             self._tolerance = None
             self.tolerance = configuration.tolerance
 
-            self._timeout= None
+            self._timeout = None
             self.timeout = configuration.timeout
 
     @property

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -206,8 +206,8 @@ class Model(Object):
         except AttributeError:
             logger.info("The current solver doesn't allow setting"
                         "timeout.")
-
-        self._timeout = value
+        else:
+            self._timeout = value
 
     @property
     def description(self):

--- a/cobra/core/model.py
+++ b/cobra/core/model.py
@@ -121,8 +121,7 @@ class Model(Object):
             self._tolerance = None
             self.tolerance = configuration.tolerance
 
-            self._timeout = None
-            self.timeout = configuration.timeout
+            self.solver.configuration.timeout = configuration.solver_timeout
 
     @property
     def solver(self):
@@ -194,20 +193,6 @@ class Model(Object):
                         "integrality tolerance.")
 
         self._tolerance = value
-
-    @property
-    def timeout(self):
-        return self._timeout
-
-    @timeout.setter
-    def timeout(self, value):
-        try:
-            self._solver.configuration.timeout = value
-        except AttributeError:
-            logger.info("The current solver doesn't allow setting"
-                        "timeout.")
-        else:
-            self._timeout = value
 
     @property
     def description(self):

--- a/cobra/test/test_core/test_configuration.py
+++ b/cobra/test/test_core/test_configuration.py
@@ -63,7 +63,7 @@ def test_default_timeout(model):
     """Verify the default solver tolerance."""
     config = Configuration()
     config.solver = "glpk"
-    assert config.timeout == None
+    assert config.timeout is None
     # Test the consistency between cobra.core.Configuration.tolerance and
     # cobra.core.Model.tolerance
     assert config.timeout == model.timeout
@@ -80,6 +80,5 @@ def test_toy_model_timeout_with_different_default():
 
 def test_timeout_assignment(model):
     """Test assignment of solver tolerance."""
-    model.timeout = 2 
+    model.timeout = 2
     assert model.timeout == 2
-

--- a/cobra/test/test_core/test_configuration.py
+++ b/cobra/test/test_core/test_configuration.py
@@ -63,22 +63,16 @@ def test_default_timeout(model):
     """Verify the default solver tolerance."""
     config = Configuration()
     config.solver = "glpk"
-    assert config.timeout is None
-    # Test the consistency between cobra.core.Configuration.tolerance and
-    # cobra.core.Model.tolerance
-    assert config.timeout == model.timeout
+    assert config.solver_timeout is None
+    # compare with `==` even if both are None so the test is consistent with
+    # possible changes in default values
+    assert config.solver_timeout == model.solver.configuration.timeout
 
 
 def test_toy_model_timeout_with_different_default():
     """Verify that different default tolerance is respected by Model."""
     config = Configuration()
-    config.timeout = 2
+    config.solver_timeout = 2
 
     toy_model = Model(name="toy model")
-    assert toy_model.timeout == 2
-
-
-def test_timeout_assignment(model):
-    """Test assignment of solver tolerance."""
-    model.timeout = 2
-    assert model.timeout == 2
+    assert toy_model.solver.configuration.timeout == 2

--- a/cobra/test/test_core/test_configuration.py
+++ b/cobra/test/test_core/test_configuration.py
@@ -57,3 +57,29 @@ def test_tolerance_assignment(model):
     """Test assignment of solver tolerance."""
     model.tolerance = 1e-06
     assert model.tolerance == 1e-06
+
+
+def test_default_timeout(model):
+    """Verify the default solver tolerance."""
+    config = Configuration()
+    config.solver = "glpk"
+    assert config.timeout == None
+    # Test the consistency between cobra.core.Configuration.tolerance and
+    # cobra.core.Model.tolerance
+    assert config.timeout == model.timeout
+
+
+def test_toy_model_timeout_with_different_default():
+    """Verify that different default tolerance is respected by Model."""
+    config = Configuration()
+    config.timeout = 2
+
+    toy_model = Model(name="toy model")
+    assert toy_model.timeout == 2
+
+
+def test_timeout_assignment(model):
+    """Test assignment of solver tolerance."""
+    model.timeout = 2 
+    assert model.timeout == 2
+


### PR DESCRIPTION
### Description

Allow the user to set the timeout of the solver through an attribute of `cobrapy.Model`, as for the tolerance. The default value in the configuration of this timeout would be `None`.