### PR TITLE
Switch to non-experimental python-libsbml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
             "pandas>=0.17.0",
             "optlang>=1.4.2",
             "depinfo",
-            "python-libsbml-experimental==5.18.0",
+            "python-libsbml==5.18.0",
         ],
         tests_require=[
             "jsonschema > 2.5",


### PR DESCRIPTION
From the same maintainers as python-libsbml-experimental. Available at https://pypi.org/project/python-libsbml/