### PR TITLE
Add Python 3.8 and remove EOL version support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,10 @@ if __name__ == "__main__":
             'License :: OSI Approved :: GNU General Public License v2'
                 ' or later (GPLv2+)',
             'Operating System :: OS Independent',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: Implementation :: CPython',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Bio-Informatics'


### PR DESCRIPTION
Python 3.8 was released in late 2019.

Python 2.7 is EOL since January 2020, and 3.4 since March 2019. See https://devguide.python.org/devcycle/#end-of-life-branches. CI test runs on both versions was removed in #939. This also removes them from package metadata.

This change marks removal of support for Python 2. It may deserve a major version bump.