### PR TITLE
Writing notes for model in SBML file

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -101,7 +101,7 @@ SBML_DOT = "__SBML_DOT__"
 # -----------------------------------------------------------------------------
 pattern_notes = re.compile(
     r"<(?P<prefix>(\w+:)?)p[^>]*>(?P<content>.*?)</(?P=prefix)p>",
-    re.IGNORECASE
+    re.IGNORECASE | re.DOTALL
 )
 
 pattern_to_sbml = re.compile(r'([^0-9_a-zA-Z])')

--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -935,9 +935,12 @@ def _model_to_sbml(cobra_model, f_replace=None, units=True):
     if cobra_model.name is not None:
         model.setName(cobra_model.name)
 
+    # for parsing annotation corresponding to the model
     _sbase_annotations(model, cobra_model.annotation)
+    # for parsing notes corresponding to the model
+    _sbase_notes_dict(model, cobra_model.notes)
 
-    # Meta information (ModelHistory)
+    # Meta information (ModelHistory) related to SBMLDocument
     if hasattr(cobra_model, "_sbml"):
         meta = cobra_model._sbml
         if "annotation" in meta:

--- a/cobra/test/test_io/test_model_notes.py
+++ b/cobra/test/test_io/test_model_notes.py
@@ -1,0 +1,31 @@
+import pytest
+import cobra
+from os.path import join
+from cobra.util.solver import set_objective
+from cobra.io import read_sbml_model, write_sbml_model
+
+
+def test_model_notes(tmp_path):
+    """Testing if model notes are written in SBML"""
+    path_to_file = join(str(tmp_path), "model_notes.xml")
+
+    # making a minimal cobra model to test notes
+    model = cobra.Model("e_coli_core")
+    model.notes["Remark"] = "...Model Notes..."
+    met = cobra.Metabolite("pyr_c", compartment="c")
+    model.add_metabolites([met])
+    met.notes["Remark"] = "I appear."
+    rxn = cobra.Reaction("R_ATPM")
+    model.add_reactions([rxn])
+    rxn.notes["Remark"] = "What about me?"
+    model.objective_direction = "max"
+    coefficients = {}
+    coefficients[rxn] = 1
+    set_objective(model, coefficients)
+    write_sbml_model(model, path_to_file)
+
+    # reading the model back
+    model_after_reading = read_sbml_model(path_to_file)
+
+    # checking if notes are written to model
+    assert model_after_reading.notes["Remark"] == "...Model Notes..."

--- a/cobra/test/test_io/test_notes.py
+++ b/cobra/test/test_io/test_notes.py
@@ -21,13 +21,17 @@ def test_notes(tmp_path):
     model.add_reactions([rxn])
     rxn.notes["Remark"] = "What about me?"
     model.objective_direction = "max"
-    coefficients = {}
-    coefficients[rxn] = 1
-    set_objective(model, coefficients)
+    model.objective = rxn
     write_sbml_model(model, path_to_file)
 
     # reading the model back
     model_after_reading = read_sbml_model(path_to_file)
+    met_after_reading = model_after_reading.metabolites.get_by_id("pyr_c")
+    reaction_after_reading = model_after_reading.reactions.get_by_id("R_ATPM")
 
     # checking if notes are written to model
     assert model_after_reading.notes["Remark"] == "...Model Notes..."
+
+    # checking notes for metabolite and reaction
+    assert met_after_reading.notes["Remark"] == "I appear."
+    assert reaction_after_reading.notes["Remark"] == "What about me?"

--- a/cobra/test/test_io/test_notes.py
+++ b/cobra/test/test_io/test_notes.py
@@ -1,11 +1,13 @@
-import pytest
-import cobra
 from os.path import join
-from cobra.util.solver import set_objective
+
+import pytest
+
+import cobra
 from cobra.io import read_sbml_model, write_sbml_model
+from cobra.util.solver import set_objective
 
 
-def test_model_notes(tmp_path):
+def test_notes(tmp_path):
     """Testing if model notes are written in SBML"""
     path_to_file = join(str(tmp_path), "model_notes.xml")
 

--- a/cobra/test/test_io/test_notes.py
+++ b/cobra/test/test_io/test_notes.py
@@ -4,7 +4,6 @@ import pytest
 
 import cobra
 from cobra.io import read_sbml_model, write_sbml_model
-from cobra.util.solver import set_objective
 
 
 def test_notes(tmp_path):
@@ -16,7 +15,7 @@ def test_notes(tmp_path):
     model.notes["Remark"] = "...Model Notes..."
     met = cobra.Metabolite("pyr_c", compartment="c")
     model.add_metabolites([met])
-    met.notes["Remark"] = "I appear."
+    met.notes["Remark"] = "Note with \n newline"
     rxn = cobra.Reaction("R_ATPM")
     model.add_reactions([rxn])
     rxn.notes["Remark"] = "What about me?"
@@ -33,5 +32,5 @@ def test_notes(tmp_path):
     assert model_after_reading.notes["Remark"] == "...Model Notes..."
 
     # checking notes for metabolite and reaction
-    assert met_after_reading.notes["Remark"] == "I appear."
+    assert met_after_reading.notes["Remark"] == "Note with \n newline"
     assert reaction_after_reading.notes["Remark"] == "What about me?"


### PR DESCRIPTION
### What does it fixes?
Currently, if we add some notes to a cobra_model and write that model to SBML, these notes are not written in the file.

Fixes issue #902 

### What was the problem?
Inside the method **_model_to_sbml()** which is used convert the _cobra_model_ to _libsbml.SBMLDocument_ object, the conversion of _notes_ for the _cobra_model_ was not done. Only _annotations_ were converted. So the method for conversion of _notes_ of the model is added here.
