### PR TITLE
Add support for the OSQP solver

### DIFF
--- a/src/cobra/flux_analysis/moma.py
+++ b/src/cobra/flux_analysis/moma.py
@@ -114,7 +114,7 @@ def add_moma(model, solution=None, linear=True):
         raise ValueError("model is already adjusted for MOMA")
 
     # Fall back to default QP solver if current one has no QP capability
-    if not linear:
+    if not linear and sutil.interface_to_str(model.problem) not in sutil.qp_solvers:
         model.solver = sutil.choose_solver(model, qp=True)
 
     if solution is None:

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -54,7 +54,7 @@ except ImportError:
 
 
 class CobraSBMLError(Exception):
-    """ SBML error class. """
+    """SBML error class."""
 
     pass
 
@@ -115,7 +115,7 @@ def _escape_non_alphanum(nonASCII):
 
 
 def _number_to_chr(numberStr):
-    """converts an ascii number to a character """
+    """converts an ascii number to a character"""
     return chr(int(numberStr.group(1)))
 
 

--- a/src/cobra/test/test_flux_analysis/conftest.py
+++ b/src/cobra/test/test_flux_analysis/conftest.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import pytest
 from pandas import Series
 
-from cobra.core import Metabolite, Model, Reaction, Solution
+from cobra.core import Model, Reaction, Solution
 from cobra.util import solver as sutil
 
 
@@ -26,7 +26,8 @@ def all_solvers(request):
 
 
 @pytest.fixture(
-    scope="session", params=[s for s in ["cplex", "gurobi"] if s in sutil.solvers]
+    scope="session",
+    params=[s for s in ["cplex", "gurobi", "osqp"] if s in sutil.solvers],
 )
 def qp_solvers(request):
     """Return the available QP solvers."""

--- a/src/cobra/test/test_flux_analysis/test_moma.py
+++ b/src/cobra/test/test_flux_analysis/test_moma.py
@@ -13,6 +13,7 @@ from cobra.flux_analysis.moma import add_moma
 def test_moma_sanity(model, qp_solvers):
     """Test optimization criterion and optimality for MOMA."""
     model.solver = qp_solvers
+    print(qp_solvers)
     sol = model.optimize()
 
     with model:

--- a/src/cobra/test/test_flux_analysis/test_moma.py
+++ b/src/cobra/test/test_flux_analysis/test_moma.py
@@ -13,7 +13,6 @@ from cobra.flux_analysis.moma import add_moma
 def test_moma_sanity(model, qp_solvers):
     """Test optimization criterion and optimality for MOMA."""
     model.solver = qp_solvers
-    print(qp_solvers)
     sol = model.optimize()
 
     with model:

--- a/src/cobra/test/test_io/test_annotation.py
+++ b/src/cobra/test/test_io/test_annotation.py
@@ -4,7 +4,7 @@ from cobra.io import read_sbml_model, write_sbml_model
 
 
 def _check_sbml_annotations(model):
-    """Checks the annotations from the annotation.xml. """
+    """Checks the annotations from the annotation.xml."""
     assert model is not None
 
     # model annotation

--- a/src/cobra/test/test_io/test_sbml.py
+++ b/src/cobra/test/test_io/test_sbml.py
@@ -74,7 +74,7 @@ trial_names = [node.name for node in trials]
 
 @pytest.mark.parametrize("trial", trials)
 def test_validate(trial, data_directory):
-    """ Test validation function. """
+    """Test validation function."""
     if trial.validation_function is None:
         pytest.skip("not implemented")
     test_file = join(data_directory, trial.test_file)
@@ -82,7 +82,7 @@ def test_validate(trial, data_directory):
 
 
 class TestCobraIO:
-    """ Tests the read and write functions. """
+    """Tests the read and write functions."""
 
     @classmethod
     def compare_models(cls, name, model1, model2):
@@ -309,7 +309,7 @@ def test_missing_flux_bounds2(data_directory):
 
 
 def test_validate(data_directory):
-    """Test the validation code. """
+    """Test the validation code."""
     sbml_path = join(data_directory, "mini_fbc2.xml")
     with open(sbml_path, "r") as f_in:
         model1, errors = validate_sbml_model(f_in, check_modeling_practice=True)
@@ -319,7 +319,7 @@ def test_validate(data_directory):
 
 
 def test_validation_warnings(data_directory):
-    """Test the validation warnings. """
+    """Test the validation warnings."""
     sbml_path = join(data_directory, "validation.xml")
     with open(sbml_path, "r") as f_in:
         model1, errors = validate_sbml_model(f_in, check_modeling_practice=True)
@@ -330,7 +330,7 @@ def test_validation_warnings(data_directory):
 
 
 def test_infinity_bounds(data_directory, tmp_path):
-    """Test infinity bound example. """
+    """Test infinity bound example."""
     sbml_path = join(data_directory, "fbc_ex1.xml")
     model = read_sbml_model(sbml_path)
 
@@ -354,7 +354,7 @@ def test_infinity_bounds(data_directory, tmp_path):
 
 
 def test_boundary_conditions(data_directory):
-    """Test infinity bound example. """
+    """Test infinity bound example."""
     sbml_path1 = join(data_directory, "fbc_ex1.xml")
     model1 = read_sbml_model(sbml_path1)
     sol1 = model1.optimize()

--- a/src/cobra/test/test_util/test_solver.py
+++ b/src/cobra/test/test_util/test_solver.py
@@ -13,8 +13,6 @@ from cobra.util import solver as su
 if TYPE_CHECKING:
     from cobra import Model
 
-logger = logging.getLogger(__name__)
-
 stable_optlang = ["glpk", "cplex", "gurobi"]
 optlang_solvers = [f"optlang-{s}" for s in stable_optlang if s in su.solvers]
 

--- a/src/cobra/test/test_util/test_solver.py
+++ b/src/cobra/test/test_util/test_solver.py
@@ -1,5 +1,6 @@
 """Test functions of solver.py."""
 
+import logging
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
@@ -12,6 +13,7 @@ from cobra.util import solver as su
 if TYPE_CHECKING:
     from cobra import Model
 
+logger = logging.getLogger(__name__)
 
 stable_optlang = ["glpk", "cplex", "gurobi"]
 optlang_solvers = [f"optlang-{s}" for s in stable_optlang if s in su.solvers]
@@ -203,3 +205,13 @@ def test_time_limit(large_model: "Model") -> None:
 
     with pytest.raises(OptimizationError):
         sol = large_model.optimize(raise_error=True)
+
+
+@pytest.mark.parametrize(
+    "solver", [s for s in su.solvers if s in ["osqp", "coinor_cbc"]]
+)
+def test_specialized_solver_warning(solver, caplog):
+    """Test the warning for specialized solvers."""
+    with caplog.at_level(logging.WARNING):
+        su.check_solver(solver)
+    assert "are specialized solvers for" in caplog.text

--- a/src/cobra/util/solver.py
+++ b/src/cobra/util/solver.py
@@ -333,7 +333,7 @@ def check_solver(obj):
         If the solver is not valid.
     """
     not_valid_interface = SolverNotFound(
-        "%s is not a valid solver interface. Pick from %s." % (obj, list(solvers))
+        f"{obj} is not a valid solver interface. Pick one from {', '.join(solvers)}."
     )
     if isinstance(obj, str):
         try:
@@ -349,10 +349,11 @@ def check_solver(obj):
 
     if interface_to_str(interface) in ["osqp", "coinor_cbc"]:
         logger.warning(
-            "OSQB and CBC are specialized solvers for QP and MIP problems and may "
-            "not perform well on general LP problems. So we recommend to change the "
-            "solver back to a general purpose solver like "
-            "`model.solver = 'glpk'` for instance."
+            "OSQP and CBC are specialized solvers for quadratic programming (QP) and "
+            "mixed-integer programming (MIP) problems and may not perform well on "
+            "general LP problems. So unless you intend to solve a QP or MIP problem, "
+            "we recommend to change the solver back to a general purpose solver "
+            "like `model.solver = 'glpk'` for instance."
         )
 
     return interface

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps=
     pytest-mock
     pytest-raises
     jsonschema
+    osqp>=0.6.0
 commands =
     pytest --cov=cobra --cov-report=term {posargs: --benchmark-skip}
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
     pytest-mock
     pytest-raises
     jsonschema
-    osqp>=0.6.0
+    osqp~=0.6.0
 commands =
     pytest --cov=cobra --cov-report=term {posargs: --benchmark-skip}
 


### PR DESCRIPTION
This branch adds support for the [OSQP](https://osqp.org) quadratic problem solver through https://github.com/biosustain/optlang/pull/210. This will not be useful until OSQP support is merged into optlang and a release has been made and mostly exists here for testing purposes. 

To test this branch you can create a *new* python or conda environment and install this branch along with the optlang OSQP branch:

```bash
pip install pip install git+https://github.com/cdiener/optlang@feature/osqp
```

If everything works that will give you QP support without a commercial solver.

**Example:**

```python
from cobra.test import create_test_model
from cobra.flux_analysis import pfba, moma

mod = create_test_model("textbook")
wt_sol = pfba(mod)

mod.solver = "osqp"
with mod: 
    mod.reactions.PFK.knock_out()
    ko_sol = moma(mod, wt_sol, linear=False)

print(ko_sol)
print((wt_sol.fluxes - ko_sol.fluxes).abs().describe())

mod = create_test_model("textbook")
mod.solver = "cplex"
with mod: 
    mod.reactions.PFK.knock_out()
    ko_sol = moma(mod, wt_sol, linear=False)

print(ko_sol)
print((wt_sol.fluxes - ko_sol.fluxes).abs().describe())
```

which gives:

```
OSQB and CBC are specialized solvers for QP and MIP problems and may not perform well on general LP problems. So we recommend to change the solver back to a general purpose solver like `model.solver = 'glpk'` for instance.
<Solution 2633.832 at 0x7fa11a201580>
count    9.500000e+01
mean     3.401458e+00
std      4.040605e+00
min      1.608099e-07
25%      4.106356e-06
50%      2.449619e+00
75%      4.974153e+00
max      2.310352e+01
Name: fluxes, dtype: float64
<Solution 2633.846 at 0x7fa11a1ac880>
count    95.000000
mean      3.401467
std       4.040615
min       0.000000
25%       0.000000
50%       2.449632
75%       4.974170
max      23.103626
Name: fluxes, dtype: float64
```
