### PR TITLE
fix: SBO terms for infinity bounds

### DIFF
--- a/cobra/io/sbml.py
+++ b/cobra/io/sbml.py
@@ -1003,9 +1003,9 @@ def _model_to_sbml(cobra_model, f_replace=None, units=True):
     _create_parameter(model, pid=ZERO_BOUND_ID,
                       value=0, sbo=SBO_DEFAULT_FLUX_BOUND)
     _create_parameter(model, pid=BOUND_MINUS_INF,
-                      value=-float("Inf"), sbo=SBO_FLUX_BOUND)
+                      value=-float("Inf"), sbo=SBO_DEFAULT_FLUX_BOUND)
     _create_parameter(model, pid=BOUND_PLUS_INF,
-                      value=float("Inf"), sbo=SBO_FLUX_BOUND)
+                      value=float("Inf"), sbo=SBO_DEFAULT_FLUX_BOUND)
 
     # Compartments
     # FIXME: use first class compartment model (and write notes & annotations)


### PR DESCRIPTION
I think `SBO:0000626` is more appropiate than `SBO:0000625` for infinity bounds. From the SBO documentation:

* [SBO:0000625](http://www.ebi.ac.uk/sbo/main/SBO:0000625): _"A parameter that limits the upper or lower value that a flux may assume. This parameter may be determined experimentally, or may be the result of theoretical investigation."_
* [SBO:0000626](http://www.ebi.ac.uk/sbo/main/SBO:0000626): _"A value used for flux bound in cases where a precise value, supported experimentally or theoretically, is not available."_