### PR TITLE
FIX: Allow comparment names with two letters

### DIFF
--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -25,18 +25,18 @@ except ImportError:
 
 
 # precompiled regular expressions
-_bracket_re = re.compile(r"\[[a-z]\]$")
-_underscore_re = re.compile(r"_[a-z]$")
+_bracket_re = re.compile(r"\[[a-z]{1,2}\]$")
+_underscore_re = re.compile(r"_[a-z]{1,2}$")
 
 
 def _get_id_compartment(id):
     """extract the compartment from the id string"""
     bracket_search = _bracket_re.findall(id)
     if len(bracket_search) == 1:
-        return bracket_search[0][1]
+        return bracket_search[0][1:]
     underscore_search = _underscore_re.findall(id)
     if len(underscore_search) == 1:
-        return underscore_search[0][1]
+        return underscore_search[0][1:]
     return None
 
 

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -33,7 +33,7 @@ def _get_id_compartment(id):
     """extract the compartment from the id string"""
     bracket_search = _bracket_re.findall(id)
     if len(bracket_search) == 1:
-        return bracket_search[0][1:]
+        return bracket_search[0][1:-1]
     underscore_search = _underscore_re.findall(id)
     if len(underscore_search) == 1:
         return underscore_search[0][1:]

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -25,7 +25,7 @@ except ImportError:
 
 
 # precompiled regular expressions
-_bracket_re = re.compile(r"\[[a-z]{1,3}\]$")
+_bracket_re = re.compile(r"\[[a-z]+\]$")
 _underscore_re = re.compile(r"_[a-z]{1,3}$")
 
 

--- a/cobra/io/mat.py
+++ b/cobra/io/mat.py
@@ -25,8 +25,8 @@ except ImportError:
 
 
 # precompiled regular expressions
-_bracket_re = re.compile(r"\[[a-z]{1,2}\]$")
-_underscore_re = re.compile(r"_[a-z]{1,2}$")
+_bracket_re = re.compile(r"\[[a-z]{1,3}\]$")
+_underscore_re = re.compile(r"_[a-z]{1,3}$")
 
 
 def _get_id_compartment(id):


### PR DESCRIPTION
New yeast models are provided with 2 letter compartment names.  Currently, the import of Yeast models from Matlab will omit the two-letter compartments. 