### PR TITLE
refactor: make `cobra.util` Python 3.6+

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -134,12 +134,9 @@ Before you submit a pull request, check that it meets these guidelines:
    usage in ``documentation_builder`` (documentation is written as
    jupyter notebooks in the ``documentation_builder`` directory, which
    are then converted to rst by the ``autodoc.sh`` script.)
-3. The pull request should work for Python 2.7, 3.4 and 3.5. Check
-   https://travis-ci.org/biosustain/cobrapy/pull_requests
-   and make sure that the tests pass for all supported Python versions.
-4. Assign a reviewer to your pull request. If in doubt, assign Henning
-   Redestig. Your pull request must be approved by at least one
-   reviewer before it can be merged.
+3. The pull request will be tested for several different Python versions.
+4. Someone from the @opencobra/cobrapy-core team will review your work and guide
+   you to a successful contribution.
 
 Unit tests and benchmarks
 -------------------------
@@ -196,18 +193,11 @@ Branching model
 Please use concise descriptive commit messages and consider using
 ``git pull --rebase`` when you update your own fork to avoid merge commits.
 
-1. Tests are in the ``cobra/test`` directory. They are automatically run
-   through continuous integration services on both python 2 and python 3
-   when pull requests are made.
-2. Please write tests for new functions. Writing documentation as well
-   would also be very helpful.
-3. Ensure code will work with both python 2 and python 3. For example,
-   instead of ``my_dict.iteritems()`` use ``six.iteritems(my_dict)``
-
 Thank you very much for contributing to cobrapy!
 
 FAQs
 ----
+
 Q1. Why do all of the tests that involve loading a pickled model fail on my branch?
 	A: Pickling is the standard method for serializing objects in python,
 	which is commonly done during operations like multiprocessing.

--- a/src/cobra/test/test_util/test_array.py
+++ b/src/cobra/test/test_util/test_array.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 """Test functions of array.py"""
-
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/src/cobra/test/test_util/test_array.py
+++ b/src/cobra/test/test_util/test_array.py
@@ -6,12 +6,6 @@ import pytest
 from cobra.util import create_stoichiometric_matrix
 
 
-try:
-    import scipy
-except ImportError:
-    scipy = None
-
-
 def test_dense_matrix(model):
     S = create_stoichiometric_matrix(model, array_type="dense", dtype=int)
     assert S.dtype == int
@@ -29,8 +23,8 @@ def test_dense_matrix(model):
     assert np.allclose(mass_balance, 0)
 
 
-@pytest.mark.skipif(not scipy, reason="Sparse array methods require scipy")
 def test_sparse_matrix(model):
+    scipy = pytest.importorskip("scipy")
     sparse_types = ["dok", "lil"]
 
     solution = model.optimize()

--- a/src/cobra/test/test_util/test_solver.py
+++ b/src/cobra/test/test_util/test_solver.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 """Test functions of solver.py"""
-
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/src/cobra/test/test_util/test_util.py
+++ b/src/cobra/test/test_util/test_util.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 """Test functions of util.py"""
-
-from __future__ import absolute_import
 
 from cobra.util import show_versions
 

--- a/src/cobra/util/__init__.py
+++ b/src/cobra/util/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 from cobra.util.array import *
 from cobra.util.context import *
 from cobra.util.solver import *

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
+"""Helper functions for array operations."""
 
 from collections import namedtuple
 
 import numpy as np
 import pandas as pd
-from six import iteritems
 
 
 try:
@@ -60,7 +57,7 @@ def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
     r_ind = model.reactions.index
 
     for reaction in model.reactions:
-        for metabolite, stoich in iteritems(reaction.metabolites):
+        for metabolite, stoich in reaction.metabolites.items():
             array[m_ind(metabolite), r_ind(reaction)] = stoich
 
     if array_type == "DataFrame":

--- a/src/cobra/util/context.py
+++ b/src/cobra/util/context.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
+"""Context manager for the package."""
 
 from functools import partial
 
 
-class HistoryManager(object):
+class HistoryManager:
     """Record a list of actions to be taken at a later time. Used to
     implement context managers that allow temporary changes to a
     :class:`~cobra.core.Model`.

--- a/src/cobra/util/solver.py
+++ b/src/cobra/util/solver.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Additional helper functions for the optlang solvers.
 
 All functions integrate well with the context manager, meaning that
@@ -9,8 +7,6 @@ all operations defined here are automatically reverted when used in a
 The functions defined here together with the existing model functions should
 allow you to implement custom flux analysis methods with ease.
 """
-
-from __future__ import absolute_import
 
 import re
 from collections import namedtuple

--- a/src/cobra/util/util.py
+++ b/src/cobra/util/util.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
+"""General utilities."""
 
 from depinfo import print_dependencies
 


### PR DESCRIPTION
This PR addresses a part of #972 and makes `cobra.util` along with its tests compatible with Python 3.6+ only.