### PR TITLE
refactor: upgrade cobra.util.array to Python 3.6+

### DIFF
--- a/src/cobra/test/test_util/test_array.py
+++ b/src/cobra/test/test_util/test_array.py
@@ -12,7 +12,7 @@ def test_dense_matrix(model):
     assert S.dtype == int
     assert np.allclose(S.max(), [59])
 
-    S_df = create_stoichiometric_matrix(model, array_type="frame", dtype=int)
+    S_df = create_stoichiometric_matrix(model, array_type="DataFrame", dtype=int)
     assert S_df.values.dtype == int
     assert np.all(S_df.columns == [r.id for r in model.reactions])
     assert np.all(S_df.index == [m.id for m in model.metabolites])

--- a/src/cobra/test/test_util/test_array.py
+++ b/src/cobra/test/test_util/test_array.py
@@ -26,7 +26,7 @@ def test_dense_matrix(model):
 
 def test_sparse_matrix(model):
     """Test sparse stoichiometric matrix creation."""
-    _ = pytest.importorskip("scipy")
+    pytest.importorskip("scipy")
     sparse_types = ["dok", "lil"]
 
     solution = model.optimize()

--- a/src/cobra/test/test_util/test_array.py
+++ b/src/cobra/test/test_util/test_array.py
@@ -1,4 +1,4 @@
-"""Test functions of array.py"""
+"""Test functions of array.py."""
 
 import numpy as np
 import pytest
@@ -7,11 +7,12 @@ from cobra.util import create_stoichiometric_matrix
 
 
 def test_dense_matrix(model):
+    """Test dense stoichiometric matrix creation."""
     S = create_stoichiometric_matrix(model, array_type="dense", dtype=int)
     assert S.dtype == int
     assert np.allclose(S.max(), [59])
 
-    S_df = create_stoichiometric_matrix(model, array_type="DataFrame", dtype=int)
+    S_df = create_stoichiometric_matrix(model, array_type="frame", dtype=int)
     assert S_df.values.dtype == int
     assert np.all(S_df.columns == [r.id for r in model.reactions])
     assert np.all(S_df.index == [m.id for m in model.metabolites])
@@ -24,7 +25,8 @@ def test_dense_matrix(model):
 
 
 def test_sparse_matrix(model):
-    scipy = pytest.importorskip("scipy")
+    """Test sparse stoichiometric matrix creation."""
+    _ = pytest.importorskip("scipy")
     sparse_types = ["dok", "lil"]
 
     solution = model.optimize()

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -1,4 +1,4 @@
-"""Helper functions for array operations."""
+"""Helper functions for array operations and sampling."""
 
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
@@ -87,7 +87,7 @@ def create_stoichiometric_matrix(
         return array
 
 
-def nullspace(A: np.ndarray, atol: float = 1E-13, rtol: float = 0.0) -> np.ndarray:
+def nullspace(A: np.ndarray, atol: float = 1e-13, rtol: float = 0.0) -> np.ndarray:
     r"""Compute an approximate basis for the nullspace of A.
 
     The algorithm used by this function is based on the Singular Value
@@ -100,7 +100,7 @@ def nullspace(A: np.ndarray, atol: float = 1E-13, rtol: float = 0.0) -> np.ndarr
         as a 2-D with shape (1, k).
     atol : float, optional
         The absolute tolerance for a zero singular value. Singular values
-        smaller than `atol` are considered to be zero (default 1E-13).
+        smaller than `atol` are considered to be zero (default 1e-13).
     rtol : float, optional
         The relative tolerance. Singular values less than `rtol * smax` are
         considered to be zero, where `smax` is the largest singular value
@@ -136,10 +136,9 @@ def nullspace(A: np.ndarray, atol: float = 1E-13, rtol: float = 0.0) -> np.ndarr
 
 
 def constraint_matrices(
-    model: "cobra.core.Model",
+    model: "Model",
     array_type: str = "dense",
-    include_vars: bool = False,
-    zero_tol: float = 1E-6,
+    zero_tol: float = 1e-6,
 ) -> NamedTuple:
     """Create a matrix representation of the problem.
 
@@ -159,7 +158,7 @@ def constraint_matrices(
         columns.
     zero_tol : float, optional
         The zero tolerance used to judge whether two bounds are the same
-        (default 1E-6).
+        (default 1e-6).
 
     Returns
     -------

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -136,9 +136,7 @@ def nullspace(A: np.ndarray, atol: float = 1e-13, rtol: float = 0.0) -> np.ndarr
 
 
 def constraint_matrices(
-    model: "Model",
-    array_type: str = "dense",
-    zero_tol: float = 1e-6,
+    model: "Model", array_type: str = "dense", zero_tol: float = 1e-6,
 ) -> NamedTuple:
     """Create a matrix representation of the problem.
 

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -30,10 +30,10 @@ def create_stoichiometric_matrix(
     ----------
     model : cobra.Model
         The cobra model to construct the matrix for.
-    array_type : {"dense", "dok", "lil", "frame"}
+    array_type : {"dense", "dok", "lil", "DataFrame"}
         The type of array to construct. "dense" will return a standard
         numpy.ndarray. "dok", or "lil" will construct a sparse array using
-        scipy of the corresponding type. "frame" will give a
+        scipy of the corresponding type. "DataFrame" will give a
         pandas.DataFrame with metabolite as indices and reaction as
         columns.
     dtype : numpy.dtype, optional
@@ -49,8 +49,12 @@ def create_stoichiometric_matrix(
     ValueError
         If sparse matrix is used and scipy is not installed.
 
+    .. deprecated:: 0.18.1
+              "DataFrame" option for `array_type` will be replaced with
+              "frame" in future versions.
+
     """
-    if array_type not in ("frame", "dense") and not dok_matrix:
+    if array_type not in ("DataFrame", "dense") and not dok_matrix:
         raise ValueError("Sparse matrices require scipy.")
 
     if dtype is None:
@@ -60,7 +64,7 @@ def create_stoichiometric_matrix(
         "dense": np.zeros,
         "dok": dok_matrix,
         "lil": lil_matrix,
-        "frame": np.zeros,
+        "DataFrame": np.zeros,
     }
 
     n_metabolites = len(model.metabolites)
@@ -74,7 +78,7 @@ def create_stoichiometric_matrix(
         for metabolite, stoich in reaction.metabolites.items():
             array[m_ind(metabolite), r_ind(reaction)] = stoich
 
-    if array_type == "frame":
+    if array_type == "DataFrame":
         metabolite_ids = [met.id for met in model.metabolites]
         reaction_ids = [rxn.id for rxn in model.reactions]
         return pd.DataFrame(array, index=metabolite_ids, columns=reaction_ids)
@@ -147,10 +151,10 @@ def constraint_matrices(
     ----------
     model : cobra.Model
         The model from which to obtain the LP problem.
-    array_type : {"dense", "dok", "lil", "frame"}
+    array_type : {"dense", "dok", "lil", "DataFrame"}
         The type of array to construct. "dense" will return a standard
         numpy.ndarray. "dok", or "lil" will construct a sparse array using
-        scipy of the corresponding type. "frame" will give a
+        scipy of the corresponding type. "DataFrame" will give a
         pandas.DataFrame with metabolite as indices and reaction as
         columns.
     zero_tol : float, optional
@@ -182,16 +186,19 @@ def constraint_matrices(
     To accomodate non-zero equalities, the problem will add the variable
     "const_one" which is a variable that equals one.
 
+    .. deprecated:: 0.18.1
+              "DataFrame" option for `array_type` will be replaced with
+              "frame" in future versions.
 
     """
-    if array_type not in ("frame", "dense") and not dok_matrix:
+    if array_type not in ("DataFrame", "dense") and not dok_matrix:
         raise ValueError("Sparse matrices require scipy.")
 
     array_builder = {
         "dense": np.array,
         "dok": dok_matrix,
         "lil": lil_matrix,
-        "frame": pd.DataFrame,
+        "DataFrame": pd.DataFrame,
     }[array_type]
 
     Problem = NamedTuple(

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -44,6 +44,11 @@ def create_stoichiometric_matrix(
     matrix of class `dtype`
         The stoichiometric matrix for the given model.
 
+    Raises
+    ------
+    ValueError
+        If sparse matrix is used and scipy is not installed.
+
     """
     if array_type not in ("frame", "dense") and not dok_matrix:
         raise ValueError("Sparse matrices require scipy.")
@@ -119,7 +124,7 @@ def nullspace(A: np.ndarray, atol: float = 1E-13, rtol: float = 0.0) -> np.ndarr
 
     """
     A = np.atleast_2d(A)
-    u, s, vh = np.linalg.svd(A)
+    _, s, vh = np.linalg.svd(A)
     tol = max(atol, rtol * s[0])
     nnz = (s >= tol).sum()
     ns = vh[nnz:].conj().T

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 # Used to avoid cyclic reference and enable third-party static type checkers to work
 if TYPE_CHECKING:
-    import cobra
+    from cobra import Model
 
 
 try:
@@ -18,7 +18,7 @@ except ImportError:
 
 
 def create_stoichiometric_matrix(
-    model: "cobra.core.Model", array_type: str = "dense", dtype: Optional[Any] = None
+    model: "Model", array_type: str = "dense", dtype: Optional[np.dtype] = None
 ) -> Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame]:
     """Return a stoichiometric array representation of the given model.
 
@@ -36,8 +36,8 @@ def create_stoichiometric_matrix(
         scipy of the corresponding type. "frame" will give a
         pandas.DataFrame with metabolite as indices and reaction as
         columns.
-    dtype : data-type, optional
-        The desired data type for the array (default numpy.float64).
+    dtype : numpy.dtype, optional
+        The desired numpy data type for the array (default numpy.float64).
 
     Returns
     -------

--- a/src/cobra/util/array.py
+++ b/src/cobra/util/array.py
@@ -1,9 +1,14 @@
 """Helper functions for array operations."""
 
-from collections import namedtuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import numpy as np
 import pandas as pd
+
+
+# Used to avoid cyclic reference and enable third-party static type checkers to work
+if TYPE_CHECKING:
+    import cobra
 
 
 try:
@@ -12,7 +17,9 @@ except ImportError:
     dok_matrix, lil_matrix = None, None
 
 
-def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
+def create_stoichiometric_matrix(
+    model: "cobra.core.Model", array_type: str = "dense", dtype: Optional[Any] = None
+) -> Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame]:
     """Return a stoichiometric array representation of the given model.
 
     The the columns represent the reactions and rows represent
@@ -23,21 +30,23 @@ def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
     ----------
     model : cobra.Model
         The cobra model to construct the matrix for.
-    array_type : string
-        The type of array to construct. if 'dense', return a standard
-        numpy.array, 'dok', or 'lil' will construct a sparse array using
-        scipy of the corresponding type and 'DataFrame' will give a
-        pandas `DataFrame` with metabolite indices and reaction columns
-    dtype : data-type
-        The desired data-type for the array. If not given, defaults to float.
+    array_type : {"dense", "dok", "lil", "frame"}
+        The type of array to construct. "dense" will return a standard
+        numpy.ndarray. "dok", or "lil" will construct a sparse array using
+        scipy of the corresponding type. "frame" will give a
+        pandas.DataFrame with metabolite as indices and reaction as
+        columns.
+    dtype : data-type, optional
+        The desired data type for the array (default numpy.float64).
 
     Returns
     -------
     matrix of class `dtype`
         The stoichiometric matrix for the given model.
+
     """
-    if array_type not in ("DataFrame", "dense") and not dok_matrix:
-        raise ValueError("Sparse matrices require scipy")
+    if array_type not in ("frame", "dense") and not dok_matrix:
+        raise ValueError("Sparse matrices require scipy.")
 
     if dtype is None:
         dtype = np.float64
@@ -46,7 +55,7 @@ def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
         "dense": np.zeros,
         "dok": dok_matrix,
         "lil": lil_matrix,
-        "DataFrame": np.zeros,
+        "frame": np.zeros,
     }
 
     n_metabolites = len(model.metabolites)
@@ -60,7 +69,7 @@ def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
         for metabolite, stoich in reaction.metabolites.items():
             array[m_ind(metabolite), r_ind(reaction)] = stoich
 
-    if array_type == "DataFrame":
+    if array_type == "frame":
         metabolite_ids = [met.id for met in model.metabolites]
         reaction_ids = [rxn.id for rxn in model.reactions]
         return pd.DataFrame(array, index=metabolite_ids, columns=reaction_ids)
@@ -69,40 +78,45 @@ def create_stoichiometric_matrix(model, array_type="dense", dtype=None):
         return array
 
 
-def nullspace(A, atol=1e-13, rtol=0):
-    """Compute an approximate basis for the nullspace of A.
-    The algorithm used by this function is based on the singular value
-    decomposition of `A`.
+def nullspace(A: np.ndarray, atol: float = 1E-13, rtol: float = 0.0) -> np.ndarray:
+    r"""Compute an approximate basis for the nullspace of A.
+
+    The algorithm used by this function is based on the Singular Value
+    Decomposition (SVD) of `A`.
 
     Parameters
     ----------
     A : numpy.ndarray
-        A should be at most 2-D.  A 1-D array with length k will be treated
-        as a 2-D with shape (1, k)
-    atol : float
-        The absolute tolerance for a zero singular value.  Singular values
-        smaller than `atol` are considered to be zero.
-    rtol : float
-        The relative tolerance.  Singular values less than rtol*smax are
-        considered to be zero, where smax is the largest singular value.
-
-    If both `atol` and `rtol` are positive, the combined tolerance is the
-    maximum of the two; that is::
-    tol = max(atol, rtol * smax)
-    Singular values smaller than `tol` are considered to be zero.
+        `A` should be at most 2-D. 1-D array with length k will be treated
+        as a 2-D with shape (1, k).
+    atol : float, optional
+        The absolute tolerance for a zero singular value. Singular values
+        smaller than `atol` are considered to be zero (default 1E-13).
+    rtol : float, optional
+        The relative tolerance. Singular values less than `rtol * smax` are
+        considered to be zero, where `smax` is the largest singular value
+        (default 0.0).
 
     Returns
     -------
     numpy.ndarray
         If `A` is an array with shape (m, k), then `ns` will be an array
-        with shape (k, n), where n is the estimated dimension of the
+        with shape (k, n), where `n` is the estimated dimension of the
         nullspace of `A`.  The columns of `ns` are a basis for the
         nullspace; each element in numpy.dot(A, ns) will be approximately
         zero.
 
     Notes
     -----
-    Taken from the numpy cookbook.
+    This is taken from the numpy cookbook.
+
+    If both `atol` and `rtol` are positive, the combined tolerance is the
+    maximum of the two; that is:
+
+    .. math:: \mathtt{tol} = \max(\mathtt{atol}, \mathtt{rtol} * \mathtt{smax})
+
+    Singular values smaller than `tol` are considered to be zero.
+
     """
     A = np.atleast_2d(A)
     u, s, vh = np.linalg.svd(A)
@@ -112,67 +126,81 @@ def nullspace(A, atol=1e-13, rtol=0):
     return ns
 
 
-def constraint_matrices(model, array_type="dense", include_vars=False, zero_tol=1e-6):
+def constraint_matrices(
+    model: "cobra.core.Model",
+    array_type: str = "dense",
+    include_vars: bool = False,
+    zero_tol: float = 1E-6,
+) -> NamedTuple:
     """Create a matrix representation of the problem.
 
-    This is used for alternative solution approaches that do not use optlang.
-    The function will construct the equality matrix, inequality matrix and
-    bounds for the complete problem.
+    This is used for alternative solution approaches that do not use
+    "optlang". The function will construct the equality matrix,
+    inequality matrix and bounds for the complete problem.
 
-    Notes
-    -----
-    To accomodate non-zero equalities the problem will add the variable
-    "const_one" which is a variable that equals one.
-
-    Arguments
-    ---------
+    Parameters
+    ----------
     model : cobra.Model
         The model from which to obtain the LP problem.
-    array_type : string
-        The type of array to construct. if 'dense', return a standard
-        numpy.array, 'dok', or 'lil' will construct a sparse array using
-        scipy of the corresponding type and 'DataFrame' will give a
-        pandas `DataFrame` with metabolite indices and reaction columns.
-    zero_tol : float
-        The zero tolerance used to judge whether two bounds are the same.
+    array_type : {"dense", "dok", "lil", "frame"}
+        The type of array to construct. "dense" will return a standard
+        numpy.ndarray. "dok", or "lil" will construct a sparse array using
+        scipy of the corresponding type. "frame" will give a
+        pandas.DataFrame with metabolite as indices and reaction as
+        columns.
+    zero_tol : float, optional
+        The zero tolerance used to judge whether two bounds are the same
+        (default 1E-6).
 
     Returns
     -------
-    collections.namedtuple
+    NamedTuple
         A named tuple consisting of 6 matrices and 2 vectors:
-        - "equalities" is a matrix S such that S*vars = b. It includes a row
-          for each constraint and one column for each variable.
-        - "b" the right side of the equality equation such that S*vars = b.
-        - "inequalities" is a matrix M such that lb <= M*vars <= ub.
+        - "equalities" is a matrix `S` such that `S * vars = b`. It
+          includes a row for each constraint and one column for each
+          variable.
+        - "b" is the right side of the equality equation such that
+          `S * vars = b`.
+        - "inequalities" is a matrix M such that `lb <= M * vars <= ub`.
           It contains a row for each inequality and as many columns as
           variables.
         - "bounds" is a compound matrix [lb ub] containing the lower and
           upper bounds for the inequality constraints in M.
-        - "variable_fixed" is a boolean vector indicating whether the variable
-          at that index is fixed (lower bound == upper_bound) and
-          is thus bounded by an equality constraint.
-        - "variable_bounds" is a compound matrix [lb ub] containing the
+        - "variable_fixed" is a boolean vector indicating whether the
+          variable at that index is fixed (`lower bound == upper_bound`)
+          and is thus bounded by an equality constraint.
+        - "variable_bounds" is a compound matrix `[lb ub]` containing the
           lower and upper bounds for all variables.
+
+    Notes
+    -----
+    To accomodate non-zero equalities, the problem will add the variable
+    "const_one" which is a variable that equals one.
+
+
     """
-    if array_type not in ("DataFrame", "dense") and not dok_matrix:
-        raise ValueError("Sparse matrices require scipy")
+    if array_type not in ("frame", "dense") and not dok_matrix:
+        raise ValueError("Sparse matrices require scipy.")
 
     array_builder = {
         "dense": np.array,
         "dok": dok_matrix,
         "lil": lil_matrix,
-        "DataFrame": pd.DataFrame,
+        "frame": pd.DataFrame,
     }[array_type]
 
-    Problem = namedtuple(
+    Problem = NamedTuple(
         "Problem",
         [
-            "equalities",
-            "b",
-            "inequalities",
-            "bounds",
-            "variable_fixed",
-            "variable_bounds",
+            ("equalities", Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame]),
+            ("b", np.ndarray),
+            ("inequalities", Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame]),
+            ("bounds", Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame]),
+            ("variable_fixed", np.ndarray),
+            (
+                "variable_bounds",
+                Union[np.ndarray, dok_matrix, lil_matrix, pd.DataFrame],
+            ),
         ],
     )
     equality_rows = []


### PR DESCRIPTION
* [x] refactor `cobra.util.array`
* [x] tests passed

This PR upgrades `cobra.util.array` to meet Python 3.6+ standard. `collections.namedtuple` is replaced with `typing.NamedTuple` (not a breaking change). "DataFrame" argument option for `array_type` is changed to "frame" to simplify option and maintain consistency with other options (breaking change).
