### PR TITLE
feature: element summary

### DIFF
--- a/src/cobra/summary/metabolite_summary.py
+++ b/src/cobra/summary/metabolite_summary.py
@@ -111,6 +111,8 @@ class MetaboliteSummary(Summary):
             optimum objective to be searched.
 
         """
+        super()._generate(model=model, solution=solution, fva=fva)
+
         if solution is None:
             logger.info("Generating new parsimonious flux distribution.")
             solution = pfba(model)
@@ -297,7 +299,7 @@ class MetaboliteSummary(Summary):
     def to_string(
         self,
         names: bool = False,
-        threshold: float = 1e-6,
+        threshold: Optional[float] = None,
         float_format: str = ".4G",
         column_width: int = 79,
     ) -> str:
@@ -310,7 +312,8 @@ class MetaboliteSummary(Summary):
             Whether or not elements should be displayed by their common names
             (default False).
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
         column_width : int, optional
@@ -322,6 +325,8 @@ class MetaboliteSummary(Summary):
             The summary formatted as a pretty string.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         if names:
             metabolite = shorten(
                 self._metabolite.name, width=column_width, placeholder="..."
@@ -356,7 +361,10 @@ class MetaboliteSummary(Summary):
         )
 
     def to_html(
-        self, names: bool = False, threshold: float = 1e-6, float_format: str = ".4G"
+        self,
+        names: bool = False,
+        threshold: Optional[float] = None,
+        float_format: str = ".4G",
     ) -> str:
         """
         Return a rich HTML representation of the metabolite summary.
@@ -367,7 +375,8 @@ class MetaboliteSummary(Summary):
             Whether or not elements should be displayed by their common names
             (default False).
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
 
@@ -377,6 +386,8 @@ class MetaboliteSummary(Summary):
             The summary formatted as HTML.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         if names:
             metabolite = self._metabolite.name
         else:

--- a/src/cobra/summary/model_summary.py
+++ b/src/cobra/summary/model_summary.py
@@ -108,6 +108,8 @@ class ModelSummary(Summary):
             optimum objective to be searched.
 
         """
+        super()._generate(model=model, solution=solution, fva=fva)
+
         coefficients = linear_reaction_coefficients(model)
         if solution is None:
             logger.info("Generating new parsimonious flux distribution.")
@@ -365,7 +367,7 @@ class ModelSummary(Summary):
         self,
         names: bool = False,
         element: str = "C",
-        threshold: float = 1e-6,
+        threshold: Optional[float] = None,
         float_format: str = ".4G",
         column_width: int = 79,
     ) -> str:
@@ -380,7 +382,8 @@ class ModelSummary(Summary):
         element : str, optional
             The atomic element to summarize uptake and secretion for (default 'C').
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
         column_width : int, optional
@@ -392,6 +395,8 @@ class ModelSummary(Summary):
             The summary formatted as a pretty string.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         objective = self._string_objective(names)
 
         uptake = self._string_table(
@@ -422,7 +427,7 @@ class ModelSummary(Summary):
         self,
         names: bool = False,
         element: str = "C",
-        threshold: float = 1e-6,
+        threshold: Optional[float] = None,
         float_format: str = ".4G",
     ) -> str:
         """
@@ -436,7 +441,8 @@ class ModelSummary(Summary):
         element : str, optional
             The atomic element to summarize uptake and secretion for (default 'C').
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
 
@@ -446,6 +452,8 @@ class ModelSummary(Summary):
             The summary formatted as HTML.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         objective = self._string_objective(names)
 
         uptake = self._html_table(

--- a/src/cobra/summary/model_summary.py
+++ b/src/cobra/summary/model_summary.py
@@ -186,9 +186,6 @@ class ModelSummary(Summary):
             self.uptake_flux = flux.loc[
                 is_produced, ["flux", "reaction", "metabolite"]
             ].copy()
-        # TODO (Midnighter): We may later want to compute % of carbon flux.
-        # production = self.producing_fluxes["flux"].abs()
-        # self.producing_fluxes["percent"] = production / production.sum()
 
         # Create consumption table from consuming fluxes or zero fluxes where the
         # metabolite is a substrate in the reaction.
@@ -201,14 +198,11 @@ class ModelSummary(Summary):
             self.secretion_flux = flux.loc[
                 is_consumed, ["flux", "reaction", "metabolite"]
             ].copy()
-        # TODO (Midnighter): We may later want to compute % of carbon flux.
-        # consumption = self.consuming_fluxes["flux"].abs()
-        # self.consuming_fluxes["percent"] = consumption / consumption.sum()
 
         self._flux = flux
 
     def _display_flux(
-        self, frame: pd.DataFrame, names: bool, threshold: float
+        self, frame: pd.DataFrame, names: bool, element: str, threshold: float
     ) -> pd.DataFrame:
         """
         Transform a flux data frame for display.
@@ -219,6 +213,8 @@ class ModelSummary(Summary):
             Either the producing or the consuming fluxes.
         names : bool
             Whether or not elements should be displayed by their common names.
+        element : str
+            The atomic element to summarize fluxes for.
         threshold : float
             Hide fluxes below the threshold from being displayed.
 
@@ -239,8 +235,21 @@ class ModelSummary(Summary):
         else:
             frame = frame.loc[frame["flux"].abs() >= threshold, :].copy()
 
+        metabolites = {m.id: m for m in self._boundary_metabolites}
+
+        element_num = f"{element}-Number"
+        frame[element_num] = [
+            metabolites[met_id].elements.get(element, 0)
+            for met_id in frame["metabolite"]
+        ]
+        element_percent = f"{element}-Flux"
+        frame[element_percent] = frame[element_num] * frame["flux"].abs()
+        total = frame[element_percent].sum()
+        if total > 0.0:
+            frame[element_percent] /= total
+        frame[element_percent] = [f"{x:.2%}" for x in frame[element_percent]]
+
         if names:
-            metabolites = {m.id: m for m in self._boundary_metabolites}
             frame["metabolite"] = [
                 metabolites[met_id].name for met_id in frame["metabolite"]
             ]
@@ -249,9 +258,20 @@ class ModelSummary(Summary):
             frame["range"] = list(
                 frame[["minimum", "maximum"]].itertuples(index=False, name=None)
             )
-            return frame[["metabolite", "reaction", "flux", "range"]]
+            return frame[
+                [
+                    "metabolite",
+                    "reaction",
+                    "flux",
+                    "range",
+                    element_num,
+                    element_percent,
+                ]
+            ]
         else:
-            return frame[["metabolite", "reaction", "flux"]]
+            return frame[
+                ["metabolite", "reaction", "flux", element_num, element_percent]
+            ]
 
     @staticmethod
     def _string_table(frame: pd.DataFrame, float_format: str, column_width: int) -> str:
@@ -344,6 +364,7 @@ class ModelSummary(Summary):
     def to_string(
         self,
         names: bool = False,
+        element: str = "C",
         threshold: float = 1e-6,
         float_format: str = ".4G",
         column_width: int = 79,
@@ -356,6 +377,8 @@ class ModelSummary(Summary):
         names : bool, optional
             Whether or not elements should be displayed by their common names
             (default False).
+        element : str, optional
+            The atomic element to summarize uptake and secretion for (default 'C').
         threshold : float, optional
             Hide fluxes below the threshold from being displayed (default 1e-6).
         float_format : str, optional
@@ -372,13 +395,13 @@ class ModelSummary(Summary):
         objective = self._string_objective(names)
 
         uptake = self._string_table(
-            self._display_flux(self.uptake_flux, names, threshold),
+            self._display_flux(self.uptake_flux, names, element, threshold),
             float_format,
             column_width,
         )
 
         secretion = self._string_table(
-            self._display_flux(self.secretion_flux, names, threshold),
+            self._display_flux(self.secretion_flux, names, element, threshold),
             float_format,
             column_width,
         )
@@ -396,7 +419,11 @@ class ModelSummary(Summary):
         )
 
     def to_html(
-        self, names: bool = False, threshold: float = 1e-6, float_format: str = ".4G"
+        self,
+        names: bool = False,
+        element: str = "C",
+        threshold: float = 1e-6,
+        float_format: str = ".4G",
     ) -> str:
         """
         Return a rich HTML representation of the model summary.
@@ -406,6 +433,8 @@ class ModelSummary(Summary):
         names : bool, optional
             Whether or not elements should be displayed by their common names
             (default False).
+        element : str, optional
+            The atomic element to summarize uptake and secretion for (default 'C').
         threshold : float, optional
             Hide fluxes below the threshold from being displayed (default 1e-6).
         float_format : str, optional
@@ -420,11 +449,13 @@ class ModelSummary(Summary):
         objective = self._string_objective(names)
 
         uptake = self._html_table(
-            self._display_flux(self.uptake_flux, names, threshold), float_format,
+            self._display_flux(self.uptake_flux, names, element, threshold),
+            float_format,
         )
 
         secretion = self._html_table(
-            self._display_flux(self.secretion_flux, names, threshold), float_format,
+            self._display_flux(self.secretion_flux, names, element, threshold),
+            float_format,
         )
 
         return (

--- a/src/cobra/summary/reaction_summary.py
+++ b/src/cobra/summary/reaction_summary.py
@@ -98,6 +98,8 @@ class ReactionSummary(Summary):
             optimum objective to be searched.
 
         """
+        super()._generate(model=model, solution=solution, fva=fva)
+
         if solution is None:
             logger.info("Generating new parsimonious flux distribution.")
             solution = pfba(model)
@@ -152,7 +154,7 @@ class ReactionSummary(Summary):
     def to_string(
         self,
         names: bool = False,
-        threshold: float = 1e-6,
+        threshold: Optional[float] = None,
         float_format: str = ".4G",
         column_width: int = 79,
     ) -> str:
@@ -165,7 +167,8 @@ class ReactionSummary(Summary):
             Whether or not elements should be displayed by their common names
             (default False).
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
         column_width : int, optional
@@ -177,6 +180,8 @@ class ReactionSummary(Summary):
             The summary formatted as a pretty string.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         if names:
             header = shorten(self._reaction.name, width=column_width, placeholder="...")
         else:
@@ -195,7 +200,10 @@ class ReactionSummary(Summary):
         )
 
     def to_html(
-        self, names: bool = False, threshold: float = 1e-6, float_format: str = ".4G"
+        self,
+        names: bool = False,
+        threshold: Optional[float] = None,
+        float_format: str = ".4G",
     ) -> str:
         """
         Return a rich HTML representation of the reaction summary.
@@ -206,7 +214,8 @@ class ReactionSummary(Summary):
             Whether or not elements should be displayed by their common names
             (default False).
         threshold : float, optional
-            Hide fluxes below the threshold from being displayed (default 1e-6).
+            Hide fluxes below the threshold from being displayed. If no value is
+            given, the model tolerance is used (default None).
         float_format : str, optional
             Format string for floats (default '.4G').
 
@@ -216,6 +225,8 @@ class ReactionSummary(Summary):
             The summary formatted as HTML.
 
         """
+        threshold = self._normalize_threshold(threshold)
+
         if names:
             header = self._reaction.name
         else:

--- a/src/cobra/test/test_summary/test_model_summary.py
+++ b/src/cobra/test/test_summary/test_model_summary.py
@@ -99,9 +99,15 @@ def test_model_summary_fva(model, opt_solver):
 def test_model_summary_flux_in_context(model, opt_solver):
     """Test that the model summary inside and outside of a context are equal."""
     model.solver = opt_solver
+    copy = model.copy()
     with model:
+        model.reactions.EX_glc__D_e.bounds = (0, 1000)
+        model.reactions.EX_ac_e.bounds = (-10, 1000)
         context_summary = model.summary()
-    outside_summary = model.summary()
+
+    copy.reactions.EX_glc__D_e.bounds = (0, 1000)
+    copy.reactions.EX_ac_e.bounds = (-10, 1000)
+    outside_summary = copy.summary()
 
     assert context_summary.to_frame()["flux"].values == pytest.approx(
         outside_summary.to_frame()["flux"].values, abs=model.tolerance


### PR DESCRIPTION
* Make the context test for the model summary closer to what was reported in #900 
* Add the ability to display atomic element uptake/secretion to the model summary. See https://gist.github.com/Midnighter/84590cbc5d46209897abcf6ec2ba812d for a preview
