### PR TITLE
Add --cov-append to Toxfile testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
     pytest-raises
     jsonschema
 commands =
-    pytest --cov=cobra --cov-report=term {posargs: --benchmark-skip}
+    pytest --cov=cobra --cov-report=term --cov-append {posargs: --benchmark-skip}
 
 [testenv:isort]
 skip_install = True


### PR DESCRIPTION
Hi there,

Was running tests on your project to see if I could contribute somewhere, when I noticed that Tox is currently configured to create a million dotfiles in the project root folder:

![image](https://user-images.githubusercontent.com/855559/100366886-0b543f00-2fc7-11eb-8a53-bbd0ba546490.png)

We can fix this by just adding the `--cov-append` to the command in your Toxfile.

![image](https://user-images.githubusercontent.com/855559/100366931-1c04b500-2fc7-11eb-8223-ee219f51cf74.png)

I know that the million dotfiles will go away once all of the testenvs are finished, but it can still be pretty annoying. Especially when running tasks in parallel!

It's just a very minor, quality-of-life tweak.