### PR TITLE
#972 Cleanup for exceptions.py

### DIFF
--- a/src/cobra/exceptions.py
+++ b/src/cobra/exceptions.py
@@ -3,23 +3,34 @@ import optlang.interface
 
 
 class OptimizationError(Exception):
+    """Exception for Optimization issues."""
+
     def __init__(self, message):
+        """Inherit parent behaviors."""
         super(OptimizationError, self).__init__(message)
 
 
 class Infeasible(OptimizationError):
+    """Exception for Infeasible issues."""
+
     pass
 
 
 class Unbounded(OptimizationError):
+    """Exception for Unbounded issues."""
+
     pass
 
 
 class FeasibleButNotOptimal(OptimizationError):
+    """Exception for Non-Optimal issues."""
+
     pass
 
 
 class UndefinedSolution(OptimizationError):
+    """Exception for Undefined issues."""
+
     pass
 
 

--- a/src/cobra/exceptions.py
+++ b/src/cobra/exceptions.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
+"""Module for shared exceptions in the Cobra package."""
 import optlang.interface
 
 


### PR DESCRIPTION
Progress with #972.  Cleans up Python 2.x references for `exceptions.py`.

Also, while I was in there, I cleaned up the Flake8 complaints for the file, which were just missing Docstrings.

This is pretty much just a cosmetic PR.