### PR TITLE
chore: depend on base libsbml, pin strictly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
 	optlang <1.4.6
 	pandas ~=1.0
 	pydantic ~=1.6
-	python-libsbml-experimental >=5.19.0
+	python-libsbml ==5.19.0
 	rich ~=6.0
 	ruamel.yaml ~=0.16
 	six


### PR DESCRIPTION
This is to finalize #1030 and make a release that can be included in the upcoming Debian release.

@cdiener and @matthiaskoenig, I think you're best positioned to assess. I've briefly described why I think that switching from python-libsbml-experimental to python-libsbml is okay here https://github.com/opencobra/cobrapy/issues/1030#issuecomment-774441844.

Additionally, I've pinned the version exactly. This is because in the past there has been a delay between a new libsbml release and the availability of wheels. This has caused unnecessary headache for environments where building from sources is not an option and our considerable portion of Windows users.

If possible, I'd like to get this in and make a release today. So that @tillea has a chance to prepare the Debian package.
