### PR TITLE
Fix the doc building on RTD

### DIFF
--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 from os.path import dirname, join
-from unittest.mock import Mock
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -22,40 +22,6 @@ from unittest.mock import Mock
 SRC_PATH = join(dirname(dirname(__file__)), "src")
 sys.path.insert(0, SRC_PATH)
 
-
-# These modules should correspond to the importable Python packages.
-MOCK_MODULES = [
-    "depinfo",
-    "numpy",
-    "scipy",
-    "scipy.optimize",
-    "scipy.sparse",
-    "scipy.io",
-    "scipy.stats",
-    "pp",
-    "libsbml",
-    "pandas",
-    "tabulate",
-    "optlang",
-    "optlang.interface",
-    "optlang.symbolics",
-    "optlang.symbolics.core",
-    "optlang.exceptions",
-    "future",
-    "future.utils",
-    "ruamel",
-    "ruamel.yaml",
-    "ruamel.yaml.compat",
-    "ruamel.yaml.main",
-    "appdirs",
-    "httpx",
-    "pydantic",
-    "rich",
-    "diskcache"
-]
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()
-
 # -- General configuration ----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -121,8 +87,8 @@ latex_documents = [
     (
         "index",
         "cobra.tex",
-        u"cobra Documentation",
-        u"The cobrapy core team",
+        "cobra Documentation",
+        "The cobrapy core team",
         "manual",
     )
 ]

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -47,6 +47,11 @@ MOCK_MODULES = [
     "ruamel.yaml",
     "ruamel.yaml.compat",
     "ruamel.yaml.main",
+    "appdirs",
+    "httpx",
+    "pydantic",
+    "rich",
+    "diskcache"
 ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -3,4 +3,3 @@ sphinxcontrib-napoleon
 sphinx-autoapi
 nbsphinx>=0.2.4
 ipykernel
-appdirs~=1.4

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-napoleon
 sphinx-autoapi
 nbsphinx>=0.2.4
 ipykernel
+appdirs~=1.4

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -1,10 +1,14 @@
 # Release notes for cobrapy x.y.z
 
 ## New features
+
 - documentation of boundary reactions (#1038)
+
 ## Fixes
 
 ## Other
+
+- Documentation is now built again on each release
 
 ## Deprecated features
 


### PR DESCRIPTION
* [ ] fix #(issue number)
* [X] description of feature/fix
* [ ] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

## Description

Docs were not built on RTD since version 0.17.0. This switches the documentation builder to the normal installation and removes the mock code which is not necessary anymore. A preview of the latest version can be found at https://cobrapy-cdiener.readthedocs.io/en/latest/ .

## After merge

We need to switch RTD to use the devel branch and not the deleted master branch. I can do that.