### PR TITLE
docs: add Zenodo badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,10 @@ COBRApy - Constraint-Based Reconstruction and Analysis in Python
    :target: https://github.com/ambv/black
    :alt: Black
 
+.. image:: https://zenodo.org/badge/6510063.svg
+   :target: https://zenodo.org/badge/latestdoi/6510063
+   :alt: Zenodo DOI
+
 What is COBRApy?
 ================
 


### PR DESCRIPTION
I've enabled this repository on Zenodo. That means every versioned release should create a fixed copy on Zenodo thus creating a permanent record with a DOI of that version.
