### PR TITLE
feat: add a dispatch to continuously update COBRApy

### DIFF
--- a/.github/workflows/biosimulators_dispatch.yml
+++ b/.github/workflows/biosimulators_dispatch.yml
@@ -6,12 +6,7 @@ on:
 
 jobs:
   dispatch:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get tag

--- a/.github/workflows/biosimulators_dispatch.yml
+++ b/.github/workflows/biosimulators_dispatch.yml
@@ -1,0 +1,26 @@
+name: BioSimulators Dispatch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+      - name: Get tag
+        id: tag
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Dispatch new release version to BioSimulators
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Continuous integration
+          repo: biosimulators/Biosimulators_COBRApy
+          token: ${{ secrets.BIOSIM_DISPATCH_TOKEN }}
+          inputs: '{ "simulatorVersion": "${{ steps.tag.outputs.version }}", "simulatorVersionLatest": "true" }'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,5 +94,5 @@ jobs:
         workflow: Continuous integration
         repo: biosimulators/Biosimulators_COBRApy
         token: ${{ secrets.BIOSIM_DISPATCH_TOKEN }}
-        inputs: '{ "simulatorVersion": "${{ steps.tag.outputs.version }}", "latest": true }'
+        inputs: '{ "simulatorVersion": "${{ steps.tag.outputs.version }}", "simulatorVersionLatest": "true" }'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,3 +88,11 @@ jobs:
         TAG: ${{ steps.tag.outputs.version }}
         WORKSPACE: ${{ github.workspace }}
         WEBSITE_DEPLOY_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
+    - name: Dispatch update on biosimulators
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: Continuous integration
+        repo: biosimulators/Biosimulators_COBRApy
+        token: ${{ secrets.BIOSIM_DISPATCH_TOKEN }}
+        inputs: '{ "simulatorVersion": "${{ steps.tag.outputs.version }}", "latest": true }'
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,11 +88,3 @@ jobs:
         TAG: ${{ steps.tag.outputs.version }}
         WORKSPACE: ${{ github.workspace }}
         WEBSITE_DEPLOY_TOKEN: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
-    - name: Dispatch update on biosimulators
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        workflow: Continuous integration
-        repo: biosimulators/Biosimulators_COBRApy
-        token: ${{ secrets.BIOSIM_DISPATCH_TOKEN }}
-        inputs: '{ "simulatorVersion": "${{ steps.tag.outputs.version }}", "simulatorVersionLatest": "true" }'
-


### PR DESCRIPTION
In @jonrkarr 's group, they have created https://biosimulators.org/, a platform that facilitates performing computational experiments with different modeling tools. They have already prepared a wrapper around cobrapy in order to make it available on the platform https://github.com/biosimulators/Biosimulators_COBRApy.

In this PR I suggest to dispatch a workflow on the https://github.com/biosimulators/Biosimulators_COBRApy repo, whenever a new version of cobrapy gets released. I hope that this is agreeable. I will open another discussion on whether and in how far we want to support this in cobrapy.