### PR TITLE
refactor: multiprocessing.Pool usage

### DIFF
--- a/src/cobra/flux_analysis/variability.py
+++ b/src/cobra/flux_analysis/variability.py
@@ -3,8 +3,8 @@
 from __future__ import absolute_import
 
 import logging
-import multiprocessing
 from builtins import map
+from multiprocessing import Pool
 from warnings import warn
 
 from numpy import zeros
@@ -208,17 +208,16 @@ def flux_variability_analysis(
                 # objective direction for all reactions. This creates a
                 # slight overhead but seems the most clean.
                 chunk_size = len(reaction_ids) // processes
-                pool = multiprocessing.Pool(
+
+                with Pool(
                     processes,
                     initializer=_init_worker,
                     initargs=(model, loopless, what[:3]),
-                )
-                for rxn_id, value in pool.imap_unordered(
-                    _fva_step, reaction_ids, chunksize=chunk_size
-                ):
-                    fva_result.at[rxn_id, what] = value
-                pool.close()
-                pool.join()
+                ) as pool:
+                    for rxn_id, value in pool.imap_unordered(
+                        _fva_step, reaction_ids, chunksize=chunk_size
+                    ):
+                        fva_result.at[rxn_id, what] = value
             else:
                 _init_worker(model, loopless, what[:3])
                 for rxn_id, value in map(_fva_step, reaction_ids):

--- a/src/cobra/sampling/optgp.py
+++ b/src/cobra/sampling/optgp.py
@@ -214,12 +214,8 @@ class OptGPSampler(HRSampler):
             # limit errors, something weird going on with multiprocessing
             args = list(zip([n_process] * self.processes, range(self.processes)))
 
-            # No with statement or starmap here since Python 2.x
-            # does not support it :(
-            mp = Pool(self.processes, initializer=mp_init, initargs=(self,))
-            results = mp.map(_sample_chain, args, chunksize=1)
-            mp.close()
-            mp.join()
+            with Pool(self.processes, initializer=mp_init, initargs=(self,)) as pool:
+                results = pool.map(_sample_chain, args, chunksize=1)
 
             chains = np.vstack([r[1] for r in results])
             self.retries += sum(r[0] for r in results)


### PR DESCRIPTION
* [x] description of feature/fix
* [x] tests added/passed

This PR upgrades the instances of `multiprocessing.Pool` to use context managers.
