### PR TITLE
Switch SBML GPR parsing to internal semantic parser

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+- now uses the internal semantic GPR parser in the SBML module
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -743,17 +743,8 @@ def _sbml_to_model(
                 if f_replace and F_GENE in f_replace:
                     gpr = " ".join(f_replace[F_GENE](t) for t in gpr.split(" "))
 
-        # remove outside parenthesis, if any
-        if gpr.startswith("(") and gpr.endswith(")"):
-            try:
-                parse_gpr(gpr[1:-1].strip())
-                gpr = gpr[1:-1].strip()
-            except (SyntaxError, TypeError) as e:
-                LOGGER.warning(
-                    "Removing parenthesis from gpr %s leads to "
-                    "an error, so keeping parenthesis",
-                    gpr,
-                )
+        # remove outside parenthesis and format into standard form
+        gpr = ast2str(parse_gpr(gpr)[0])
 
         cobra_reaction.gene_reaction_rule = gpr
 

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -42,7 +42,7 @@ import libsbml
 
 import cobra
 from cobra.core import Gene, Group, Metabolite, Model, Reaction
-from cobra.core.gene import parse_gpr
+from cobra.core.gene import parse_gpr, ast2str
 from cobra.manipulation.validate import check_metabolite_compartment_formula
 from cobra.util.solver import linear_reaction_coefficients, set_objective
 
@@ -1202,19 +1202,15 @@ def _model_to_sbml(cobra_model, f_replace=None, units=True):
         # GPR
         gpr = cobra_reaction.gene_reaction_rule
         if gpr is not None and len(gpr) > 0:
-
+            # we will parse the GPR to format them correctly for libSBML
+            # avoids cases where a GPR can be parsed by cobrapy but not libSBML
+            tree, gids = parse_gpr(gpr)
             # replace ids in string
             if f_replace and F_GENE_REV in f_replace:
-                gpr = gpr.replace("(", "( ")
-                gpr = gpr.replace(")", " )")
-                tokens = gpr.split()
-
-                for k in range(len(tokens)):
-                    if tokens[k] not in ["and", "or", "(", ")"]:
-                        tokens[k] = f_replace[F_GENE_REV](tokens[k])
-                gpr_new = " ".join(tokens)
+                idmap = {gid: f_replace[F_GENE_REV](gid) for gid in gids}
+                gpr_new = ast2str(tree, names=idmap)
             else:
-                gpr_new = gpr
+                gpr_new = ast2str(tree)
 
             gpa = (
                 r_fbc.createGeneProductAssociation()

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -42,7 +42,7 @@ import libsbml
 
 import cobra
 from cobra.core import Gene, Group, Metabolite, Model, Reaction
-from cobra.core.gene import parse_gpr, ast2str
+from cobra.core.gene import ast2str, parse_gpr
 from cobra.manipulation.validate import check_metabolite_compartment_formula
 from cobra.util.solver import linear_reaction_coefficients, set_objective
 

--- a/src/cobra/test/test_io/test_sbml.py
+++ b/src/cobra/test/test_io/test_sbml.py
@@ -529,3 +529,14 @@ def test_smbl_with_notes(data_directory, tmp_path):
             reaction_annotations[annotation_key]
             == model.reactions[0].annotation[annotation_key]
         )
+
+
+def test_stable_gprs(data_directory, tmp_path):
+    mini = read_sbml_model(join(data_directory, "mini_fbc2.xml"))
+    mini.reactions.GLCpts.gene_reaction_rule = "((b2415 and b2417)or (b2416))"
+    fixed = join(str(tmp_path), "fixed_gpr.xml")
+    write_sbml_model(mini, fixed)
+    fixed_model = read_sbml_model(fixed)
+    assert (
+        fixed_model.reactions.GLCpts.gene_reaction_rule == "(b2415 and b2417) or b2416"
+    )


### PR DESCRIPTION
* [X] fix #1104 
* [X] description of feature/fix
* [X] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)

This is a small fix that now uses the internal GPR parser from `core/gene.py` when simplifying and formatting GPRs instead of using an ad-hoc token parser. This makes writing GPRs more stable and allows for formatting variations such as `((gene1 and gene2)or(gene2 and gene3))`. Does not seem to affect speed and now allows Recon3 to be converted without any manual modifications of GPRs.