### PR TITLE
don't compare objective values for infeasible solutions

### DIFF
--- a/src/cobra/test/test_io/conftest.py
+++ b/src/cobra/test/test_io/conftest.py
@@ -4,8 +4,9 @@
 
 from __future__ import absolute_import
 
+from optlang.interface import OPTIMAL
 from os.path import join
-from pickle import dump, load
+from pickle import load
 
 import pytest
 
@@ -78,7 +79,7 @@ def compare_models(model_1, model_2):
     # ensure they have the same solution max
     solution_1 = model_1.optimize()
     solution_2 = model_2.optimize()
-    if solution_1.status == "optimal" and solution_2.status == "optimal":
+    if solution_1.status == OPTIMAL and solution_2.status == OPTIMAL:
         assert abs(
             solution_1.objective_value - solution_2.objective_value
         ) == pytest.approx(0.0)

--- a/src/cobra/test/test_io/conftest.py
+++ b/src/cobra/test/test_io/conftest.py
@@ -78,9 +78,12 @@ def compare_models(model_1, model_2):
     # ensure they have the same solution max
     solution_1 = model_1.optimize()
     solution_2 = model_2.optimize()
-    assert abs(
-        solution_1.objective_value - solution_2.objective_value
-    ) == pytest.approx(0.0)
+    if solution_1.status == "optimal" and solution_2.status == "optimal":
+        assert abs(
+            solution_1.objective_value - solution_2.objective_value
+        ) == pytest.approx(0.0)
+    else:
+        assert solution_1.status == solution_2.status
 
     # ensure the references are correct
     # metabolite -> model reference

--- a/src/cobra/test/test_io/conftest.py
+++ b/src/cobra/test/test_io/conftest.py
@@ -4,11 +4,11 @@
 
 from __future__ import absolute_import
 
-from optlang.interface import OPTIMAL
 from os.path import join
 from pickle import load
 
 import pytest
+from optlang.interface import OPTIMAL
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* [X] fix unreported issue
* [X] description of feature/fix
* [X] fixes tests themselves
* [ ] add an entry to the [next release](../release-notes/next-release.md) - only relevant for unit tests

I noticed that the io tests fail for the mini model with cplex. The mini model is infeasible and trying to get the same objective value for infeasible solutions is somewhat arbitrary and worked for GLPK just by chance. `compare_models` now checks for the solution status as well.
