### PR TITLE
Make sure `model.medium` setter does not overwrite export bounds

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - now uses the internal semantic GPR parser in the SBML module
+- setting a growth medium will not reset export flux bounds anymore
 
 ## Other
 

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -290,7 +290,10 @@ class Model(Object):
 
         # Turn off reactions not present in media
         for rxn in exchange_rxns - media_rxns:
-            set_active_bound(rxn, 0)
+            is_export = rxn.reactants and not rxn.products
+            set_active_bound(
+                rxn, min(0, -rxn.lower_bound if is_export else rxn.upper_bound)
+            )
 
     def __add__(self, other_model):
         """Add the content of another model to this model (+).

--- a/src/cobra/test/test_medium/test_minimal_medium.py
+++ b/src/cobra/test/test_medium/test_minimal_medium.py
@@ -108,3 +108,17 @@ def test_model_medium(model: Model) -> None:
     new_medium["bogus_rxn"] = 0
     with pytest.raises(KeyError):
         model.medium = new_medium
+
+
+def test_medium_does_not_affect_exports(model: Model) -> None:
+    """Test that the medium setter does not overwrite exports."""
+    med = model.medium
+    # Set a fixed export rate
+    model.reactions.EX_ac_e.lower_bound = 0.1
+    model.medium = med
+    assert model.reactions.EX_ac_e.lower_bound == 0.1
+
+    # should be overwritten if actually in the medium
+    med["EX_ac_e"] = 1
+    model.medium = med
+    assert model.reactions.EX_ac_e.lower_bound == -1

--- a/src/cobra/test/test_medium/test_minimal_medium.py
+++ b/src/cobra/test/test_medium/test_minimal_medium.py
@@ -110,8 +110,8 @@ def test_model_medium(model: Model) -> None:
         model.medium = new_medium
 
 
-def test_medium_does_not_affect_exports(model: Model) -> None:
-    """Test that the medium setter does not overwrite exports."""
+def test_medium_does_not_affect_reactant_exports(model: Model) -> None:
+    """Test that the medium setter does not overwrite exports defined as reactants."""
     med = model.medium
     # Set a fixed export rate
     model.reactions.EX_ac_e.lower_bound = 0.1
@@ -122,3 +122,19 @@ def test_medium_does_not_affect_exports(model: Model) -> None:
     med["EX_ac_e"] = 1
     model.medium = med
     assert model.reactions.EX_ac_e.lower_bound == -1
+
+
+def test_medium_does_not_affect_product_exports(model: Model) -> None:
+    """Test that the medium setter does not overwrite exports defined as products."""
+    med = model.medium
+    # Reverse reaction definition
+    model.reactions.EX_ac_e *= -1
+    # Set a fixed export rate
+    model.reactions.EX_ac_e.bounds = -1, -0.1
+    model.medium = med
+    assert model.reactions.EX_ac_e.bounds == (-1, -0.1)
+
+    # should be overwritten if actually in the medium
+    med["EX_ac_e"] = 1
+    model.medium = med
+    assert model.reactions.EX_ac_e.upper_bound == 1


### PR DESCRIPTION
* [x] fix #1126
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)

This PR introduces a check so `model.medium = ...` will not overwrite export bounds for reactions *not in the medium*. 

This fixes #1126:

```
Python 3.9.8 (main, Nov  7 2021, 15:47:09) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import cobra
   ...: 
   ...: model = cobra.io.read_sbml_model("iNF517.xml")
   ...: 
   ...: with model:
   ...:     print(model.slim_optimize())
   ...: 
   ...: with model:
   ...:     model.medium = model.medium
   ...:     print(model.slim_optimize())
   ...: 
0.04263460544337329
0.04263460544337329
```