### PR TITLE
Update package pins and repair the CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]*)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 tag_name = {new_version}
@@ -15,7 +15,7 @@ tag_name = {new_version}
 name = cobra
 url = https://opencobra.github.io/cobrapy
 download_url = https://pypi.org/project/cobra
-project_urls = 
+project_urls =
 	Source Code = https://github.com/opencobra/cobrapy
 	Documentation = https://cobrapy.readthedocs.io
 	Bug Tracker = https://github.com/opencobra/cobrapy/issues
@@ -23,7 +23,7 @@ author = The cobrapy core development team.
 author_email = cobra-pie@googlegroups.com
 maintainer = Moritz E. Beber
 maintainer_email = moritz.beber@gmail.com
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
@@ -39,7 +39,7 @@ license = LGPL-2.0-or-later OR GPL-2.0-or-later
 description = COBRApy is a package for constraint-based modeling of metabolic networks.
 long_description = file: README.rst, INSTALL.rst
 long_description_content_type = text/x-rst
-keywords = 
+keywords =
 	metabolism
 	biology
 	constraint-based
@@ -51,14 +51,14 @@ keywords =
 
 [options]
 zip_safe = True
-install_requires = 
+install_requires =
 	appdirs ~=1.4
 	depinfo ~=1.7
 	diskcache ~=5.0
 	future
 	httpx ~=0.14
 	importlib_resources
-	numpy ~=1.13
+	numpy ~=1.22
 	optlang ~=1.5
 	pandas ~=1.0
 	pydantic ~=1.6
@@ -66,24 +66,24 @@ install_requires =
 	rich >=8.0
 	ruamel.yaml ~=0.16
 	swiglpk
-tests_require = 
+tests_require =
 	tox
 packages = find:
-package_dir = 
+package_dir =
 	= src
 
 [options.packages.find]
 where = src
 
 [options.package_data]
-cobra = 
+cobra =
 	io/*.json
 	test/data/*
 
 [options.extras_require]
-array = 
+array =
 	scipy
-development = 
+development =
 	black
 	bumpversion
 	isort
@@ -95,7 +95,7 @@ universal = 1
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 


### PR DESCRIPTION
* [X] description of feature/fix
* [X] add an entry to the [next release](../release-notes/next-release.md)

This fixes some issues currently wrecking the CI. Black now has a major version and will complain about some additional formattings now. For now this PR pins black to the previous versions and the codebase will need to be reformatted in the future.

The numpy pin was very old. Is there a mechanism to actually update the version pins periodically? This had led to breakages before and often does not play nice with tox safety.