### PR TITLE
modifying the gene_reaction_rule will remove genes no longer used

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.10']
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ on:
     - devel
 
 jobs:
-  test:
+  lint:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.10']
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+name: CI-CD
+
+on:
+  push:
+    branches:
+    - stable
+    - devel
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+a[0-9]+'
+  pull_request:
+    branches:
+    - stable
+    - devel
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install tox tox-gh-actions
+    - name: isort
+      run:
+        tox -e isort
+    - name: black
+      run:
+        tox -e black
+# We ignore flake8 for the time being because there are tons of things to fix.
+#    - name: flake8
+#      run:
+#        tox -e flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: CI-CD
+name: Lint
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.10']
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install tox tox-gh-actions
+    - name: safety
+      continue-on-error: true
+      run:
+        tox -e safety
     - name: Test with tox
       run:
         tox -- --cov-report=xml --benchmark-skip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-    timeout-minutes: 30
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install tox tox-gh-actions
-    - name: safety
-      continue-on-error: true
-      run:
-        tox -e safety
     - name: Test with tox
       run:
         tox -- --cov-report=xml --benchmark-skip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,11 +64,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install twine
+        python -m pip install build twine
     - name: Build package
-      run: python setup.py sdist bdist_wheel
-    - name: Check the package
-      run: twine check dist/*
+      run: python -m build
     - name: Publish to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-    timeout-minutes: 30
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -1,0 +1,34 @@
+name: Safety
+
+on:
+  push:
+    branches:
+    - stable
+    - devel
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+a[0-9]+'
+
+jobs:
+  safety:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install tox tox-gh-actions
+    - name: safety
+      run:
+        tox -e safety

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ classifiers =
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: Implementation :: CPython
 	Topic :: Scientific/Engineering :: Bio-Informatics
 license = LGPL-2.0-or-later OR GPL-2.0-or-later

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
+"""Provide functions for dealing with genes and gene product rules (GPR)."""
 
 import re
 from ast import (
@@ -19,7 +17,7 @@ from ast import (
 from ast import parse as ast_parse
 from copy import deepcopy
 from keyword import kwlist
-from typing import FrozenSet, Iterable, Set, Tuple, Union
+from typing import FrozenSet, Iterable, Optional, Set, Tuple, Union
 from warnings import warn
 
 from cobra.core.dictlist import DictList
@@ -32,7 +30,7 @@ keywords = list(kwlist)
 keywords.remove("and")
 keywords.remove("or")
 keywords.extend(("True", "False"))
-keyword_re = re.compile(r"(?=\b(%s)\b)" % "|".join(keywords))
+keyword_re = re.compile(rf"(?=\b({'|'.join(keywords)})\b)")
 number_start_re = re.compile(r"(?=\b[0-9])")
 
 replacements = (
@@ -53,14 +51,38 @@ class GPRWalker(NodeVisitor):
     Walks over the tree, and identifies the id of each Name node
     """
 
-    def __init__(self):
-        NodeVisitor.__init__(self)
+    def __init__(self, **kwargs) -> None:
+        """Initialize a new object.
+
+        Other Parameters
+        ----------------
+        **kwargs:
+            Further keyword arguments are passed on to the parent class.
+
+        """
+        super().__init__(**kwargs)
         self.gene_set = set()
 
-    def visit_Name(self, node) -> None:
+    def visit_Name(self, node: Name) -> None:
+        """Visit a Gene node and add the id to the gene_set.
+
+        Parameters
+        ----------
+        node: ast.Name
+            The node to visit
+
+        """
         self.gene_set.add(node.id)
 
     def visit_BoolOp(self, node: BoolOp) -> None:
+        """Visit a BoolOp node (AND/OR) and visit the children to add them to gene_set.
+
+        Parameters
+        ----------
+        node: ast.BoolOp
+            The node to visit
+
+        """
         self.generic_visit(node)
         for val in node.values:
             self.visit(val)
@@ -73,11 +95,35 @@ class GPRCleaner(NodeTransformer):
     bitwise boolean operations
     """
 
-    def __init__(self):
-        NodeTransformer.__init__(self)
+    def __init__(self, **kwargs) -> None:
+        """Initialize a new object.
+
+        Other Parameters
+        ----------------
+        **kwargs:
+            Further keyword arguments are passed on to the parent class.
+
+        """
+        super().__init__(**kwargs)
         self.gene_set = set()
 
-    def visit_Name(self, node):
+    def visit_Name(self, node: Name) -> Name:
+        """Visit a Gene node and add the id to the gene_set.
+
+        The gene id will be cleaned used __cobra_escape__ and replacements
+        dictionary (see above).
+
+        Parameters
+        ----------
+        node: ast.Name
+            The node to visit
+
+        Returns
+        -------
+        node: ast.Name
+            The transformed node (with the id changed).
+
+        """
         if node.id.startswith("__cobra_escape__"):
             node.id = node.id[16:]
         for char, escaped in replacements:
@@ -86,14 +132,26 @@ class GPRCleaner(NodeTransformer):
         self.gene_set.add(node.id)
         return node
 
-    def visit_BinOp(self, node):
+    def visit_BinOp(self, node: BoolOp) -> None:
+        """Visit a BoolOp node (AND/OR) and visit the children (genes) to process them.
+
+        Parameters
+        ----------
+        node: ast.BoolOp
+            The node to visit. Nodes other than And() and Or() will cause an error.
+
+        Returns
+        -------
+        node: ast.BoolOp
+            The node with the children transformed.
+        """
         self.generic_visit(node)
         if isinstance(node.op, BitAnd):
             return BoolOp(And(), (node.left, node.right))
         elif isinstance(node.op, BitOr):
             return BoolOp(Or(), (node.left, node.right))
         else:
-            raise TypeError("unsupported operation '%s'" % node.op.__class__.__name__)
+            raise TypeError(f"unsupported operation '{node.op.__class__.__name__}'")
 
 
 def parse_gpr(str_expr: str) -> Tuple:
@@ -137,7 +195,8 @@ class Gene(Species):
         used.
     """
 
-    def __init__(self, id=None, name="", functional=True):
+    # noinspection PyShadowingBuiltins
+    def __init__(self, id: str = None, name: str = "", functional: bool = True) -> None:
         """Initialize a gene.
 
         Parameters
@@ -150,11 +209,11 @@ class Gene(Species):
         functional: bool
             A flag whether or not the gene is functional
         """
-        Species.__init__(self, id=id, name=name)
+        super().__init__(id=id, name=name)
         self._functional = functional
 
     @property
-    def functional(self):
+    def functional(self) -> bool:
         """Flag indicating if the gene is functional.
 
         Changing the flag is reverted upon exit if executed within the model
@@ -164,12 +223,12 @@ class Gene(Species):
 
     @functional.setter
     @resettable
-    def functional(self, value):
+    def functional(self, value: bool) -> None:
         if not isinstance(value, bool):
             raise ValueError("expected boolean")
         self._functional = value
 
-    def knock_out(self):
+    def knock_out(self) -> None:
         """Knockout gene by marking it as non-functional.
 
         Knockout gene by marking it as non-functional and setting all
@@ -183,9 +242,9 @@ class Gene(Species):
                 reaction.bounds = (0, 0)
 
     def remove_from_model(
-        self, model=None, make_dependent_reactions_nonfunctional=True
-    ):
-        """Removes the association.
+        self, model: "Model" = None, make_dependent_reactions_nonfunctional: bool = True
+    ) -> None:
+        """Remove the association of gene from a model.
 
         Parameters
         ----------
@@ -206,17 +265,17 @@ class Gene(Species):
         if model is not None:
             if model != self._model:
                 raise Exception(
-                    "%s is a member of %s, not %s"
-                    % (repr(self), repr(self._model), repr(model))
+                    f"{repr(self)} is a member of {repr(self._model)}, "
+                    f"not {repr(model)}"
                 )
         if self._model is None:
-            raise Exception("%s is not in a model" % repr(self))
+            raise Exception(f"{repr(self)} is not in a model")
 
         if make_dependent_reactions_nonfunctional:
             gene_state = "False"
         else:
             gene_state = "True"
-        the_gene_re = re.compile("(^|(?<=( |\()))%s(?=( |\)|$))" % re.escape(self.id))
+        the_gene_re = re.compile(rf"(^|(?<=( |\())){re.escape(self.id)}(?=( |\)|$))")
 
         # remove reference to the gene in all groups
         associated_groups = self._model.get_associated_groups(self)
@@ -236,7 +295,7 @@ class Gene(Species):
             the_gene_reaction_relation = the_reaction.gene_reaction_rule
             for other_gene in the_reaction._genes:
                 other_gene_re = re.compile(
-                    "(^|(?<=( |\()))%s(?=( |\)|$))" % re.escape(other_gene.id)
+                    rf"(^|(?<=( |\())){re.escape(other_gene.id)}(?=( |\)|$))"
                 )
                 the_gene_reaction_relation = other_gene_re.sub(
                     "True", the_gene_reaction_relation
@@ -248,29 +307,23 @@ class Gene(Species):
         self._reaction.clear()
 
     def _repr_html_(self):
-        return """
+        return f"""
         <table>
             <tr>
-                <td><strong>Gene identifier</strong></td><td>{id}</td>
+                <td><strong>Gene identifier</strong></td><td>{self.id}</td>
             </tr><tr>
-                <td><strong>Name</strong></td><td>{name}</td>
+                <td><strong>Name</strong></td><td>{self.name}</td>
             </tr><tr>
                 <td><strong>Memory address</strong></td>
-                <td>{address}</td>
+                <td>{id(self):#x}</td>
             </tr><tr>
-                <td><strong>Functional</strong></td><td>{functional}</td>
+                <td><strong>Functional</strong></td><td>{self.functional}</td>
             </tr><tr>
-                <td><strong>In {n_reactions} reaction(s)</strong></td><td>
-                    {reactions}</td>
+                <td><strong>In {len(self.reactions)} reaction(s)</strong></td><td>
+                    {format_long_string(", ".join(r.id for r in self.reactions), 200)}
+                    </td>
             </tr>
-        </table>""".format(
-            id=self.id,
-            name=self.name,
-            functional=self.functional,
-            address="0x0%x" % id(self),
-            n_reactions=len(self.reactions),
-            reactions=format_long_string(", ".join(r.id for r in self.reactions), 200),
-        )
+        </table>"""
 
 
 class GPR(Module):
@@ -283,9 +336,18 @@ class GPR(Module):
     """
 
     def __init__(self, gpr_from: Union[Expression, Module, AST] = None, **kwargs):
+        """Initialize a gene.
+
+        Parameters
+        ----------
+        gpr_from: Expression, Module, AST
+            An AST expression that will be parsed to GPR.
+        **kwargs:
+            Further keyword arguments are passed on to the parent class.
+        """
         super().__init__(**kwargs)
         self._genes = set()
-        self.body = None
+        self.body: Optional[list] = None
         if gpr_from:
             if isinstance(gpr_from, str):
                 self.from_string(gpr_from)
@@ -297,7 +359,6 @@ class GPR(Module):
                 cleaner = GPRCleaner()
                 cleaner.visit(gpr_from)
                 self._genes = deepcopy(cleaner.gene_set)
-                # noinspection PyTypeChecker
                 self.body = deepcopy(gpr_from.body)
                 self.eval()
             else:
@@ -347,6 +408,7 @@ class GPR(Module):
                     f"Uppercase AND/OR found in rule '{string_gpr}'.",
                     SyntaxWarning,
                 )
+                warn(e.msg)
                 string_gpr = uppercase_AND.sub("and", string_gpr)
                 string_gpr = uppercase_OR.sub("or", string_gpr)
             try:
@@ -458,7 +520,7 @@ class GPR(Module):
 
     def _ast2str(
         self,
-        expr: Union[Expression, BoolOp, Name, list],
+        expr: Union["GPR", Expression, BoolOp, Name, list],
         level: int = 0,
         names: dict = None,
     ) -> str:
@@ -525,21 +587,20 @@ class GPR(Module):
         -----
         Calls __aststr()
         """
-        # noinspection PyTypeChecker
         return self._ast2str(self, names=names)
 
     def copy(self):
         """Copy a GPR."""
         return deepcopy(self)
 
-    def __repr__(self):
-        return "%s.%s(%r)" % (
-            self.__class__.__module__,
-            self.__class__.__qualname__,
-            self.to_string(),
+    def __repr__(self) -> str:
+        """Return the GPR with module, class, and code to recreate it."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__qualname__}"
+            f"({self.to_string()!r})"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Convert compiled ast to gene_reaction_rule str.
 
         Parameters
@@ -554,16 +615,12 @@ class GPR(Module):
         """
         return self.to_string(names={})
 
-    def _repr_html__(self):
-        return """<p><strong>GPR</strong></p><p>{gpr}</p>""".format(
-            gpr=format_long_string(self.to_string(), 100)
-        )
-
-    # def as_symbolic(self):
-    #     # ...
+    def _repr_html_(self) -> str:
+        return f"""<p><strong>GPR</strong></p><p>{format_long_string(self.to_string(),
+                                                                     100)}</p>"""
 
 
-def eval_gpr(expr, knockouts):
+def eval_gpr(expr: Union[Expression, GPR], knockouts: Union[DictList, set]) -> bool:
     """Evaluate compiled ast of gene_reaction_rule with knockouts.
 
     .. deprecated ::
@@ -602,7 +659,8 @@ def ast2str(expr: Union[Expression, GPR], level: int = 0, names: dict = None) ->
     expr : AST or GPR
         AST or GPR
     level : int
-        internal use only
+        internal use only. Ignored because of GPR() class, kept only for interface
+        consistency with code still using ast2str.
     names : dict
         Dict where each element id a gene identifier and the value is the
         gene name. Use this to get a rule str which uses names instead. This

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -21,6 +21,7 @@ from cobra.core.gene import GPR, Gene
 from cobra.core.metabolite import Metabolite
 from cobra.core.object import Object
 from cobra.exceptions import OptimizationError
+from cobra.manipulation import remove_genes
 from cobra.util.context import get_context, resettable
 from cobra.util.solver import (
     check_solver_status,
@@ -426,7 +427,7 @@ class Reaction(Object):
         new_gene_names: set
         """
         if new_gene_names is None:
-            if self._gpr is not None:
+            if self._gpr.body is not None:
                 new_gene_names = self._gpr.genes
             else:
                 new_gene_names = set()
@@ -454,6 +455,8 @@ class Reaction(Object):
             if g not in self._genes:  # if an old gene is not a new gene
                 try:
                     g._reaction.remove(self)
+                    if not len(g.reactions) and self.model and g in self.model.genes:
+                        remove_genes(self.model, [g], False)
                 except KeyError:
                     warn(
                         "could not remove old gene %s from reaction %s"

--- a/src/cobra/manipulation/delete.py
+++ b/src/cobra/manipulation/delete.py
@@ -334,6 +334,7 @@ def remove_genes(
     gene_id_set = {i.id for i in gene_set}
     remover = _GeneRemover(gene_id_set)
     target_reactions = []
+    rxns_to_revisit = set()
     for rxn in model.reactions:
         if rxn.gene_reaction_rule is None or len(rxn.gene_reaction_rule) == 0:
             continue
@@ -346,7 +347,9 @@ def remove_genes(
             remover.visit(rxn.gpr)
             if "body" not in rxn.gpr.__dict__.keys():
                 rxn.gpr = GPR()
-            rxn._update_genes_from_gpr()
+                rxn._genes = set()
+            else:
+                rxns_to_revisit.add(rxn)
     for gene in gene_set:
         model.genes.remove(gene)
         # remove reference to the gene in all groups
@@ -354,3 +357,5 @@ def remove_genes(
         for group in associated_groups:
             group.remove_members(gene)
     model.remove_reactions(target_reactions)
+    for rxn in rxns_to_revisit:
+        rxn._update_genes_from_gpr()

--- a/src/cobra/test/test_core/test_core_reaction.py
+++ b/src/cobra/test/test_core/test_core_reaction.py
@@ -76,6 +76,7 @@ def test_gpr_modification(model: Model) -> None:
     # Remove old gene correctly
     assert old_gene not in reaction.genes
     assert reaction not in old_gene.reactions
+    assert old_gene not in model.genes
 
     # Add a new 'gene' to the GPR
     reaction.gene_reaction_rule = "fake_gene"

--- a/src/cobra/test/test_core/test_gene.py
+++ b/src/cobra/test/test_core/test_gene.py
@@ -1,5 +1,5 @@
 """Test functions of gene.py"""
 
 
-def test_repr_html_(model):
+def test_repr_html_(model) -> None:
     assert "<table>" in model.genes[0]._repr_html_()

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -16,7 +16,7 @@ def test_gpr() -> None:
     assert gpr1.to_string() == ""
     assert gpr1.eval()
     gpr2 = gpr1.copy()
-    assert gpr2 is GPR
+    assert isinstance(gpr2, GPR)
     assert len(gpr1.genes) == 0
 
 

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -1,13 +1,14 @@
 """Test functions of cobra.core.gene.GPR ."""
 import itertools
 from ast import parse as ast_parse
+from typing import Iterable, Iterator, Union
 
 import pytest
 
 from cobra.core.gene import GPR, ast2str, eval_gpr, parse_gpr
 
 
-def test_gpr():
+def test_gpr() -> None:
     gpr1 = GPR()
     assert len(gpr1.genes) == 0
     gpr1.update_genes()
@@ -15,6 +16,7 @@ def test_gpr():
     assert gpr1.to_string() == ""
     assert gpr1.eval()
     gpr2 = gpr1.copy()
+    assert gpr2 is GPR
     assert len(gpr1.genes) == 0
 
 
@@ -30,7 +32,7 @@ def test_empty_gpr(test_input) -> None:
     assert len(gpr1.genes) == 0
 
 
-def test_one_gene_gpr():
+def test_one_gene_gpr() -> None:
     gpr1 = GPR.from_string("a")
     assert len(gpr1.genes) == 1
     gpr1.update_genes()
@@ -43,7 +45,7 @@ def test_one_gene_gpr():
 
 # Gets an iterable of all combinations of genes except the empty list. Used to
 # evaluate AND gprs
-def powerset_ne(iterable):
+def powerset_ne(iterable: Iterable) -> Iterator:
     "powerset_ne([1,2,3]) --> (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
     s = list(iterable)
     return itertools.chain.from_iterable(
@@ -63,7 +65,7 @@ def powerset_ne(iterable):
         ("a and b and c", 3, {"a", "b", "c"}, "a and b and c"),
     ],
 )
-def test_and_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string):
+def test_and_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string) -> None:
     gpr1 = GPR.from_string(gpr_input)
     assert len(gpr1.genes) == num_genes
     gpr1.update_genes()
@@ -79,7 +81,7 @@ def test_and_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string):
 
 # Gets an iterable of all combinations of genes except a single gene and the empty
 # list. Used to evaluate OR gprs
-def all_except_one(iterable):
+def all_except_one(iterable: Iterable) -> Iterator:
     "all_except_one([1,2,3]) --> (1,) (2,) (3,) (1,2) (1,3) (2,3)"
     s = list(iterable)
     return itertools.chain.from_iterable(
@@ -99,7 +101,7 @@ def all_except_one(iterable):
         ("a or b or c", 3, {"a", "b", "c"}, "a or b or c"),
     ],
 )
-def test_or_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string):
+def test_or_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string) -> None:
     gpr1 = GPR.from_string(gpr_input)
     assert len(gpr1.genes) == num_genes
     gpr1.update_genes()
@@ -122,7 +124,7 @@ def test_or_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string):
         pytest.param("(a OR b) AND c", marks=pytest.mark.filterwarnings),
     ],
 )
-def test_complicated_gpr(gpr_input):
+def test_complicated_gpr(gpr_input: str) -> None:
     gpr1 = GPR.from_string(gpr_input)
     assert len(gpr1.genes) == 3
     gpr1.update_genes()
@@ -149,7 +151,7 @@ def test_complicated_gpr(gpr_input):
     ],
 )
 def test_gpr_from_ast_or(
-    string_to_ast, num_genes, gpr_genes, gpr_output_string
+    string_to_ast: str, num_genes: int, gpr_genes: set, gpr_output_string: str
 ) -> None:
     ast_tree = ast_parse(string_to_ast, "<string>", "eval")
     gpr1 = GPR(ast_tree)
@@ -174,7 +176,7 @@ def test_gpr_from_ast_or(
     ],
 )
 def test_gpr_from_ast_and(
-    string_to_ast, num_genes, gpr_genes, gpr_output_string
+    string_to_ast: str, num_genes: int, gpr_genes: set, gpr_output_string: str
 ) -> None:
     ast_tree = ast_parse(string_to_ast, "<string>", "eval")
     gpr1 = GPR(ast_tree)
@@ -190,7 +192,7 @@ def test_gpr_from_ast_and(
 
 
 @pytest.mark.parametrize("test_input", [["a", "b"], {"a", "b"}])
-def test_wrong_input_gpr_error(test_input):
+def test_wrong_input_gpr_error(test_input: Union[list, set]) -> None:
     with pytest.raises(TypeError):
         GPR.from_string(test_input)
     with pytest.raises(TypeError):
@@ -198,19 +200,19 @@ def test_wrong_input_gpr_error(test_input):
 
 
 @pytest.mark.parametrize("test_input", ["a |", "a &"])
-def test_wrong_input_gpr_warning(test_input):
+def test_wrong_input_gpr_warning(test_input: str) -> None:
     with pytest.warns(SyntaxWarning):
         gpr1 = GPR.from_string(test_input)
         assert gpr1.body is None
         assert len(gpr1.genes) == 0
 
 
-def test_deprecated_gpr():
+def test_deprecated_gpr() -> None:
     gpr1 = GPR.from_string("(a | b) & c")
     with pytest.deprecated_call():
         assert ast2str(gpr1) == "(a or b) and c"
     with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {})
+        assert eval_gpr(gpr1, set())
     with pytest.deprecated_call():
         assert eval_gpr(gpr1, {"a"})
     with pytest.deprecated_call():
@@ -223,7 +225,7 @@ def test_deprecated_gpr():
     with pytest.deprecated_call():
         assert ast2str(gpr1) == "(a or b) and c"
     with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {})
+        assert eval_gpr(gpr1, set())
     with pytest.deprecated_call():
         assert eval_gpr(gpr1, {"a"})
     with pytest.deprecated_call():

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 envlist = isort, black, flake8, safety, py3{6,7,8,9,10}
 
 [gh-actions]
-# We ignore flake8 for the time being because there are tons of things to fix.
 python =
-    3.6: isort, black, safety, py36
-    3.7: safety, py37
-    3.8: safety, py38
-    3.9: safety, py39
-    3.10: safety, py310
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -93,23 +93,23 @@ omit =
 
 [isort]
 skip = __init__.py
-line_length = 88
-indent = 4
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
+profile = black
 lines_after_imports = 2
 known_first_party = cobra
 known_third_party =
+    appdirs
     depinfo
+    diskcache
     future
+    httpx
     importlib_resources
     libsbml
     numpy
     optlang
     pandas
+    pydantic
     pytest
+    rich
     ruamel.yaml
     scipy
     swiglpk

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = isort, black, flake8, safety, py3{6,7,8,9,10}
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
+    3.6: install, py36
+    3.7: install, py37
+    3.8: install, py38
+    3.9: install, py39
+    3.10: install, py310
 
 [testenv]
 extras =
@@ -51,6 +51,16 @@ deps=
     safety
 commands=
     safety check --full-report
+
+[testenv:install]
+skip_install = True
+deps=
+    build
+    twine
+commands=
+    pip check {toxinidir}
+    python -m build {toxinidir}
+    twine check {toxinidir}/dist/*
 
 ################################################################################
 # Testing tools configuration                                                  #


### PR DESCRIPTION
* [X] fix #1157 
* [X] description of feature/fix
For consistency, renaming/removing genes via reaction.gene_reaction_rule will remove unused genes for the model. This is now consistent with using manipulation.modify.rename_genes.
Maintainers can decide to merge this or ignore it, depending what you want the behavior to be.