### PR TITLE
modifying the gene_reaction_rule will remove genes that are no longer used

### DIFF
--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -21,6 +21,7 @@ from cobra.core.gene import GPR, Gene
 from cobra.core.metabolite import Metabolite
 from cobra.core.object import Object
 from cobra.exceptions import OptimizationError
+from cobra.manipulation import remove_genes
 from cobra.util.context import get_context, resettable
 from cobra.util.solver import (
     check_solver_status,
@@ -426,7 +427,7 @@ class Reaction(Object):
         new_gene_names: set
         """
         if new_gene_names is None:
-            if self._gpr is not None:
+            if self._gpr.body is not None:
                 new_gene_names = self._gpr.genes
             else:
                 new_gene_names = set()
@@ -454,6 +455,8 @@ class Reaction(Object):
             if g not in self._genes:  # if an old gene is not a new gene
                 try:
                     g._reaction.remove(self)
+                    if not len(g.reactions) and self.model and g in self.model.genes:
+                        remove_genes(self.model, [g], False)
                 except KeyError:
                     warn(
                         "could not remove old gene %s from reaction %s"

--- a/src/cobra/manipulation/delete.py
+++ b/src/cobra/manipulation/delete.py
@@ -334,6 +334,7 @@ def remove_genes(
     gene_id_set = {i.id for i in gene_set}
     remover = _GeneRemover(gene_id_set)
     target_reactions = []
+    rxns_to_revisit = set()
     for rxn in model.reactions:
         if rxn.gene_reaction_rule is None or len(rxn.gene_reaction_rule) == 0:
             continue
@@ -346,7 +347,9 @@ def remove_genes(
             remover.visit(rxn.gpr)
             if "body" not in rxn.gpr.__dict__.keys():
                 rxn.gpr = GPR()
-            rxn._update_genes_from_gpr()
+                rxn._genes = set()
+            else:
+                rxns_to_revisit.add(rxn)
     for gene in gene_set:
         model.genes.remove(gene)
         # remove reference to the gene in all groups
@@ -354,3 +357,5 @@ def remove_genes(
         for group in associated_groups:
             group.remove_members(gene)
     model.remove_reactions(target_reactions)
+    for rxn in rxns_to_revisit:
+        rxn._update_genes_from_gpr()

--- a/src/cobra/test/test_core/test_core_reaction.py
+++ b/src/cobra/test/test_core/test_core_reaction.py
@@ -76,6 +76,7 @@ def test_gpr_modification(model: Model) -> None:
     # Remove old gene correctly
     assert old_gene not in reaction.genes
     assert reaction not in old_gene.reactions
+    assert old_gene not in model.genes
 
     # Add a new 'gene' to the GPR
     reaction.gene_reaction_rule = "fake_gene"


### PR DESCRIPTION
[X] fix #1157 
[X] description of feature/fix
For consistency, renaming/removing genes via reaction.gene_reaction_rule will remove unused genes for the model. This is now consistent with using manipulation.modify.rename_genes.
Maintainers can decide to merge this or ignore it, depending what you want the behavior to be.
