### PR TITLE
chore: ignore known vulnerabilities

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,9 @@ commands=
 deps=
     safety
 commands=
-    safety check --full-report
+    py36: safety check --full-report --ignore 43453 --ignore 44715 --ignore 44716 --ignore 44717
+    py37: safety check --full-report --ignore 44715 --ignore 44716 --ignore 44717
+    !py3{6,7}: safety check --full-report
 
 [testenv:install]
 skip_install = True


### PR DESCRIPTION
These are vulnerabilities in older numpy versions. Newer versions are
not available any longer for Python 3.6 & 7 thus we ignore them here.
