### PR TITLE
Change safety command, adjust timing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-    timeout-minutes: 120
+    timeout-minutes: 360
 
     steps:
     - uses: actions/checkout@v2
@@ -36,6 +36,7 @@ jobs:
     - name: Test with tox
       run:
         tox -- --cov-report=xml --benchmark-skip
+      timeout-minutes: 60
     - name: Report coverage
       shell: bash
       run: bash <(curl -s https://codecov.io/bash)

--- a/tox.ini
+++ b/tox.ini
@@ -50,9 +50,7 @@ commands=
 deps=
     safety
 commands=
-    py36: safety check --full-report --ignore 43453 --ignore 44715 --ignore 44716 --ignore 44717
-    py37: safety check --full-report --ignore 44715 --ignore 44716 --ignore 44717
-    !py3{6,7}: safety check --full-report
+    safety check --full-report --ignore 43453 --ignore 44715 --ignore 44716 --ignore 44717
 
 [testenv:install]
 skip_install = True


### PR DESCRIPTION
* Tox configuration for safety didn't work out the way I planned so I propose to just always ignore the numpy vulnerabilities
* We've had a lot of CI action lately and problems with queuing (especially Mac nodes) so I propose
    * to increase the workflow time to the maximum possible 360 minutes
    * limit the test suite step to an hour

My reason being that I can see GLPK getting stuck on specific solutions somewhat randomly. 60 minutes is already generous. The tests should run in a few minutes really.