### PR TITLE
make model.copy() handle GPRs correctly

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+`model.copy()` will now correctly copy GPRs.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -602,6 +602,10 @@ class GPR(Module):
         """Copy a GPR."""
         return deepcopy(self)
 
+    def __copy__(self) -> "GPR":
+        """Ensure a correct shallow copy."""
+        return self.copy()
+
     def __repr__(self) -> str:
         """Return the GPR with module, class, and code to recreate it."""
         return (
@@ -778,6 +782,7 @@ class GPR(Module):
             if isinstance(self_symb, Symbol) or isinstance(other_symb, Symbol):
                 return False
             return self_symb.equals(other_symb)
+
 
 
 def eval_gpr(expr: Union[Expression, GPR], knockouts: Union[DictList, set]) -> bool:

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -784,7 +784,6 @@ class GPR(Module):
             return self_symb.equals(other_symb)
 
 
-
 def eval_gpr(expr: Union[Expression, GPR], knockouts: Union[DictList, set]) -> bool:
     """Evaluate compiled ast of gene_reaction_rule with knockouts.
 

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -378,16 +378,15 @@ def test_gpr_symbolism_benchmark(large_model, benchmark):
     benchmark(gpr_symbolic)
 
 
-def test_gpr_equality_benchmark(medium_model, benchmark):
+def test_gpr_equality_benchmark(model, benchmark):
     """Benchmark equality of GPR using the mini model."""
-    model = medium_model.copy()
+    model2 = model.copy()
 
     def gpr_equality_all_reactions():
         for i in range(len(model.reactions)):
             rxn1 = model.reactions[i]
-            for j in range(i + 1, len(model.reactions)):
-                rxn2 = model.reactions[j]
-                assert rxn1.gpr == rxn2.gpr
+            rxn2 = model2.reactions[i]
+            assert rxn1.gpr == rxn2.gpr
 
     benchmark(gpr_equality_all_reactions)
 

--- a/src/cobra/test/test_core/test_model.py
+++ b/src/cobra/test/test_core/test_model.py
@@ -491,6 +491,9 @@ def test_copy(model):
     assert model_copy.annotation is not model.annotation
     assert len(model.reactions) == len(model_copy.reactions)
     assert len(model.metabolites) == len(model_copy.metabolites)
+    # test if GPRs are copied by content but not by reference
+    assert model.reactions[0].gpr == model_copy.reactions[0].gpr
+    assert id(model.reactions[0].gpr.body) != id(model_copy.reactions[0].gpr.body)
     model_copy.remove_reactions(model_copy.reactions[0:5])
     assert old_reaction_count == len(model.reactions)
     assert len(model.reactions) != len(model_copy.reactions)


### PR DESCRIPTION
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This ensures that GPRs are handled correctly in `model.copy()`. Prior to this the copy would leave a dangling reference to the old GPR body.

I also fixed one banchmark test for GRPs which was set up to fail and way too slow.