### PR TITLE
Fix copying

### DIFF
--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -1118,7 +1118,7 @@ class Model(Object):
             for gene in self.genes:
                 gene._reaction.clear()
             for rxn in self.reactions:
-                rxn._update_genes_from_gpr()
+                rxn.update_genes_from_gpr()
                 for met in rxn._metabolites:
                     met._reaction.add(rxn)
 

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -17,11 +17,7 @@ from cobra.core.metabolite import Metabolite
 from cobra.core.object import Object
 from cobra.core.reaction import Reaction
 from cobra.core.solution import get_solution
-from cobra.medium import (
-    find_boundary_types,
-    find_external_compartment,
-    sbo_terms,
-)
+from cobra.medium import find_boundary_types, find_external_compartment, sbo_terms
 from cobra.util.context import HistoryManager, get_context, resettable
 from cobra.util.solver import (
     add_cons_vars_to_problem,

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -590,7 +590,7 @@ class Reaction(Object):
         """
         return frozenset(self._genes)
 
-    def _update_genes_from_gpr(self, new_gene_names: Optional[Set] = None) -> None:
+    def update_genes_from_gpr(self, new_gene_names: Optional[Set] = None) -> None:
         """Update genes of reation based on GPR.
 
         Parameters
@@ -668,7 +668,7 @@ class Reaction(Object):
             warn("Context management not implemented for gene reaction rules.")
 
         self._gpr = GPR.from_string(new_rule)
-        self._update_genes_from_gpr()
+        self.update_genes_from_gpr()
 
     @property
     def gene_name_reaction_rule(self):
@@ -708,7 +708,7 @@ class Reaction(Object):
         cobra.core.gene.GPR()
         """
         self._gpr = value
-        self._update_genes_from_gpr()
+        self.update_genes_from_gpr()
 
     @property
     def functional(self) -> bool:

--- a/src/cobra/manipulation/delete.py
+++ b/src/cobra/manipulation/delete.py
@@ -358,4 +358,4 @@ def remove_genes(
             group.remove_members(gene)
     model.remove_reactions(target_reactions)
     for rxn in rxns_to_revisit:
-        rxn._update_genes_from_gpr()
+        rxn.update_genes_from_gpr()


### PR DESCRIPTION
* [X] fix #1179 
* [X] description of feature/fix
Copying should use reaction.update_genes_from_gpr() instead of the private ._genes.
update_genes_from_gpr() should have context.
