### PR TITLE
Fix bounds setting in matlab reader

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -6,6 +6,9 @@
 
 `model.copy()` will now correctly copy GPRs.
 
+Fixed an error where matlab models can not be read if their bounds exceed the configuration
+default in some cases.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/io/mat.py
+++ b/src/cobra/io/mat.py
@@ -325,8 +325,7 @@ def from_mat_struct(
     for i, name in enumerate(m["rxns"][0, 0]):
         new_reaction = Reaction()
         new_reaction.id = str(name[0][0])
-        new_reaction.lower_bound = float(m["lb"][0, 0][i][0])
-        new_reaction.upper_bound = float(m["ub"][0, 0][i][0])
+        new_reaction.bounds = float(m["lb"][0, 0][i][0]), float(m["ub"][0, 0][i][0])
         if np.isinf(new_reaction.lower_bound) and new_reaction.lower_bound < 0:
             new_reaction.lower_bound = -inf
         if np.isinf(new_reaction.upper_bound) and new_reaction.upper_bound > 0:

--- a/src/cobra/io/mat.py
+++ b/src/cobra/io/mat.py
@@ -260,7 +260,7 @@ def from_mat_struct(
 
     """
     m = mat_struct
-    print(m.dtype.names)
+
     if m.dtype.names is None or not {"rxns", "mets", "S", "lb", "ub"} <= set(
         m.dtype.names
     ):
@@ -287,7 +287,7 @@ def from_mat_struct(
 
     for i, name in enumerate(m["mets"][0, 0]):
         new_metabolite = Metabolite()
-        new_metabolite.id = str(name[0][0])
+        new_metabolite.id = str(name[0][0]).strip()
         if all(var in m.dtype.names for var in ["metComps", "comps", "compNames"]):
             comp_index = m["metComps"][0, 0][i][0] - 1
             new_metabolite.compartment = m["comps"][0, 0][comp_index][0][0]
@@ -324,7 +324,7 @@ def from_mat_struct(
     coefficients = {}
     for i, name in enumerate(m["rxns"][0, 0]):
         new_reaction = Reaction()
-        new_reaction.id = str(name[0][0])
+        new_reaction.id = str(name[0][0]).strip()
         new_reaction.bounds = float(m["lb"][0, 0][i][0]), float(m["ub"][0, 0][i][0])
         if np.isinf(new_reaction.lower_bound) and new_reaction.lower_bound < 0:
             new_reaction.lower_bound = -inf
@@ -333,17 +333,17 @@ def from_mat_struct(
         if c_vec is not None:
             coefficients[new_reaction] = float(c_vec[i][0])
         try:
-            new_reaction.gene_reaction_rule = str(m["grRules"][0, 0][i][0][0])
+            new_reaction.gene_reaction_rule = str(m["grRules"][0, 0][i][0][0]).strip()
         except (IndexError, ValueError):
             # TODO: use custom cobra exception to handle exception
             pass
         try:
-            new_reaction.name = str(m["rxnNames"][0, 0][i][0][0])
+            new_reaction.name = str(m["rxnNames"][0, 0][i][0][0]).strip()
         except (IndexError, ValueError):
             # TODO: use custom cobra exception to handle exception
             pass
         try:
-            new_reaction.subsystem = str(m["subSystems"][0, 0][i][0][0])
+            new_reaction.subsystem = str(m["subSystems"][0, 0][i][0][0]).strip()
         except (IndexError, ValueError):
             # TODO: use custom cobra exception to handle exception
             pass

--- a/src/cobra/test/test_io/test_mat.py
+++ b/src/cobra/test/test_io/test_mat.py
@@ -1,10 +1,10 @@
 """Test functionalities of I/O in MATLAB (.mat) format."""
 
+import pathlib
 from os.path import join
 from pickle import load
 from typing import TYPE_CHECKING
 
-import pathlib
 import pytest
 
 from cobra import io
@@ -68,7 +68,7 @@ def test_save_matlab_model(
 
 
 @pytest.mark.skipif(scipy is None, reason="scipy unavailable")
-def test_large_bounds(tmpdir: pathlib.Path, model: "Model"):
+def test_large_bounds(tmpdir: pathlib.Path, model: "Model") -> None:
     """Verify that mat bounds don't get broken by the config defaults."""
     model.reactions[0].bounds = -1e6, 1e6
     filepath = str(tmpdir.join("model.mat"))

--- a/src/cobra/test/test_io/test_mat.py
+++ b/src/cobra/test/test_io/test_mat.py
@@ -4,6 +4,7 @@ from os.path import join
 from pickle import load
 from typing import TYPE_CHECKING
 
+import pathlib
 import pytest
 
 from cobra import io
@@ -53,7 +54,7 @@ def test_load_matlab_model(
 #                            "raven.mat")])
 # TODO: wait for pytest.fixture_request() to get approved
 def test_save_matlab_model(
-    tmpdir: str, mini_model: "Model", raven_model: "Model"
+    tmpdir: pathlib.Path, mini_model: "Model", raven_model: "Model"
 ) -> None:
     """Test the writing of MAT model."""
     mini_output_file = tmpdir.join("mini.mat")
@@ -64,3 +65,13 @@ def test_save_matlab_model(
     io.save_matlab_model(raven_model, str(raven_output_file))
     assert mini_output_file.check()
     assert raven_output_file.check()
+
+
+@pytest.mark.skipif(scipy is None, reason="scipy unavailable")
+def test_large_bounds(tmpdir: pathlib.Path, model: "Model"):
+    """Verify that mat bounds don't get broken by the config defaults."""
+    model.reactions[0].bounds = -1e6, 1e6
+    filepath = str(tmpdir.join("model.mat"))
+    io.save_matlab_model(model, filepath)
+    read = io.load_matlab_model(filepath)
+    assert read.reactions[0].bounds == (-1e6, 1e6)


### PR DESCRIPTION
* [X] fix #1194 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This fixes a bug where bound setting can thrown an error in reading matlab models due to the bounds validation clashing with the configuration defaults bounds. For instance, if the rxn bounds in the matlab file are 10000, 20000 this would crash due the lower bounds being set first and exceeding the default upper bound of 1000. 

This seems to also affect the JSON, dict and potentially the SBML (?) loader. So we should check there as well.  

This PR includes an additional fix to strip whitespace from IDs in order to fix #1194.
