### PR TITLE
fix bug in GPR.from_string()

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,7 +9,15 @@
 Fixed an error where matlab models can not be read if their bounds exceed the configuration
 default in some cases.
 
+Fixed some bugs in GPR().from_string() where it was using the unmodified string, 
+leading to errors with GPRs that should work. Made GPRs that have empty parenthesis 
+fail more comprehensibly.
+
 ## Other
+
+Added two tests for GPR fixes
+test_gpr_wrong_input()
+test_gpr_that_needs_two_replacements()
 
 ## Deprecated features
 

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -253,46 +253,6 @@ class Gene(Species):
             if not reaction.functional:
                 reaction.bounds = (0, 0)
 
-    def remove_from_model(
-        self, model: "Model" = None, make_dependent_reactions_nonfunctional: bool = True
-    ) -> None:
-        """Remove the association of gene from a model.
-
-        Parameters
-        ----------
-        model : cobra model
-           The model to remove the gene from
-        make_dependent_reactions_nonfunctional : bool
-           If True then replace the gene with 'False' in the gene
-           association, else replace the gene with 'True'
-
-
-        .. deprecated :: 0.4
-            Use cobra.manipulation.delete_model_genes to simulate knockouts
-            and cobra.manipulation.remove_genes to remove genes from
-            the model.
-
-        """
-        logger.warning(
-            "Use cobra.manipulation.remove_genes instead to remove genes "
-            "from the model."
-        )
-        logger.warning(
-            "Use cobra.manipulation.delete_model_genes to simulate knockouts."
-        )
-        if model is not None:
-            if model != self._model:
-                raise Exception(
-                    f"{repr(self)} is a member of {repr(self._model)}, "
-                    f"not {repr(model)}"
-                )
-        if self._model is None:
-            raise Exception(f"{repr(self)} is not in a model")
-        from cobra.manipulation import remove_genes
-
-        remove_genes(self._model, [self])
-        self._model = None
-
     def _repr_html_(self):
         return f"""
         <table>

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -183,9 +183,10 @@ def parse_gpr(str_expr: str) -> Tuple:
     Use GPR(string_gpr=str_expr) in the future. Because of the GPR() class,
     this function will be removed.
     """
-    logger.warning(
+    warn(
         "parse_gpr() will be removed soon."
         "Use GPR(string_gpr=str_expr) in the future",
+        DeprecationWarning,
     )
     gpr_tree = GPR.from_string(str_expr)
     return gpr_tree, gpr_tree.genes
@@ -394,10 +395,13 @@ class GPR(Module):
             if "AND" in escaped_str or "OR" in escaped_str:
                 # noinspection PyTypeChecker
                 logger.warning(
-                    f"Uppercase AND/OR found in rule '{string_gpr}'.", exc_info=1
+                    f"Uppercase AND/OR found in rule '{string_gpr}'.",
                 )
                 logger.warning(e.msg)
-                warn(f"Uppercase AND/OR found in rule '{string_gpr}'.", SyntaxWarning)
+                warn(
+                    "Uppercase AND/OR found in rule '{}'.".format(string_gpr),
+                    SyntaxWarning,
+                )
                 escaped_str = uppercase_AND.sub("and", escaped_str)
                 escaped_str = uppercase_OR.sub("or", escaped_str)
             try:
@@ -409,7 +413,10 @@ class GPR(Module):
                     exc_info=1,
                 )
                 logger.warning("GPR will be empty")
-                warn(f"Malformed gene_reaction_rule '{escaped_str}'", SyntaxWarning)
+                warn(
+                    "Malformed gene_reaction_rule '{}'".format(escaped_str),
+                    SyntaxWarning,
+                )
                 return gpr
         gpr = cls(tree)
         gpr.update_genes()
@@ -742,7 +749,6 @@ class GPR(Module):
         except SyntaxError as e:
             logger.warning(
                 f"Problem with sympy expression '{sympy_gpr}' for {repr(gpr)}",
-                SyntaxWarning,
             )
             logger.warning("GPR will be empty")
             logger.warning(e.msg)
@@ -787,8 +793,9 @@ def eval_gpr(expr: Union[Expression, GPR], knockouts: Union[DictList, set]) -> b
         True if the gene reaction rule is true with the given knockouts
         otherwise false
     """
-    logger.warning(
+    warn(
         "eval_gpr() will be removed soon." "Use GPR().eval(knockouts) in the future",
+        DeprecationWarning,
     )
     if isinstance(expr, GPR):
         return expr.eval(knockouts=knockouts)
@@ -821,8 +828,9 @@ def ast2str(expr: Union[Expression, GPR], level: int = 0, names: dict = None) ->
     Use GPR.to_string(names=) in the future. Because of the GPR() class,
     this function will be removed.
     """
-    logger.warning(
+    warn(
         "ast2satr() will be removed soon. Use gpr.to_string(names=names) in the future",
+        DeprecationWarning,
     )
     if isinstance(expr, GPR):
         return expr.to_string(names=names)

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -19,6 +19,7 @@ from ast import parse as ast_parse
 from copy import deepcopy
 from keyword import kwlist
 from typing import TYPE_CHECKING, FrozenSet, Iterable, Optional, Set, Tuple, Union
+from warnings import warn
 
 import sympy.logic.boolalg as spl
 from sympy import Symbol
@@ -185,7 +186,6 @@ def parse_gpr(str_expr: str) -> Tuple:
     logger.warning(
         "parse_gpr() will be removed soon."
         "Use GPR(string_gpr=str_expr) in the future",
-        DeprecationWarning,
     )
     gpr_tree = GPR.from_string(str_expr)
     return gpr_tree, gpr_tree.genes
@@ -396,17 +396,20 @@ class GPR(Module):
                 logger.warning(
                     f"Uppercase AND/OR found in rule '{string_gpr}'.", exc_info=1
                 )
+                logger.warning(e.msg)
+                warn(f"Uppercase AND/OR found in rule '{string_gpr}'.", SyntaxWarning)
                 escaped_str = uppercase_AND.sub("and", escaped_str)
                 escaped_str = uppercase_OR.sub("or", escaped_str)
             try:
                 tree = ast_parse(escaped_str, "<string>", "eval")
-            except SyntaxError as e:
+            except SyntaxError:
                 # noinspection PyTypeChecker
                 logger.warning(
-                    f"Malformed gene_reaction_rule '{escaped_str}' for {repr(gpr)}",
+                    f"Malformed gene_reaction_rule '{escaped_str}' for {string_gpr}",
                     exc_info=1,
                 )
                 logger.warning("GPR will be empty")
+                warn(f"Malformed gene_reaction_rule '{escaped_str}'", SyntaxWarning)
                 return gpr
         gpr = cls(tree)
         gpr.update_genes()
@@ -786,7 +789,6 @@ def eval_gpr(expr: Union[Expression, GPR], knockouts: Union[DictList, set]) -> b
     """
     logger.warning(
         "eval_gpr() will be removed soon." "Use GPR().eval(knockouts) in the future",
-        DeprecationWarning,
     )
     if isinstance(expr, GPR):
         return expr.eval(knockouts=knockouts)
@@ -821,7 +823,6 @@ def ast2str(expr: Union[Expression, GPR], level: int = 0, names: dict = None) ->
     """
     logger.warning(
         "ast2satr() will be removed soon. Use gpr.to_string(names=names) in the future",
-        DeprecationWarning,
     )
     if isinstance(expr, GPR):
         return expr.to_string(names=names)

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -217,39 +217,29 @@ def test_wrong_input_gpr_warning(test_input: str) -> None:
 
 
 def test_gpr_that_needs_two_replacements() -> None:
-    gpr1 = GPR.from_string('(591001.3.peg.1891 AND 591001.3.peg.1892 '
-                           'AND 591001.3.peg.1893)')
-    assert(len(gpr1.genes) == 3)
-    assert '591001.3.peg.1891' in gpr1.genes
-    assert '591001.3.peg.1892' in gpr1.genes
-    assert '591001.3.peg.1893' in gpr1.genes
+    gpr1 = GPR.from_string(
+        "(591001.3.peg.1891 AND 591001.3.peg.1892 " "AND 591001.3.peg.1893)"
+    )
+    assert len(gpr1.genes) == 3
+    assert "591001.3.peg.1891" in gpr1.genes
+    assert "591001.3.peg.1892" in gpr1.genes
+    assert "591001.3.peg.1893" in gpr1.genes
 
 
 def test_deprecated_gpr() -> None:
     gpr1 = GPR.from_string("(a | b) & c")
-    with pytest.deprecated_call():
-        assert ast2str(gpr1) == "(a or b) and c"
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, set())
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {"a"})
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {"b"})
-    with pytest.deprecated_call():
-        assert not eval_gpr(gpr1, {"c"})
-    with pytest.deprecated_call():
-        gpr1, genes = parse_gpr("(a | b) & c")
-        assert genes == {"a", "b", "c"}
-    with pytest.deprecated_call():
-        assert ast2str(gpr1) == "(a or b) and c"
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, set())
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {"a"})
-    with pytest.deprecated_call():
-        assert eval_gpr(gpr1, {"b"})
-    with pytest.deprecated_call():
-        assert not eval_gpr(gpr1, {"c"})
+    assert ast2str(gpr1) == "(a or b) and c"
+    assert eval_gpr(gpr1, set())
+    assert eval_gpr(gpr1, {"a"})
+    assert eval_gpr(gpr1, {"b"})
+    assert not eval_gpr(gpr1, {"c"})
+    gpr1, genes = parse_gpr("(a | b) & c")
+    assert genes == {"a", "b", "c"}
+    assert ast2str(gpr1) == "(a or b) and c"
+    assert eval_gpr(gpr1, set())
+    assert eval_gpr(gpr1, {"a"})
+    assert eval_gpr(gpr1, {"b"})
+    assert not eval_gpr(gpr1, {"c"})
 
 
 def test_gpr_as_symbolic() -> None:

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -208,12 +208,21 @@ def test_wrong_input_gpr_error(test_input: Union[list, set]) -> None:
         GPR(test_input)
 
 
-@pytest.mark.parametrize("test_input", ["a |", "a &"])
+@pytest.mark.parametrize("test_input", ["a |", "a &", "a and ()", "a or ()"])
 def test_wrong_input_gpr_warning(test_input: str) -> None:
     with pytest.warns(SyntaxWarning):
         gpr1 = GPR.from_string(test_input)
         assert gpr1.body is None
         assert len(gpr1.genes) == 0
+
+
+def test_gpr_that_needs_two_replacements() -> None:
+    gpr1 = GPR.from_string('(591001.3.peg.1891 AND 591001.3.peg.1892 '
+                           'AND 591001.3.peg.1893)')
+    assert(len(gpr1.genes) == 3)
+    assert '591001.3.peg.1891' in gpr1.genes
+    assert '591001.3.peg.1892' in gpr1.genes
+    assert '591001.3.peg.1893' in gpr1.genes
 
 
 def test_deprecated_gpr() -> None:

--- a/src/cobra/test/test_core/test_gpr.py
+++ b/src/cobra/test/test_core/test_gpr.py
@@ -218,7 +218,7 @@ def test_wrong_input_gpr_warning(test_input: str) -> None:
 
 def test_gpr_that_needs_two_replacements() -> None:
     gpr1 = GPR.from_string(
-        "(591001.3.peg.1891 AND 591001.3.peg.1892 " "AND 591001.3.peg.1893)"
+        "(591001.3.peg.1891 AND 591001.3.peg.1892 AND 591001.3.peg.1893)"
     )
     assert len(gpr1.genes) == 3
     assert "591001.3.peg.1891" in gpr1.genes
@@ -228,18 +228,29 @@ def test_gpr_that_needs_two_replacements() -> None:
 
 def test_deprecated_gpr() -> None:
     gpr1 = GPR.from_string("(a | b) & c")
-    assert ast2str(gpr1) == "(a or b) and c"
-    assert eval_gpr(gpr1, set())
-    assert eval_gpr(gpr1, {"a"})
-    assert eval_gpr(gpr1, {"b"})
-    assert not eval_gpr(gpr1, {"c"})
-    gpr1, genes = parse_gpr("(a | b) & c")
-    assert genes == {"a", "b", "c"}
-    assert ast2str(gpr1) == "(a or b) and c"
-    assert eval_gpr(gpr1, set())
-    assert eval_gpr(gpr1, {"a"})
-    assert eval_gpr(gpr1, {"b"})
-    assert not eval_gpr(gpr1, {"c"})
+    with pytest.deprecated_call():
+        assert ast2str(gpr1) == "(a or b) and c"
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, set())
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, {"a"})
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, {"b"})
+    with pytest.deprecated_call():
+        assert not eval_gpr(gpr1, {"c"})
+    with pytest.deprecated_call():
+        gpr1, genes = parse_gpr("(a | b) & c")
+        assert genes == {"a", "b", "c"}
+    with pytest.deprecated_call():
+        assert ast2str(gpr1) == "(a or b) and c"
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, set())
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, {"a"})
+    with pytest.deprecated_call():
+        assert eval_gpr(gpr1, {"b"})
+    with pytest.deprecated_call():
+        assert not eval_gpr(gpr1, {"c"})
 
 
 def test_gpr_as_symbolic() -> None:

--- a/src/cobra/test/test_core/test_model.py
+++ b/src/cobra/test/test_core/test_model.py
@@ -16,6 +16,7 @@ from optlang.symbolics import Zero
 
 from cobra.core import Group, Metabolite, Model, Reaction
 from cobra.exceptions import OptimizationError
+from cobra.manipulation.delete import remove_genes
 from cobra.util import solver as su
 from cobra.util.solver import SolverNotFound, set_objective, solvers
 
@@ -323,7 +324,7 @@ def test_remove_gene(model):
     gene_reactions = list(target_gene.reactions)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        target_gene.remove_from_model()
+        remove_genes(model, [target_gene])
     assert target_gene.model is None
 
     # Make sure the reaction was removed from the model
@@ -395,7 +396,7 @@ def test_group_loss_of_elements(model):
     remove_rxn = model.reactions[0]
     model.remove_reactions([remove_rxn])
     remove_gene = model.genes[0]
-    remove_gene.remove_from_model()
+    remove_genes(model, [remove_gene])
     assert remove_met not in group.members
     assert remove_rxn not in group.members
     assert remove_gene not in group.members


### PR DESCRIPTION
* [X] description of feature/fix
Fixed some bugs in GPR().from_string() where it was using the unmodified string, leading to errors with GPRs that should work. Made GPRs that have empty parenthesis fail more comprehensibly.
* [X] tests added/passed
test_gpr_wrong_input()
test_gpr_that_needs_two_replacements()
* [x] add an entry to the [next release](../release-notes/next-release.md)
