### PR TITLE
fix: enable tox for `tests`

### DIFF
--- a/tests/test_manipulation/test_validate.py
+++ b/tests/test_manipulation/test_validate.py
@@ -3,10 +3,7 @@
 import pytest
 
 from cobra.core import Metabolite, Model, Reaction
-from cobra.manipulation import (
-    check_mass_balance,
-    check_metabolite_compartment_formula,
-)
+from cobra.manipulation import check_mass_balance, check_metabolite_compartment_formula
 
 
 def test_validate_mass_balance(model: Model) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -42,14 +42,14 @@ skip_install = True
 deps=
     isort
 commands=
-    isort --check-only --diff {toxinidir}/src/cobra {toxinidir}/setup.py
+    isort --check-only --diff {toxinidir}/src/cobra {toxinidir}/setup.py {toxinidir}/tests
 
 [testenv:black]
 skip_install = True
 deps=
     black
 commands=
-    black --check --diff {toxinidir}/src/cobra {toxinidir}/setup.py
+    black --check --diff {toxinidir}/src/cobra {toxinidir}/setup.py {toxinidir}/tests
 
 [testenv:flake8]
 skip_install = True
@@ -58,7 +58,7 @@ deps=
     flake8-docstrings
     flake8-bugbear
 commands=
-    flake8 {toxinidir}/src/cobra {toxinidir}/setup.py
+    flake8 {toxinidir}/src/cobra {toxinidir}/setup.py {toxinidir}/tests
 
 [testenv:safety]
 deps=


### PR DESCRIPTION
* [ ] fix #(issue number)
* [x] description of feature/fix
* [x] tests added/passed
* [ ] add an entry to the [next release](../release-notes/next-release.md)

This PR enables `tox` tests: `isort`, `black` and `flake8` for `tests/`.