### PR TITLE
Fix #1249, sparse stoichiometric matrix for mat writing

### DIFF
--- a/src/cobra/io/mat.py
+++ b/src/cobra/io/mat.py
@@ -683,7 +683,7 @@ def create_mat_dict(model: Model) -> OrderedDict:
         )
     else:
         mat["subSystems"] = _cell(rxns.list_attr("subsystem"))
-    stoich_mat = create_stoichiometric_matrix(model)
+    stoich_mat = create_stoichiometric_matrix(model, array_type="dok")
     mat["S"] = stoich_mat if stoich_mat is not None else [[]]
     # multiply by 1 to convert to float, working around scipy bug
     # https://github.com/scipy/scipy/issues/4537


### PR DESCRIPTION
Uses sparse stoichiometric matrix for mat model writing.