### PR TITLE
Fix 673

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -10,6 +10,7 @@
 of SBO:0000633 (see https://sourceforge.net/p/sbo/term-request/113/)
 * Correct reading and writing of subsystem in mat.
 * General cleanup of code in mat.py
+* Fixed issue 673 (problem when copying reaction from a different model)
 
 ## Other
 

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -899,7 +899,7 @@ class Model(Object):
             """
             if new_group.id in self.groups:
                 logger.warning(
-                    f"Ignoring group '{new_group.id}'" f" since it already exists."
+                    f"Ignoring group '{new_group.id}' since it already exists."
                 )
                 return False
             return True

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -847,13 +847,13 @@ class Model(Object):
                 reaction._model = None
 
                 for met in reaction.metabolites:
-                    if reaction in met.reactions:
+                    if reaction in met._reaction:
                         met.reaction_remove(reaction, context)
                         if remove_orphans and len(met.reactions) == 0:
                             self.remove_metabolites(met)
 
                 for gene in reaction.genes:
-                    if reaction in gene.reactions:
+                    if reaction in gene._reaction:
                         gene.reaction_remove(reaction, context)
 
                         if remove_orphans and len(gene.reactions) == 0:

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -1232,7 +1232,7 @@ class Reaction(Object):
             # Make sure metabolites being added belong to the same model, or
             # else copy them.
             if isinstance(metabolite, Metabolite):
-                if (metabolite.model is not None) and (
+                if (metabolite.model is not None) and self.model and (
                     metabolite.model is not self._model
                 ):
                     metabolite = metabolite.copy()

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -585,8 +585,8 @@ class Reaction(Object):
         """Set metabolites to a dictionary of metabolites and coefficients.
 
         Parameters
-        -------
-        metabolites: Dict[Metabolite, float]
+        ----------
+        value: Dict[Metabolite, float]
             A dictionary of cobra.Metabolite for keys and floats for coeffecieints.
             Positive coefficient means the reaction produces this metabolite, while
             negative coefficient means the reaction consumes this metabolite.
@@ -1034,7 +1034,7 @@ class Reaction(Object):
         rule2 = other.gene_reaction_rule.strip()
         if rule1 != "" and rule2 != "":
             self.gene_reaction_rule = (
-                f"({self.gene_reaction_rule}) and " f"({other.gene_reaction_rule})"
+                f"({self.gene_reaction_rule}) and ({other.gene_reaction_rule})"
             )
         elif rule1 != "" and rule2 == "":
             self.gene_reaction_rule = rule1
@@ -1247,13 +1247,12 @@ class Reaction(Object):
 
             # Make sure metabolites being added belong to the same model, or
             # else copy them.
-            if isinstance(metabolite, Metabolite):
-                if (
-                    (metabolite.model is not None)
-                    and self.model
-                    and (metabolite.model is not self._model)
-                ):
-                    metabolite = metabolite.copy()
+            if isinstance(metabolite, Metabolite) and (
+                (metabolite.model is not None)
+                and self.model
+                and (metabolite.model is not self._model)
+            ):
+                metabolite = metabolite.copy()
 
             met_id = str(metabolite)
             # If a metabolite already exists in the reaction then

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -581,7 +581,7 @@ class Reaction(Object):
 
     @metabolites.setter
     @resettable
-    def metabolites(self, value:  Dict[Metabolite, float]) -> None:
+    def metabolites(self, value: Dict[Metabolite, float]) -> None:
         """Set metabolites to a dictionary of metabolites and coefficients.
 
         Parameters
@@ -1248,8 +1248,10 @@ class Reaction(Object):
             # Make sure metabolites being added belong to the same model, or
             # else copy them.
             if isinstance(metabolite, Metabolite):
-                if (metabolite.model is not None) and self.model and (
-                    metabolite.model is not self._model
+                if (
+                    (metabolite.model is not None)
+                    and self.model
+                    and (metabolite.model is not self._model)
                 ):
                     metabolite = metabolite.copy()
 

--- a/src/cobra/core/species.py
+++ b/src/cobra/core/species.py
@@ -2,11 +2,9 @@
 
 
 from copy import deepcopy
-from functools import partial
 from typing import TYPE_CHECKING, FrozenSet, Optional
 
 from ..core.object import Object
-from ..util import HistoryManager
 
 
 if TYPE_CHECKING:
@@ -57,49 +55,31 @@ class Species(Object):
         FrozenSet
             A frozenset that includes the reactions of the species.
         """
-        if self.model and self.__class__.__name__ == "Gene":
-            return frozenset(self.model.reactions.query(lambda x: self in x, "genes"))
-        elif self.model and self.__class__.__name__ == "Metabolite":
-            return frozenset(
-                self.model.reactions.query(lambda x: self in x, "metabolites")
-            )
         return frozenset(self._reaction)
 
-    def reaction_add(
-        self, reaction: "Reaction", context: Optional[HistoryManager] = None
-    ) -> None:
+    def add_reaction(self, reaction: "Reaction") -> None:
         """Add reaction to .reaction field, with context.
 
-        If this is called with a context, will be reversed when exiting the context.
+        If this is called within a context, will be reversed when exiting the context.
 
         Parmeters
         ---------
         reaction: cobra.Reaction
-        context: HistoryManager, optional
-            context this action is in, optional (defualt None).
         """
         self._reaction.add(reaction)
-        if context:
-            context(partial(self._reaction.remove, reaction))
 
-    def reaction_remove(
-        self, reaction: "Reaction", context: Optional[HistoryManager] = None
-    ) -> None:
+    def remove_reaction(self, reaction: "Reaction") -> None:
         """Remove reaction from .reaction field, with context.
 
-        If this is called with a context, will be reversed when exiting the context.
+        If this is called within a context, will be reversed when exiting the context.
 
         Parmeters
         ---------
         reaction: cobra.Reaction
-        context: HistoryManager, optional
-            context this action is in, optional (defualt None).
         """
         self._reaction.remove(reaction)
-        if context:
-            context(partial(self._reaction.add, reaction))
 
-    def reaction_clear(self) -> None:
+    def clear_reaction(self) -> None:
         """Clear the reaction field."""
         self._reaction.clear()
 

--- a/src/cobra/core/species.py
+++ b/src/cobra/core/species.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, FrozenSet, Optional
 from ..core.object import Object
 from ..util import HistoryManager
 
+
 if TYPE_CHECKING:
     from .. import Model, Reaction
 
@@ -57,12 +58,14 @@ class Species(Object):
             A frozenset that includes the reactions of the species.
         """
         if self.model and self.__class__.__name__ == "Gene":
-            return self.model.reactions.query(lambda x: self in x, 'genes')
+            return self.model.reactions.query(lambda x: self in x, "genes")
         elif self.model and self.__class__.__name__ == "Metabolite":
-            return self.model.reactions.query(lambda x: self in x, 'metabolites')
+            return self.model.reactions.query(lambda x: self in x, "metabolites")
         return frozenset(self._reaction)
 
-    def reaction_add(self, reaction: Reaction, context: Optional[HistoryManager] = None) -> None:
+    def reaction_add(
+        self, reaction: Reaction, context: Optional[HistoryManager] = None
+    ) -> None:
         """Add reaction to .reaction field, with context.
 
         If this is called with a context, will be reversed when exiting the context.
@@ -77,7 +80,9 @@ class Species(Object):
         if context:
             context(partial(self._reaction.remove, reaction))
 
-    def reaction_remove(self, reaction: Reaction, context: Optional[HistoryManager] = None) -> None:
+    def reaction_remove(
+        self, reaction: Reaction, context: Optional[HistoryManager] = None
+    ) -> None:
         """Remove reaction from .reaction field, with context.
 
         If this is called with a context, will be reversed when exiting the context.

--- a/src/cobra/core/species.py
+++ b/src/cobra/core/species.py
@@ -62,6 +62,40 @@ class Species(Object):
             return self.model.reactions.query(lambda x: self in x, 'metabolites')
         return frozenset(self._reaction)
 
+    def reaction_add(self, reaction: Reaction, context: Optional[HistoryManager] = None) -> None:
+        """Add reaction to .reaction field, with context.
+
+        If this is called with a context, will be reversed when exiting the context.
+
+        Parmeters
+        ---------
+        reaction: cobra.Reaction
+        context: HistoryManager, optional
+            context this action is in, optional (defualt None).
+        """
+        self._reaction.add(reaction)
+        if context:
+            context(partial(self._reaction.remove, reaction))
+
+    def reaction_remove(self, reaction: Reaction, context: Optional[HistoryManager] = None) -> None:
+        """Remove reaction from .reaction field, with context.
+
+        If this is called with a context, will be reversed when exiting the context.
+
+        Parmeters
+        ---------
+        reaction: cobra.Reaction
+        context: HistoryManager, optional
+            context this action is in, optional (defualt None).
+        """
+        self._reaction.remove(reaction)
+        if context:
+            context(partial(self._reaction.add, reaction))
+
+    def reaction_clear(self) -> None:
+        """Clear the reaction field."""
+        self._reaction.clear()
+
     def __getstate__(self) -> dict:
         """Return the state of the species.
 

--- a/src/cobra/core/species.py
+++ b/src/cobra/core/species.py
@@ -58,13 +58,15 @@ class Species(Object):
             A frozenset that includes the reactions of the species.
         """
         if self.model and self.__class__.__name__ == "Gene":
-            return self.model.reactions.query(lambda x: self in x, "genes")
+            return frozenset(self.model.reactions.query(lambda x: self in x, "genes"))
         elif self.model and self.__class__.__name__ == "Metabolite":
-            return self.model.reactions.query(lambda x: self in x, "metabolites")
+            return frozenset(
+                self.model.reactions.query(lambda x: self in x, "metabolites")
+            )
         return frozenset(self._reaction)
 
     def reaction_add(
-        self, reaction: Reaction, context: Optional[HistoryManager] = None
+        self, reaction: "Reaction", context: Optional[HistoryManager] = None
     ) -> None:
         """Add reaction to .reaction field, with context.
 
@@ -81,7 +83,7 @@ class Species(Object):
             context(partial(self._reaction.remove, reaction))
 
     def reaction_remove(
-        self, reaction: Reaction, context: Optional[HistoryManager] = None
+        self, reaction: "Reaction", context: Optional[HistoryManager] = None
     ) -> None:
         """Remove reaction from .reaction field, with context.
 

--- a/src/cobra/core/species.py
+++ b/src/cobra/core/species.py
@@ -2,13 +2,14 @@
 
 
 from copy import deepcopy
+from functools import partial
 from typing import TYPE_CHECKING, FrozenSet, Optional
 
 from ..core.object import Object
-
+from ..util import HistoryManager
 
 if TYPE_CHECKING:
-    from .. import Model
+    from .. import Model, Reaction
 
 
 class Species(Object):
@@ -55,6 +56,10 @@ class Species(Object):
         FrozenSet
             A frozenset that includes the reactions of the species.
         """
+        if self.model and self.__class__.__name__ == "Gene":
+            return self.model.reactions.query(lambda x: self in x, 'genes')
+        elif self.model and self.__class__.__name__ == "Metabolite":
+            return self.model.reactions.query(lambda x: self in x, 'metabolites')
         return frozenset(self._reaction)
 
     def __getstate__(self) -> dict:

--- a/tests/test_core/test_model.py
+++ b/tests/test_core/test_model.py
@@ -1034,10 +1034,9 @@ def test_add_reactions_from_another_model(model: Model, data_directory: Path) ->
     data_directory: Path
         Directory where mini_cobra.xml is found.
     """
-    mini = read_sbml_model(data_directory / 'mini_cobra.xml')
-    mini.add_reactions([model.reactions.get_by_id('ACALD')])
-    assert len(mini.metabolites.get_by_id('acald_c').reactions) == 1
-
+    mini = read_sbml_model(data_directory / "mini_cobra.xml")
+    mini.add_reactions([model.reactions.get_by_id("ACALD")])
+    assert len(mini.metabolites.get_by_id("acald_c").reactions) == 1
 
 
 def test_add_reactions_single_existing(model: Model) -> None:


### PR DESCRIPTION
* [X] fix #673
* [X] description of feature/fix
Fix #673 by making reactions in species search the model fields, if this species is in a model.
Added checks in the code to copy the reaction if it is in a model that isn't the one it is added to.
Added properties reaction.metabolites as a settable property, added reaction_add, reaction_remove, reaction_clear to species.py, in order to minimize use of ._reaction.
* [X] tests added/passed
test_add_reactions_with_context
test_add_reactions_from_another_model
* [X] add an entry to the [next release](../release-notes/next-release.md)
