### PR TITLE
Fix recursion error in Formula.__init__

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -15,6 +15,7 @@
 * Correct reading and writing of subsystem in mat.
 * General cleanup of code in mat.py
 * fix the pandas deprecation warning in `find_external_compartment`
+* fix an issue where creating a Formula object would give a recursion error
 
 ## Other
 

--- a/src/cobra/core/formula.py
+++ b/src/cobra/core/formula.py
@@ -30,7 +30,7 @@ class Formula(Object):
         formula: str, optional
             An string that will be parsed as a formula.
         """
-        super().__init__(self, formula, **kwargs)
+        super().__init__(id=formula, **kwargs)
         self.formula = formula
         self.elements = {}
         if self.formula is not None:

--- a/tests/test_core/test_formula.py
+++ b/tests/test_core/test_formula.py
@@ -1,8 +1,8 @@
 """Test functions of formula.py ."""
 
+import pytest
 
 from cobra.core.formula import Formula
-import pytest
 
 
 def test_formula_init() -> None:
@@ -14,12 +14,11 @@ def test_formula_init() -> None:
 
 
 @pytest.mark.parametrize(
-    ["formula", "weight"],
-    [["H2O", 18.01528], ["C6H12O6", 180.15588], ["NO3", 62.0049]]
+    ["formula", "weight"], [["H2O", 18.01528], ["C6H12O6", 180.15588], ["NO3", 62.0049]]
 )
 def test_formula_weight(formula, weight) -> None:
     """Test molecular weight calculation."""
-    assert Formula(formula).weight == pytest.approx(weight)\
+    assert Formula(formula).weight == pytest.approx(weight)
 
 
 def test_formula_wrong() -> None:

--- a/tests/test_core/test_formula.py
+++ b/tests/test_core/test_formula.py
@@ -1,0 +1,29 @@
+"""Test functions of formula.py ."""
+
+
+from cobra.core.formula import Formula
+import pytest
+
+
+def test_formula_init() -> None:
+    """Test initialization."""
+    f = Formula("H2O")
+    assert "Formula H2O" in repr(f)
+    f = Formula("H2O", name="Water")
+    assert f.name == "Water"
+
+
+@pytest.mark.parametrize(
+    ["formula", "weight"],
+    [["H2O", 18.01528], ["C6H12O6", 180.15588], ["NO3", 62.0049]]
+)
+def test_formula_weight(formula, weight) -> None:
+    """Test molecular weight calculation."""
+    assert Formula(formula).weight == pytest.approx(weight)\
+
+
+def test_formula_wrong() -> None:
+    """Test incorrect formula elements."""
+    with pytest.warns(UserWarning):
+        w = Formula("NOX").weight
+        assert w is None


### PR DESCRIPTION
* [X] fix #1291 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

Fixes an incorrect `super()` call. This will allow initialization of formula object again.

```
Python 3.10.7 (main, Oct  1 2022, 04:31:04) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cobra.core.formula import Formula

In [2]: Formula("H2O")
Out[2]: <Formula H2O at 0x7f5688f87490>
```