### PR TITLE
Repair the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,4 +27,5 @@ sphinx:
 python:
    install:
    - requirements: documentation_builder/requirements.txt
-   - requirements: requirements.txt
+   - method: pip
+     path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,3 +27,4 @@ sphinx:
 python:
    install:
    - requirements: documentation_builder/requirements.txt
+   - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: documentation_builder/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: documentation_builder/requirements.txt

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -37,6 +37,7 @@ extensions = [
 ]
 # Document Python Code
 autoapi_dirs = [join(SRC_PATH, "cobra")]
+autoapi_add_toctree_entry = False
 
 # Enable typehints
 autodoc_typehints = "signature"

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -39,7 +39,7 @@ extensions = [
 autoapi_dirs = [join(SRC_PATH, "cobra")]
 
 # Enable typehints
-autodoc_typehints = 'description'
+autodoc_typehints = "signature"
 
 # Napoleon settings
 napoleon_numpy_docstring = True

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -36,7 +36,10 @@ extensions = [
     "nbsphinx",
 ]
 # Document Python Code
-autoapi_dirs = [SRC_PATH]
+autoapi_dirs = [join(SRC_PATH, "cobra")]
+
+# Enable typehints
+autodoc_typehints = 'description'
 
 # Napoleon settings
 napoleon_numpy_docstring = True

--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -49,7 +49,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "cobra"
-copyright = "2016-2019, The cobrapy core team"
+copyright = "2016-2022, The cobrapy core team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -2,7 +2,7 @@ Documentation for COBRApy
 =========================
 
 For installation instructions, please see `INSTALL.rst
-<https://github.com/opencobra/cobrapy/blob/stable/INSTALL.rst>`_.
+<https://github.com/opencobra/cobrapy/blob/devel/INSTALL.rst>`_.
 
 Many of the examples below are viewable as IPython notebooks, which can
 be viewed at `nbviewer

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -9,7 +9,7 @@ be viewed at `nbviewer
 <http://nbviewer.ipython.org/github/opencobra/cobrapy/tree/stable/documentation_builder/>`_.
 
 .. toctree::
-    :numbered:
+    :numbered: 2
     :maxdepth: 2
 
     getting_started
@@ -29,6 +29,7 @@ be viewed at `nbviewer
     dfba
     pymatbridge
     faq
+    autoapi/cobra
 
 
 Indices and tables

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -29,7 +29,6 @@ be viewed at `nbviewer
     dfba
     pymatbridge
     faq
-    _autogen/modules
 
 
 Indices and tables

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -29,7 +29,7 @@ be viewed at `nbviewer
     dfba
     pymatbridge
     faq
-    autoapi/cobra
+    /autoapi/cobra/index.rst
 
 
 Indices and tables

--- a/documentation_builder/index.rst
+++ b/documentation_builder/index.rst
@@ -9,7 +9,7 @@ be viewed at `nbviewer
 <http://nbviewer.ipython.org/github/opencobra/cobrapy/tree/stable/documentation_builder/>`_.
 
 .. toctree::
-    :numbered: 2
+    :numbered: 3
     :maxdepth: 2
 
     getting_started
@@ -29,7 +29,7 @@ be viewed at `nbviewer
     dfba
     pymatbridge
     faq
-    /autoapi/cobra/index.rst
+    API </autoapi/cobra/index.rst>
 
 
 Indices and tables

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -3,4 +3,3 @@ sphinxcontrib-napoleon
 sphinx-autoapi
 nbsphinx>=0.2.4
 ipykernel
-appdirs

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-napoleon
 sphinx-autoapi
 nbsphinx>=0.2.4
 ipykernel
+appdirs

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx~=2.2
+Sphinx~=5.3
 sphinxcontrib-napoleon
 sphinx-autoapi
 nbsphinx>=0.2.4

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+Fix automatic building of the documentation.
+
 ## Other
 
 ## Deprecated features


### PR DESCRIPTION
* [X] fix #1289, fix #1041
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This modernizes some part of the doc building and fixes the RTD builds by switching to the new `.readthedocs.yaml` which is required to pin a higher Python version (due to sympy needing Python >= 3.8). Also removes one TOC level for the API and adds type hints. 

One of the main issues was that the RTD webhook was deleted from the repo. I regenerated it, so the builds should trigger again also for the dev version.
