### PR TITLE
Fix type for SBML history dates

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -6,6 +6,9 @@
 
 Fix automatic building of the documentation.
 
+Fix an issue where SBML models with a "created" date would break lots of the cobrapy
+functionality.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -606,7 +606,7 @@ def _sbml_to_model(
         history: "libsbml.ModelHistory" = model.getModelHistory()
 
         if history.isSetCreatedDate():
-            created = history.getCreatedDate()
+            created = history.getCreatedDate().getDateAsString()
 
         c: "libsbml.ModelCreator"
         for c in history.getListCreators():

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -1237,7 +1237,7 @@ def _model_to_sbml(
 
         history: "libsbml.ModelHistory" = libsbml.ModelHistory()
         if "created" in meta and meta["created"]:
-            history.setCreatedDate(meta["created"])
+            history.setCreatedDate(libsbml.Date(meta["created"]))
         else:
             time = datetime.datetime.now()
             timestr = time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/tests/data/mini_history.xml
+++ b/tests/data/mini_history.xml
@@ -1,0 +1,1449 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" sboTerm="SBO:0000624" level="3" version="1" fbc:required="false">
+  <model metaid="meta_mini_textbook_history" id="mini_textbook" fbc:strict="true">
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#meta_mini_textbook_history">
+          <dcterms:creator>
+            <rdf:Bag>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>The COBRAPY core development team</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Diener</vCard:Family>
+                  <vCard:Given>Christian</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>mail [at] cdiener.com</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>COBRAPY core development team</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+            </rdf:Bag>
+          </dcterms:creator>
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2022-11-17T11:00:00Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2022-11-17T11:15:00Z</dcterms:W3CDTF>
+          </dcterms:modified>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfUnitDefinitions>
+      <unitDefinition id="mmol_per_gDW_per_hr">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="-3" multiplier="1"/>
+          <unit kind="gram" exponent="-1" scale="0" multiplier="1"/>
+          <unit kind="second" exponent="-1" scale="0" multiplier="3600"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="c" name="cytosol" constant="true"/>
+      <compartment id="e" name="extracellular" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="meta_M_13dpg_c" id="M_13dpg_c" name="3-Phospho-D-glyceroyl phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C3H4O10P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_13dpg_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/13dpg"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/DPG"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:20189"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01270"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00236"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3535"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29800"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00203"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00236"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_2pg_c" id="M_2pg_c" name="D-Glycerate 2-phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C3H4O7P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_2pg_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2pg"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/2-PG"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1267"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58289"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17835"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21028"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11651"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:12986"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24344"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39868"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB03391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00362"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00631"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3904"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_30485"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00631"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_3pg_c" id="M_3pg_c" name="3-Phospho-D-glycerate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C3H4O7P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_3pg_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/3pg"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/G3P"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:40016"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58272"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11879"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1657"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1659"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17050"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21029"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11882"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11880"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:12987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17794"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24345"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00807"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00197"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29728"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00169"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00197"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_adp_c" id="M_adp_c" name="ADP" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C10H12N5O10P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_adp_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/adp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/ADP"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/ADP-GROUP"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/58-64-0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13222"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16761"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2342"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22244"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:40553"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:456216"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00008"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.glycan/G11113"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3310"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_190072"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_481002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_211606"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_429160"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29370"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_196180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113581"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113582"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_114564"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_114565"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_429153"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00008"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00008"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_atp_c" id="M_atp_c" name="ATP" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C10H12N5O13P3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_atp_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/atp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/ATP"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/56-65-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:40938"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15422"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57299"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13236"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10789"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30616"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10841"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2359"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00538"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D08646"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_190078"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113592"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113593"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_114570"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29358"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_389573"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_139836"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_211579"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00002"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_dhap_c" id="M_dhap_c" name="Dihydroxyacetone phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C3H5O6P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_dhap_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/dhap"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/DIHYDROXY-ACETONE-PHOSPHATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/57-04-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57642"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14342"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16108"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5454"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24355"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39571"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01473"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB11735"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3411"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_188451"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_75970"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_390404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00095"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00111"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_f6p_c" id="M_f6p_c" name="D-Fructose 6-phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H11O9P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_f6p_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/f6p"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/FRUCTOSE-6P"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/643-13-0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57634"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:12352"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:45804"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:61527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:61553"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10375"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16084"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22768"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB03971"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05345"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3385"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00072"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC05345"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00085"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_fdp_c" id="M_fdp_c" name="D-Fructose 1,6-bisphosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C6H10O12P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_fdp_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/fdp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/FRUCTOSE-16-DIPHOSPHATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/488-69-7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32968"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:49299"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42553"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32966"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37736"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28013"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32967"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41014"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10374"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:40595"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:40591"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00354"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00290"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00354"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_g3p_c" id="M_g3p_c" name="Glyceraldehyde 3-phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C3H5O6P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_g3p_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/g3p"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/142-10-9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17138"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14333"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5446"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58027"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01112"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00661"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00118"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3930"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00661"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00118"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_g6p_c" id="M_g6p_c" name="D-Glucose 6-phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H11O9P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_g6p_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/g6p"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/D-glucose-6-phosphate"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/GLC-6-P"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/56-73-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10399"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22797"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41041"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17719"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4170"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:61548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58247"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:12375"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB03498"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB06793"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01401"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01549"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00092"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01172"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3392"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1629756"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00079"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00092"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_glc__D_e" id="M_glc__D_e" name="D-Glucose" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H12O6">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_glc__D_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glc__D"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/50-99-7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00031"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3333"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h2o_c" id="M_h2o_c" name="H2O" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h2o_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h2o"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/WATER"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/OH"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/OXONIUM"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/7732-18-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15377"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13365"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41979"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16234"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:36385"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27313"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44819"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10743"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5594"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29356"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:53442"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29375"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29374"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13419"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43228"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44292"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13352"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41981"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29412"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:33811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:33813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5585"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44701"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01039"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB02111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01328"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18714"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18712"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D06322"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D03703"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3303"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_947593"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_189422"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_141343"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113518"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1605715"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_109276"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113521"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113519"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2022884"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_351603"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29356"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15275"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC01328"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h2o_e" id="M_h2o_e" name="H2O" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h2o_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h2o"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/WATER"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/OH"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/OXONIUM"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/7732-18-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15377"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13365"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41979"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16234"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:36385"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27313"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44819"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10743"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5594"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29356"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:53442"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29375"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29374"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13419"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43228"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44292"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13352"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:41981"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29412"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:33811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:33813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5585"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44701"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01039"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB02111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01328"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18714"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18712"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D06322"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D03703"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3303"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_947593"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_189422"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_141343"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113518"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1605715"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_109276"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113521"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113519"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2022884"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_351603"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29356"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15275"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC01328"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h_c" id="M_h_c" name="H+" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="H">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PROTON"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/12408-02-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24636"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10744"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13357"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5584"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00080"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_194688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_193465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_374900"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_74722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_428040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_163953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_372511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2000349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_70106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1470067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_428548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_156540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1614597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_351626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_427899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00080"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_h_e" id="M_h_e" name="H+" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="H">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_h_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/h"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PROTON"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/12408-02-5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24636"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15378"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10744"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13357"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5584"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00080"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_194688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_193465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_374900"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_74722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_428040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_163953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_372511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2000349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_70106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1470067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_425969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_428548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_156540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_1614597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_351626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_427899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00080"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_lac__D_c" id="M_lac__D_c" name="D-Lactate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H5O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_lac__D_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lac__D"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:D-LACTATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18684"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43701"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00171"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01311"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM285"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00221"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_lac__D_e" id="M_lac__D_e" name="D-Lactate" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H5O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_lac__D_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lac__D"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:D-LACTATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18684"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:42111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43701"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00171"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01311"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM285"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00221"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_nad_c" id="M_nad_c" name="Nicotinamide adenine dinucleotide" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H26N7O14P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_nad_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/nad"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/NAD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/53-84-9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21901"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7422"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44214"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15846"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13394"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13393"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44215"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13389"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44281"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00902"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00003"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D00002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_192307"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29360"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_427523"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_194653"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00003"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00003"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_nadh_c" id="M_nadh_c" name="Nicotinamide adenine dinucleotide - reduced" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H27N7O14P2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_nadh_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/nadh"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/NADH"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/58-68-4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13395"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21902"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16908"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44216"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:57945"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:13396"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB01487"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3306"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_192305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_73473"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_194697"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29362"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00004"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_pep_c" id="M_pep_c" name="Phosphoenolpyruvate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C3H2O6P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_pep_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pep"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PHOSPHO-ENOL-PYRUVATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/138-08-9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44897"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:44894"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14812"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:8147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26055"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26054"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:58702"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18021"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00263"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00074"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3374"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29492"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_372364"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00061"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00074"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_pi_c" id="M_pi_c" name="Phosphate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="HO4P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_pi_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/Pi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PHOSPHATE-GROUP"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/CPD0-1421"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/14265-44-2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37583"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7793"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37585"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:34683"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14791"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:34855"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29137"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29139"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:63036"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26020"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39739"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32596"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43474"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:63051"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43470"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9679"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35433"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4496"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:45024"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18367"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26078"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39745"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24838"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB02142"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C13556"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C13558"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D05467"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3311"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_947590"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_109277"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2255331"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29372"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113550"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113551"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09464"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09463"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00009"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_pi_e" id="M_pi_e" name="Phosphate" compartment="e" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="HO4P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_pi_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/Pi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PHOSPHATE-GROUP"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/CPD0-1421"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/14265-44-2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37583"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7793"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37585"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:34683"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14791"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:34855"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29137"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29139"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:63036"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26020"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39739"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32596"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43474"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:63051"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:43470"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9679"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35433"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4496"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:45024"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18367"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26078"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39745"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24838"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB02142"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C13556"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C13558"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.drug/D05467"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3311"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_947590"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_109277"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_2255331"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29372"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113550"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113551"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09464"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09463"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00009"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_pyr_c" id="M_pyr_c" name="Pyruvate" compartment="c" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H3O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_pyr_c">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pyr"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/PYRUVATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/cas/127-17-3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15361"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:14987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:8685"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32816"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:45253"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26466"/>
+                  <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:26462"/>
+                  <rdf:li rdf:resource="https://identifiers.org/hmdb/HMDB00243"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/lipidmaps/LMFA01060077"/>
+                  <rdf:li rdf:resource="https://identifiers.org/pubchem.substance/3324"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_113557"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_389680"/>
+                  <rdf:li rdf:resource="https://identifiers.org/reactome/REACT_29398"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00020"/>
+                  <rdf:li rdf:resource="https://identifiers.org/unipathway.compound/UPC00022"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
+      <parameter sboTerm="SBO:0000626" id="cobra_default_ub" value="1000" constant="true"/>
+      <parameter sboTerm="SBO:0000626" id="cobra_0_bound" value="0" constant="true"/>
+      <parameter sboTerm="SBO:0000626" id="minus_inf" value="-INF" constant="true"/>
+      <parameter sboTerm="SBO:0000626" id="plus_inf" value="INF" constant="true"/>
+      <parameter sboTerm="SBO:0000625" id="R_ATPM_lower_bound" value="8.39" units="mmol_per_gDW_per_hr" constant="true"/>
+      <parameter sboTerm="SBO:0000625" id="R_EX_glc__D_e_lower_bound" value="-10" units="mmol_per_gDW_per_hr" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction metaid="meta_R_ATPM" id="R_ATPM" name="ATP maintenance requirement" reversible="false" fast="false" fbc:lowerFluxBound="R_ATPM_lower_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_ATPM">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ATPM"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_atp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h2o_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_adp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pi_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_D_LACt2" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_ENO" id="R_ENO" name="enolase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_ENO">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ENO"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_2pg_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_pep_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h2o_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_b2779"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_EX_glc__D_e" sboTerm="SBO:0000627" id="R_EX_glc__D_e" name="D-Glucose exchange" reversible="true" fast="false" fbc:lowerFluxBound="R_EX_glc__D_e_lower_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_EX_glc__D_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/glc"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_glc__D_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_h_e" sboTerm="SBO:0000627" id="R_EX_h_e" name="H+ exchange" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_EX_h_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/h"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_h_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_lac__D_e" sboTerm="SBO:0000627" id="R_EX_lac__D_e" name="D-lactate exchange" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_EX_lac__D_e">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/lac__D"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_lac__D_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_FBA" id="R_FBA" name="fructose-bisphosphate aldolase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_FBA">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FBA"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_fdp_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_dhap_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_g3p_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b1773"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b2097"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b2925"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_GAPD" id="R_GAPD" name="glyceraldehyde-3-phosphate dehydrogenase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_GAPD">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GAPD"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_g3p_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pi_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_13dpg_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_b1779"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_GLCpts" id="R_GLCpts" name="D-glucose transport via PEP:Pyr PTS" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_GLCpts">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLCpts"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_glc__D_e" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pep_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_g6p_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pyr_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_b2415"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b2417"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b1101"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b2416"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_b2415"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b2417"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b1621"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b2416"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_b2415"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b1818"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b1817"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b1819"/>
+              <fbc:geneProductRef fbc:geneProduct="G_b2416"/>
+            </fbc:and>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_H2Ot" id="R_H2Ot" name="R H2O transport via - diffusion" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_H2Ot">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/H2Ot"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_h2o_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_h2o_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b0875"/>
+            <fbc:geneProductRef fbc:geneProduct="G_s0001"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_LDH_D" sboTerm="SBO:0000375" id="R_LDH_D" name="D-lactate dehydrogenase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_LDH_D">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LDH_D"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DLACTDEHYDROGNAD-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.28"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00704"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101037"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/16369"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/16370"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/16371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/16372"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_lac__D_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pyr_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b2133"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b1380"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PFK" id="R_PFK" name="phosphofructokinase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PFK">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PFK"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_f6p_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_atp_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_adp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_fdp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b3916"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b1723"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PGI" id="R_PGI" name="glucose-6-phosphate isomerase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PGI">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PGI"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_g6p_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_f6p_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_b4025"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PGK" id="R_PGK" name="phosphoglycerate kinase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PGK">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PGK"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_3pg_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_atp_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_13dpg_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_adp_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_b2926"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PGM" id="R_PGM" name="phosphoglycerate mutase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PGM">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PGM"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_2pg_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_3pg_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b4395"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b3612"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b0755"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PIt2r" id="R_PIt2r" name="R phosphate reversible transport via - symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PIt2r">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PIt2r"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_pi_e" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_e" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pi_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b2987"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b3493"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_PYK" id="R_PYK" name="pyruvate kinase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_PYK">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PYK"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_adp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pep_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_atp_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_pyr_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_b1854"/>
+            <fbc:geneProductRef fbc:geneProduct="G_b1676"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_TPI" id="R_TPI" name="triose-phosphate isomerase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_TPI">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/TPI"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_dhap_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_g3p_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_b3919"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+    </listOfReactions>
+    <fbc:listOfObjectives fbc:activeObjective="obj">
+      <fbc:objective fbc:id="obj" fbc:type="maximize">
+        <fbc:listOfFluxObjectives>
+          <fbc:fluxObjective fbc:reaction="R_ATPM" fbc:coefficient="1"/>
+          <fbc:fluxObjective fbc:reaction="R_PFK" fbc:coefficient="1"/>
+        </fbc:listOfFluxObjectives>
+      </fbc:objective>
+    </fbc:listOfObjectives>
+    <fbc:listOfGeneProducts>
+      <fbc:geneProduct fbc:id="G_b0755" fbc:name="gpmA" fbc:label="G_b0755"/>
+      <fbc:geneProduct fbc:id="G_b0875" fbc:name="aqpZ" fbc:label="G_b0875"/>
+      <fbc:geneProduct fbc:id="G_b1101" fbc:name="ptsG" fbc:label="G_b1101"/>
+      <fbc:geneProduct fbc:id="G_b1380" fbc:name="ldhA" fbc:label="G_b1380"/>
+      <fbc:geneProduct fbc:id="G_b1621" fbc:name="malX" fbc:label="G_b1621"/>
+      <fbc:geneProduct metaid="meta_G_b1676" fbc:id="G_b1676" fbc:name="pykF" fbc:label="G_b1676">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_b1676">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1208453"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1652654"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_b1723" fbc:name="pfkB" fbc:label="G_b1723"/>
+      <fbc:geneProduct fbc:id="G_b1773" fbc:name="ydjI" fbc:label="G_b1773"/>
+      <fbc:geneProduct fbc:id="G_b1779" fbc:name="gapA" fbc:label="G_b1779"/>
+      <fbc:geneProduct fbc:id="G_b1817" fbc:name="manX" fbc:label="G_b1817"/>
+      <fbc:geneProduct fbc:id="G_b1818" fbc:name="manY" fbc:label="G_b1818"/>
+      <fbc:geneProduct fbc:id="G_b1819" fbc:name="manZ" fbc:label="G_b1819"/>
+      <fbc:geneProduct fbc:id="G_b1854" fbc:name="pykA" fbc:label="G_b1854"/>
+      <fbc:geneProduct fbc:id="G_b2097" fbc:name="fbaB" fbc:label="G_b2097"/>
+      <fbc:geneProduct fbc:id="G_b2133" fbc:name="dld" fbc:label="G_b2133"/>
+      <fbc:geneProduct fbc:id="G_b2415" fbc:name="ptsH" fbc:label="G_b2415"/>
+      <fbc:geneProduct fbc:id="G_b2416" fbc:name="ptsI" fbc:label="G_b2416"/>
+      <fbc:geneProduct fbc:id="G_b2417" fbc:name="crr" fbc:label="G_b2417"/>
+      <fbc:geneProduct metaid="meta_G_b2779" fbc:id="G_b2779" fbc:name="eno" fbc:label="G_b2779">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_b2779">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1653839"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_b2925" fbc:name="fbaA" fbc:label="G_b2925"/>
+      <fbc:geneProduct metaid="meta_G_b2926" fbc:id="G_b2926" fbc:name="pgk" fbc:label="G_b2926">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_b2926">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1653609"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_b2987" fbc:name="pitB" fbc:label="G_b2987"/>
+      <fbc:geneProduct fbc:id="G_b3493" fbc:name="pitA" fbc:label="G_b3493"/>
+      <fbc:geneProduct fbc:id="G_b3612" fbc:name="gpmM" fbc:label="G_b3612"/>
+      <fbc:geneProduct metaid="meta_G_b3916" fbc:id="G_b3916" fbc:name="pfkA" fbc:label="G_b3916">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_b3916">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1006614"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1651919"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_b3919" fbc:name="tpiA" fbc:label="G_b3919"/>
+      <fbc:geneProduct metaid="meta_G_b4025" fbc:id="G_b4025" fbc:name="pgi" fbc:label="G_b4025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_b4025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ncbiprotein/1653253"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_b4395" fbc:name="ytjC" fbc:label="G_b4395"/>
+      <fbc:geneProduct fbc:id="G_s0001" fbc:name="G_s0001" fbc:label="G_s0001"/>
+    </fbc:listOfGeneProducts>
+  </model>
+</sbml>

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from optlang.interface import OPTIMAL
 
 from cobra import Model
+from cobra.io import read_sbml_model
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_io/conftest.py
+++ b/tests/test_io/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from optlang.interface import OPTIMAL
 
 from cobra import Model
-from cobra.io import read_sbml_model
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_io/test_sbml.py
+++ b/tests/test_io/test_sbml.py
@@ -704,3 +704,13 @@ def test_stable_gprs(data_directory: Path, tmp_path: Path) -> None:
     assert (
         fixed_model.reactions.GLCpts.gene_reaction_rule == "(b2415 and b2417) or b2416"
     )
+
+
+def test_history(data_directory: Path) -> None:
+    """Test that the history is read from the model."""
+    mini = read_sbml_model(join(data_directory, "mini_history.xml"))
+    assert "creators" in mini._sbml
+    assert "organisation" in mini._sbml["creators"][0]
+    assert "created" in mini._sbml
+    assert isinstance(mini._sbml["created"], str)
+    assert "2022" in mini._sbml["created"]


### PR DESCRIPTION
* [X] fix issue [from gitter](https://gitter.im/opencobra/cobrapy?at=6363cff5a3ccb16cbe3b2b98)
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

## Current behavior

```
Python 3.10.8 (main, Nov  4 2022, 09:21:25) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from cobra.io import load_model

In [2]: mod = load_model("BIOMD0000000003")
Model does not contain SBML fbc package information.
Restricted license - for non-production use only - expires 2023-10-25
SBML package 'layout' not supported by cobrapy, information is not parsed
SBML package 'render' not supported by cobrapy, information is not parsed
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction1 "creation of cyclin">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction1 "creation of cyclin">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction2 "default degradation of cyclin">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction2 "default degradation of cyclin">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction3 "cdc2 kinase triggered degration of cyclin">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction3 "cdc2 kinase triggered degration of cyclin">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction4 "activation of cdc2 kinase">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction4 "activation of cdc2 kinase">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction5 "deactivation of cdc2 kinase">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction5 "deactivation of cdc2 kinase">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction6 "activation of cyclin protease">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction6 "activation of cyclin protease">'
Missing lower flux bound set to '-1000.0' for reaction: '<Reaction reaction7 "deactivation of cyclin protease">'
Missing upper flux bound set to '1000.0' for reaction: '<Reaction reaction7 "deactivation of cyclin protease">'
No objective coefficients in model. Unclear what should be optimized
Missing flux bounds on reactions set to default bounds.As best practise and to avoid confusion flux bounds should be set explicitly on all reactions.

In [3]: import pickle

In [4]: s = pickle.dumps(mod)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 s = pickle.dumps(mod)

TypeError: cannot pickle 'SwigPyObject' object

In [5]: mod._sbml["created"]
Out[5]: <libsbml.Date; proxy of <Swig Object of type 'Date_t *' at 0x7f3c8b80fa20> >
```

This will also affect any parallel code on Mac and Windows since those use spawn for new processes which will pickle the model.

## Fix

This PR casts the date to a Python string which fixes the behavior.