### PR TITLE
fix: set temporary upper bound for numpy version 

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,6 +9,8 @@ Fix automatic building of the documentation.
 Fix an issue where SBML models with a "created" date would break lots of the cobrapy
 functionality.
 
+Temporary fix of restricting numpy to <1.24 as that release introduces breaking changes both in cobrapy and dependencies
+
 ## Other
 
 ## Deprecated features

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
 	future
 	httpx ~=0.14
 	importlib_resources
-	numpy ~=1.13
+	numpy >=1.13,<1.24
 	optlang ~=1.5
 	pandas ~=1.0
 	pydantic ~=1.6


### PR DESCRIPTION
* [x] Sets upper numpy version bound as numpy 1.24 breaks code
* [x] temporary fix for #1305 until dependencies have caught up
* [x] tests passed except for a security warning for mpmath, which is unrelated to this PR and apparently not yet fixed
* [x] add an entry to the [next release](../release-notes/next-release.md)
