### PR TITLE
Link to docs fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ the GPL.</p>
     <div class="intro">
         <h3>Getting Help</h3>
         <p>The documentation is browsable online at
-<a href="https://cobrapy.readthedocs.org/en/stable/">readthedocs</a> and can
+<a href="https://cobrapy.readthedocs.org/en/latest/">readthedocs</a> and can
 also be
 <a href="https://readthedocs.org/projects/cobrapy/downloads/">downloaded</a>.</p>
 <p>Please use the <a href="http://groups.google.com/group/cobra-pie">Google


### PR DESCRIPTION
This is just a simple link fix for cobrapy gh pages.
