### PR TITLE
remove obsolete numpy aliases `np.bool` and `np.float`

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -5,6 +5,8 @@
 ## Fixes
 [#1300](https://github.com/opencobra/cobrapy/pull/1312)- Fixed issue where reaction bounds were being overwritten by global model min/max values when writing sbml model to file
 
+[fbc_curation #98](`runfrog` does not work via github actions or local installation)- removed use of obsolete numpy aliases for `float` and `bool`
+
 ## Other
 
 ## Deprecated features

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -3,9 +3,13 @@
 ## New features
 
 ## Fixes
-[#1300](https://github.com/opencobra/cobrapy/pull/1312)- Fixed issue where reaction bounds were being overwritten by global model min/max values when writing sbml model to file
 
-[fbc_curation #98](`runfrog` does not work via github actions or local installation)- removed use of obsolete numpy aliases for `float` and `bool`
+Fixed an issue where reaction bounds were being overwritten by global model min/max values
+when writing sbml model to file. See [#1300](https://github.com/opencobra/cobrapy/pull/1312).
+
+Fix an issue where [`runfrog`](https://github.com/matthiaskoenig/fbc_curation/issues/98) does
+not work via github actions or local installation by removing the use of obsolete numpy
+aliases for `float` and `bool`.
 
 ## Other
 

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -15,8 +15,6 @@ from typing import (
     Union,
 )
 
-import numpy as np
-
 from .object import Object
 
 

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -457,7 +457,7 @@ class DictList(list):
             selection._extend_nocheck(list.__getitem__(self, i))
             return selection
         elif hasattr(i, "__len__"):
-            if len(i) == len(self) and isinstance(i[0], (bool, np.bool)):
+            if len(i) == len(self) and isinstance(i[0], (bool, bool)):
                 selection = self.__class__()
                 result = (o for j, o in enumerate(self) if i[j])
                 selection._extend_nocheck(result)

--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -68,13 +68,13 @@ _OPTIONAL_MODEL_ATTRIBUTES = {
 
 
 def _fix_type(
-    value: Union[str, np.float, np.bool, Set, Dict]
+    value: Union[str, float, bool, Set, Dict]
 ) -> Union[str, float, bool, List, OrderedDict]:
     """Convert possible types to correct Python types.
 
     Parameters
     ----------
-    value : str, np.float, np.bool, set, dict
+    value : str, float, bool, set, dict
         The value to fix type for.
 
     Returns
@@ -86,9 +86,9 @@ def _fix_type(
     # Because numpy floats can not be pickled to json
     if isinstance(value, str):
         return str(value)
-    if isinstance(value, np.float):
+    if isinstance(value, float):
         return float(value)
-    if isinstance(value, np.bool):
+    if isinstance(value, bool):
         return bool(value)
     if isinstance(value, set):
         return list(value)


### PR DESCRIPTION
This basically fixes the following error that many people encountered:

```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'float_'?
```

Migth not work with veeery old versions of numpy but I guess that requiring
numpy>=1.20 is quite safe nowadays.


* [x] fixes an issue in fbc_curation: https://github.com/matthiaskoenig/fbc_curation/issues/98
* [x] description of feature/fix
* [ ] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)
