### PR TITLE
Remove pin for numpy

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,9 @@
 
 ## Fixes
 
+COBRApy is now compatible with the latest numpy versions and pin to a lower version 
+has been removed.
+
 ## Other
 
 ## Deprecated features

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]*)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 tag_name = {new_version}
@@ -15,7 +15,7 @@ tag_name = {new_version}
 name = cobra
 url = https://opencobra.github.io/cobrapy
 download_url = https://pypi.org/project/cobra
-project_urls = 
+project_urls =
 	Source Code = https://github.com/opencobra/cobrapy
 	Documentation = https://cobrapy.readthedocs.io
 	Bug Tracker = https://github.com/opencobra/cobrapy/issues
@@ -23,7 +23,7 @@ author = The cobrapy core development team.
 author_email = cobra-pie@googlegroups.com
 maintainer = Moritz E. Beber
 maintainer_email = moritz.beber@gmail.com
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
@@ -41,7 +41,7 @@ license = LGPL-2.0-or-later OR GPL-2.0-or-later
 description = COBRApy is a package for constraint-based modeling of metabolic networks.
 long_description = file: README.rst, INSTALL.rst
 long_description_content_type = text/x-rst
-keywords = 
+keywords =
 	metabolism
 	biology
 	constraint-based
@@ -53,14 +53,14 @@ keywords =
 
 [options]
 zip_safe = True
-install_requires = 
+install_requires =
 	appdirs ~=1.4
 	depinfo ~=1.7
 	diskcache ~=5.0
 	future
 	httpx ~=0.24
 	importlib_resources
-	numpy >=1.13,<1.24
+	numpy >=1.13
 	optlang ~=1.5
 	pandas ~=1.0
 	pydantic ~=1.6
@@ -68,24 +68,24 @@ install_requires =
 	rich >=8.0
 	ruamel.yaml ~=0.16
 	swiglpk
-tests_require = 
+tests_require =
 	tox
 packages = find:
-package_dir = 
+package_dir =
 	= src
 
 [options.packages.find]
 where = src
 
 [options.package_data]
-cobra = 
+cobra =
 	data/*
 	io/*.json
 
 [options.extras_require]
-array = 
+array =
 	scipy
-development = 
+development =
 	black
 	bumpversion
 	isort
@@ -97,7 +97,7 @@ universal = 1
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 


### PR DESCRIPTION
* [X] fix #1305 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This removes the pin for numpy. Have to make sure that is also applied to the conda package.
