### PR TITLE
gapfilling.ipynb bug fix

### DIFF
--- a/documentation_builder/gapfilling.ipynb
+++ b/documentation_builder/gapfilling.ipynb
@@ -42,19 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Scaling...\n",
-      " A: min|aij| =  1.000e+00  max|aij| =  1.000e+00  ratio =  1.000e+00\n",
-      "Problem data seem to be well scaled\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from cobra.io import load_model\n",
     "from cobra.flux_analysis import gapfill\n",
@@ -70,14 +60,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import cobra\n",
     "universal = cobra.Model(\"universal_reactions\")\n",
     "for i in [i.id for i in model.metabolites.f6p_c.reactions]:\n",
     "    reaction = model.reactions.get_by_id(i)\n",
-    "    universal.add_reaction(reaction.copy())\n",
+    "    universal.add_reactions([reaction.copy()])\n",
     "    model.remove_reactions([reaction])"
    ]
   },
@@ -90,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +90,7 @@
        "0.0"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -117,13 +108,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpshctvlc5.lp\n",
+      "Reading time = 0.02 seconds\n",
+      ": 2436 rows, 6684 columns, 24996 nonzeros\n",
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpw7ur2bdf.lp\n",
+      "Reading time = 0.00 seconds\n",
+      ": 28 rows, 30 columns, 118 nonzeros\n",
       "GF6PTA\n",
       "TALA\n"
      ]
@@ -144,13 +141,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmp1wn5o8dy.lp\n",
+      "Reading time = 0.02 seconds\n",
+      ": 2436 rows, 6684 columns, 24996 nonzeros\n",
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpa1kn_gtf.lp\n",
+      "Reading time = 0.00 seconds\n",
+      ": 28 rows, 30 columns, 118 nonzeros\n",
       "---- Run 1 ----\n",
       "GF6PTA\n",
       "TALA\n",
@@ -158,12 +161,13 @@
       "GF6PTA\n",
       "TALA\n",
       "---- Run 3 ----\n",
-      "TKT2\n",
       "GF6PTA\n",
       "FBP\n",
+      "TKT2\n",
       "---- Run 4 ----\n",
+      "F6PA\n",
       "GF6PTA\n",
-      "TALA\n"
+      "TKT2\n"
      ]
     }
    ],
@@ -184,14 +188,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "F6PA\n"
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpl9agwmnw.lp\n",
+      "Reading time = 0.02 seconds\n",
+      ": 2436 rows, 6686 columns, 24998 nonzeros\n",
+      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpw6l79cku.lp\n",
+      "Reading time = 0.00 seconds\n",
+      ": 28 rows, 30 columns, 118 nonzeros\n",
+      "PGI\n"
      ]
     }
    ],
@@ -227,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/documentation_builder/gapfilling.ipynb
+++ b/documentation_builder/gapfilling.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +90,7 @@
        "0.0"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,21 +108,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpshctvlc5.lp\n",
-      "Reading time = 0.02 seconds\n",
-      ": 2436 rows, 6684 columns, 24996 nonzeros\n",
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpw7ur2bdf.lp\n",
-      "Reading time = 0.00 seconds\n",
-      ": 28 rows, 30 columns, 118 nonzeros\n",
-      "GF6PTA\n",
-      "TALA\n"
+      "TALA\n",
+      "GF6PTA\n"
      ]
     }
    ],
@@ -141,33 +135,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmp1wn5o8dy.lp\n",
-      "Reading time = 0.02 seconds\n",
-      ": 2436 rows, 6684 columns, 24996 nonzeros\n",
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpa1kn_gtf.lp\n",
-      "Reading time = 0.00 seconds\n",
-      ": 28 rows, 30 columns, 118 nonzeros\n",
       "---- Run 1 ----\n",
-      "GF6PTA\n",
       "TALA\n",
+      "GF6PTA\n",
       "---- Run 2 ----\n",
-      "GF6PTA\n",
       "TALA\n",
+      "GF6PTA\n",
       "---- Run 3 ----\n",
-      "GF6PTA\n",
-      "FBP\n",
       "TKT2\n",
-      "---- Run 4 ----\n",
-      "F6PA\n",
       "GF6PTA\n",
-      "TKT2\n"
+      "PGI\n",
+      "---- Run 4 ----\n",
+      "TALA\n",
+      "GF6PTA\n"
      ]
     }
    ],
@@ -188,19 +175,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpl9agwmnw.lp\n",
-      "Reading time = 0.02 seconds\n",
-      ": 2436 rows, 6686 columns, 24998 nonzeros\n",
-      "Read LP format model from file /var/folders/_x/tfg8s2ks4n1ftkkwzp5sqjpc0000gn/T/tmpw6l79cku.lp\n",
-      "Reading time = 0.00 seconds\n",
-      ": 28 rows, 30 columns, 118 nonzeros\n",
       "PGI\n"
      ]
     }


### PR DESCRIPTION
Hi,
I noticed that the gapfilling.ipynb notebook in the documentation has an error in the second cell: First the reaction is not called correctly. I changed add_reaction() for add_reactions() which the correct way of calling it. Second, the argument in the add_reactions() function needs to be an iterable so I enclosed the reaction.copy() in []. Third, the cell needs to import cobra to work.

Finally, some of the output that I got in the following cells differ a little bit from what you have in the original notebook.

I hope you find these changes useful.

* [x] description of feature/fix
* [x] tests added/passed
