### PR TITLE
Improve backwards compatibility for pickled models

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,10 +4,12 @@
 
 ## Fixes
 
-COBRApy is now compatible with the latest numpy versions and pin to a lower version 
+COBRApy is now compatible with the latest numpy versions and pin to a lower version
 has been removed.
 
 ## Other
+
+Backwards compatibility for pickled models has been improved.
 
 ## Deprecated features
 

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -920,14 +920,14 @@ class Reaction(Object):
             state.pop("reaction")
         if "gene_reaction_rule" in state:
             state["_gene_reaction_rule"] = state.pop("gene_reaction_rule")
-            if "_gpr" not in state:
-                state["_gpr"] = state["_gene_reaction_rule"]
         if "lower_bound" in state:
             state["_lower_bound"] = state.pop("lower_bound")
         if "upper_bound" in state:
             state["_upper_bound"] = state.pop("upper_bound")
 
         # Used for efficient storage in newer cobrapy versions
+        if "_gpr" not in state:
+            state["_gpr"] = state["_gene_reaction_rule"]
         if type(state["_gpr"]) is str:
             state["_gpr"] = GPR.from_string(state["_gpr"])
 

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -920,6 +920,8 @@ class Reaction(Object):
             state.pop("reaction")
         if "gene_reaction_rule" in state:
             state["_gene_reaction_rule"] = state.pop("gene_reaction_rule")
+            if "_gpr" not in state:
+                state["_gpr"] = state["_gene_reaction_rule"]
         if "lower_bound" in state:
             state["_lower_bound"] = state.pop("lower_bound")
         if "upper_bound" in state:

--- a/tests/test_core/test_core_reaction.py
+++ b/tests/test_core/test_core_reaction.py
@@ -1037,3 +1037,14 @@ def test_gpr_serialization(model: Model) -> None:
     """Verify that reactions GPRs are serialized compactly as str."""
     state = model.reactions[0].__getstate__()
     assert type(state["_gpr"]) == str
+
+
+def test_gpr_serialization_backwards_compatibility(model: Model) -> None:
+    """Verify that GPR serialization is backwards compatible."""
+    state = model.reactions[0].__getstate__()
+    print(state)
+    state["gene_reaction_rule"] = state["_gpr"]  # old format
+    del state["_gpr"]
+    rxn = Reaction("test")
+    rxn.__setstate__(state)
+    assert isinstance(rxn.gpr, GPR)


### PR DESCRIPTION
* [X] fix https://github.com/micom-dev/micom/issues/121
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This now allows models with the old GPR-structure to be unpickled into the new structure. Though we don't *need* to guarantee pickle compatibility across versions of cobrapy it may help users to recover older models if those weren't saved in a different format.
