### PR TITLE
Fix broken test for utils.solver with symengine

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -1,4 +1,4 @@
-# Release notes for cobrapy x.y.z
+# Release notes for cobrapy 0.27.0
 
 ## New features
 
@@ -11,6 +11,8 @@ has been removed.
 
 `loopless_solution` now fixes the objective to its optimum as in the
 originally published method and returns the objective value in the solution object.
+
+Repair a broken test for `fix_objective_as_constraint`.
 
 ## Other
 

--- a/tests/test_util/test_solver.py
+++ b/tests/test_util/test_solver.py
@@ -118,14 +118,19 @@ def test_absolute_expression(model: "Model") -> None:
 def test_fix_objective_as_constraint(solver: str, model: "Model") -> None:
     """Test fixing present objective as a constraint."""
     model.solver = solver
+    opt = model.slim_optimize()
     with model as m:
         su.fix_objective_as_constraint(model, 1.0)
         constraint_name = m.constraints[-1]
-        assert abs(m.constraints[-1].expression - m.objective.expression) < 1e-6
+        assert (m.constraints[-1].expression - m.objective.expression).simplify() == 0
+        assert m.constraints[-1].lb == pytest.approx(opt)
     assert constraint_name not in m.constraints
     su.fix_objective_as_constraint(model)
     constraint_name = model.constraints[-1]
-    assert abs(model.constraints[-1].expression - model.objective.expression) < 1e-6
+    assert (
+        model.constraints[-1].expression - model.objective.expression
+    ).simplify() == 0
+    assert m.constraints[-1].lb == pytest.approx(opt)
     assert constraint_name in model.constraints
 
 

--- a/tests/test_util/test_solver.py
+++ b/tests/test_util/test_solver.py
@@ -120,18 +120,16 @@ def test_fix_objective_as_constraint(solver: str, model: "Model") -> None:
     model.solver = solver
     opt = model.slim_optimize()
     with model as m:
-        su.fix_objective_as_constraint(model, 1.0)
-        constraint_name = m.constraints[-1]
-        assert (m.constraints[-1].expression - m.objective.expression).simplify() == 0
-        assert m.constraints[-1].lb == pytest.approx(opt)
-    assert constraint_name not in m.constraints
-    su.fix_objective_as_constraint(model)
-    constraint_name = model.constraints[-1]
+        su.fix_objective_as_constraint(model, 1.0, name="fixed")
+        assert (m.constraints.fixed.expression - m.objective.expression).simplify() == 0
+        assert m.constraints.fixed.lb == pytest.approx(opt)
+    assert "fixed" not in m.constraints
+    su.fix_objective_as_constraint(model, name="fixed")
     assert (
-        model.constraints[-1].expression - model.objective.expression
+        model.constraints.fixed.expression - model.objective.expression
     ).simplify() == 0
-    assert m.constraints[-1].lb == pytest.approx(opt)
-    assert constraint_name in model.constraints
+    assert m.constraints.fixed.lb == pytest.approx(opt)
+    assert "fixed" in model.constraints
 
 
 @pytest.mark.parametrize("solver", optlang_solvers)


### PR DESCRIPTION
* [X] fix failing test on newer sympy versions
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

Minor change that repairs a broken test. Also, the logic of the test was a bit off and has now been corrected.