### PR TITLE
[Suggestion] drop suppport for Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     timeout-minutes: 360
 
     steps:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     timeout-minutes: 120
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
 	License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
 	Natural Language :: English
 	Operating System :: OS Independent
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
-envlist = isort, black, flake8, safety, py3{7,8,9,10,11}, coverage
+envlist = isort, black, flake8, safety, py3{8,9,10,11}, coverage
 
 [gh-actions]
 python =
-    3.6: install, py36
-    3.7: install, py37
     3.8: install, py38
     3.9: install, py39
     3.10: install, py310, coverage
@@ -65,7 +63,7 @@ commands=
 deps=
     safety
 commands=
-    safety check --full-report --ignore 43453 --ignore 44715 --ignore 44716 --ignore 44717
+    safety check --full-report
 
 [testenv:install]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = isort, black, flake8, safety, py3{8,9,10,11}, coverage
 
 [gh-actions]
 python =
-    3.8: install, py38
+    3.8: install, safety, py38
     3.9: install, py39
     3.10: install, py310, coverage
     3.11: install, py311


### PR DESCRIPTION
Python 3.7 has reached end-of-life and several vulnerabilities have been discovered in numpy and scipy that themselves no longer support 3.7.
