### PR TITLE
Enable the hybrid solver interface

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* Adds a new "hybrid" solver that exposes an HIGHS/OSQP combinations for large scale
+* Added a new "hybrid" solver that exposes an HIGHS/OSQP combinations for large scale
   LPs, MILPs, and QPs.
 
 ## Fixes

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -2,10 +2,17 @@
 
 ## New features
 
+* Adds a new "hybrid" solver that exposes an HIGHS/OSQP combinations for large scale
+  LPs, MILPs, and QPs.
+
 ## Fixes
 
 ## Other
 
 ## Deprecated features
+
+* The OSQP solver is deprecated in favor of the hybrid solver which also uses OSQP but
+  will not attempt to solve LPs with OSQP anymore. Setting the `model.solver = "osqp"`
+  will now use the hybrid interface and will raise an error in a future release.
 
 ## Backwards incompatible changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,13 @@ install_requires =
 	httpx ~=0.24
 	importlib_resources
 	numpy >=1.13
+<<<<<<< HEAD
 	optlang ~=1.5
 	pandas >=1.0,<3.0
+=======
+	optlang ~=1.8
+	pandas ~=1.0
+>>>>>>> 50e0a04b (bump optlang req)
 	pydantic >=1.6
 	python-libsbml ~=5.19
 	rich >=8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	(?P<release>[a]*)(?P<num>\d*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{num}
 	{major}.{minor}.{patch}
 tag_name = {new_version}
@@ -15,7 +15,7 @@ tag_name = {new_version}
 name = cobra
 url = https://opencobra.github.io/cobrapy
 download_url = https://pypi.org/project/cobra
-project_urls = 
+project_urls =
 	Source Code = https://github.com/opencobra/cobrapy
 	Documentation = https://cobrapy.readthedocs.io
 	Bug Tracker = https://github.com/opencobra/cobrapy/issues
@@ -23,7 +23,7 @@ author = The cobrapy core development team.
 author_email = cobra-pie@googlegroups.com
 maintainer = Moritz E. Beber
 maintainer_email = moritz.beber@gmail.com
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Science/Research
 	License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
@@ -40,7 +40,7 @@ license = LGPL-2.0-or-later OR GPL-2.0-or-later
 description = COBRApy is a package for constraint-based modeling of metabolic networks.
 long_description = file: README.rst, INSTALL.rst
 long_description_content_type = text/x-rst
-keywords = 
+keywords =
 	metabolism
 	biology
 	constraint-based
@@ -52,7 +52,7 @@ keywords =
 
 [options]
 zip_safe = True
-install_requires = 
+install_requires =
 	appdirs ~=1.4
 	depinfo ~=2.2
 	diskcache ~=5.0
@@ -60,36 +60,31 @@ install_requires =
 	httpx ~=0.24
 	importlib_resources
 	numpy >=1.13
-<<<<<<< HEAD
 	optlang ~=1.5
 	pandas >=1.0,<3.0
-=======
-	optlang ~=1.8
-	pandas ~=1.0
->>>>>>> 50e0a04b (bump optlang req)
 	pydantic >=1.6
 	python-libsbml ~=5.19
 	rich >=8.0
 	ruamel.yaml ~=0.16
 	swiglpk
-tests_require = 
+tests_require =
 	tox
 packages = find:
-package_dir = 
+package_dir =
 	= src
 
 [options.packages.find]
 where = src
 
 [options.package_data]
-cobra = 
+cobra =
 	data/*
 	io/*.json
 
 [options.extras_require]
-array = 
+array =
 	scipy
-development = 
+development =
 	black
 	bumpversion
 	isort
@@ -101,7 +96,7 @@ universal = 1
 [bumpversion:part:release]
 optional_value = placeholder
 first_value = placeholder
-values = 
+values =
 	placeholder
 	a
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
 	httpx ~=0.24
 	importlib_resources
 	numpy >=1.13
-	optlang ~=1.5
+	optlang ~=1.8
 	pandas >=1.0,<3.0
 	pydantic >=1.6
 	python-libsbml ~=5.19

--- a/src/cobra/util/solver.py
+++ b/src/cobra/util/solver.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 solvers = {
     match.split("_interface")[0]: getattr(optlang, match)
     for match in dir(optlang)
-    if "_interface" in match
+    if "_interface" in match and match != "matrix_interface"
 }
 
 # Defines all the QP solvers implemented in optlang.

--- a/src/cobra/util/solver.py
+++ b/src/cobra/util/solver.py
@@ -54,7 +54,7 @@ solvers = {
 }
 
 # Defines all the QP solvers implemented in optlang.
-qp_solvers = ["cplex", "gurobi", "osqp"]
+qp_solvers = ["cplex", "gurobi", "hybrid", "osqp"]
 
 # optlang solution statuses which still allow retrieving primal values
 has_primals = [NUMERIC, FEASIBLE, INFEASIBLE, SUBOPTIMAL, ITERATION_LIMIT, TIME_LIMIT]
@@ -252,9 +252,9 @@ def get_solver_name(mip: bool = False, qp: bool = False) -> str:
     if len(solvers) == 0:
         raise SolverNotFound("No solvers found.")
     # Those lists need to be updated as optlang implements more solvers
-    mip_order = ["gurobi", "cplex", "glpk"]
-    lp_order = ["glpk", "cplex", "gurobi"]
-    qp_order = ["gurobi", "cplex", "osqp"]
+    mip_order = ["gurobi", "cplex", "hybrid", "glpk"]
+    lp_order = ["glpk", "hybrid", "cplex", "gurobi"]
+    qp_order = ["cplex", "gurobi", "hybrid", "osqp"]
 
     if mip is False and qp is False:
         for solver_name in lp_order:

--- a/src/cobra/util/solver.py
+++ b/src/cobra/util/solver.py
@@ -54,7 +54,7 @@ solvers = {
 }
 
 # Defines all the QP solvers implemented in optlang.
-qp_solvers = ["cplex", "gurobi", "hybrid", "osqp"]
+qp_solvers = ["cplex", "gurobi", "hybrid"]
 
 # optlang solution statuses which still allow retrieving primal values
 has_primals = [NUMERIC, FEASIBLE, INFEASIBLE, SUBOPTIMAL, ITERATION_LIMIT, TIME_LIMIT]
@@ -254,7 +254,7 @@ def get_solver_name(mip: bool = False, qp: bool = False) -> str:
     # Those lists need to be updated as optlang implements more solvers
     mip_order = ["gurobi", "cplex", "hybrid", "glpk"]
     lp_order = ["glpk", "hybrid", "cplex", "gurobi"]
-    qp_order = ["cplex", "gurobi", "hybrid", "osqp"]
+    qp_order = ["cplex", "gurobi", "hybrid"]
 
     if mip is False and qp is False:
         for solver_name in lp_order:

--- a/tests/test_flux_analysis/conftest.py
+++ b/tests/test_flux_analysis/conftest.py
@@ -15,7 +15,7 @@ from cobra.util import solver as sutil
 # solutions.
 @pytest.fixture(
     scope="session",
-    params=[s for s in ["glpk", "cplex", "gurobi"] if s in sutil.solvers],
+    params=[s for s in ["glpk", "cplex", "gurobi", "hybrid"] if s in sutil.solvers],
 )
 def all_solvers(request) -> List[str]:
     """Return the avaialble solvers."""
@@ -24,7 +24,7 @@ def all_solvers(request) -> List[str]:
 
 @pytest.fixture(
     scope="session",
-    params=[s for s in ["cplex", "gurobi", "osqp"] if s in sutil.solvers],
+    params=[s for s in ["cplex", "gurobi", "hybrid"] if s in sutil.solvers],
 )
 def qp_solvers(request) -> List[str]:
     """Return the available QP solvers."""

--- a/tests/test_flux_analysis/test_deletion.py
+++ b/tests/test_flux_analysis/test_deletion.py
@@ -25,7 +25,7 @@ def test_single_gene_deletion_fba_benchmark(
 ) -> None:
     """Benchmark single gene deletion using FBA."""
     model.solver = all_solvers
-    benchmark(single_gene_deletion, model)
+    benchmark(single_gene_deletion, model, model.genes[1::10])
 
 
 def test_single_gene_deletion_fba(model: Model, all_solvers: List[str]) -> None:
@@ -187,7 +187,9 @@ def test_single_reaction_deletion_benchmark(
 ) -> None:
     """Benchmark single reaction deletion."""
     model.solver = all_solvers
-    benchmark(single_reaction_deletion, model=model, processes=1)
+    benchmark(
+        single_reaction_deletion, model=model, genes=model.genes[1::10], processes=1
+    )
 
 
 def test_single_reaction_deletion(model: Model, all_solvers) -> None:
@@ -410,7 +412,7 @@ def test_double_reaction_deletion_benchmark(
     large_model: Model, benchmark: Callable
 ) -> None:
     """Benchmark double reaction deletion."""
-    reactions = large_model.reactions[1::100]
+    reactions = large_model.reactions[100:110]
     benchmark(double_reaction_deletion, large_model, reaction_list1=reactions)
 
 

--- a/tests/test_flux_analysis/test_deletion.py
+++ b/tests/test_flux_analysis/test_deletion.py
@@ -412,7 +412,7 @@ def test_double_reaction_deletion_benchmark(
     large_model: Model, benchmark: Callable
 ) -> None:
     """Benchmark double reaction deletion."""
-    reactions = large_model.reactions[100:110]
+    reactions = large_model.reactions[100:105]
     benchmark(double_reaction_deletion, large_model, reaction_list1=reactions)
 
 

--- a/tests/test_flux_analysis/test_variability.py
+++ b/tests/test_flux_analysis/test_variability.py
@@ -26,7 +26,7 @@ def test_flux_variability_benchmark(
     benchmark(
         flux_variability_analysis,
         large_model,
-        reaction_list=large_model.reactions[1::10],
+        reaction_list=large_model.reactions[1::100],
         processes=1,
     )
 

--- a/tests/test_flux_analysis/test_variability.py
+++ b/tests/test_flux_analysis/test_variability.py
@@ -26,7 +26,7 @@ def test_flux_variability_benchmark(
     benchmark(
         flux_variability_analysis,
         large_model,
-        reaction_list=large_model.reactions[1::3],
+        reaction_list=large_model.reactions[1::10],
         processes=1,
     )
 
@@ -106,7 +106,7 @@ def test_flux_variability_loopless_benchmark(
         flux_variability_analysis,
         model,
         loopless=True,
-        reaction_list=model.reactions[1::3],
+        reaction_list=model.reactions[1::50],
     )
 
 


### PR DESCRIPTION
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This enables the hybrid solver from optlang.

## Example

```
In [1]: from cobra.io import load_model

In [2]: mod = load_model("textbook")

In [3]: mod.solver.configuration.lp_method = "auto"

In [4]: mod.solver.configuration.qp_method = "auto"

In [5]: mod.solver = "hybrid"

In [6]: mod.optimize()
Out[6]: <Solution 0.874 at 0x7f27a95d20d0>

In [7]: from cobra.medium import minimal_medium

In [8]: minimal_medium(mod, minimize_components=True, open_exchanges=True)
/home/cdiener/code/cobrapy/src/cobra/medium/minimal_medium.py:112: FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
  medium = pd.Series()
Out[8]: 
EX_fru_e       7.040736
EX_gln__L_e    0.272640
EX_pi_e        0.367870
dtype: float64

In [9]: from cobra.flux_analysis import moma

In [10]: moma(mod, linear=False)  # kind of a stupid example, just to illustrate it works
Out[10]: <Solution 0.000 at 0x7f27a8b52390>
```

## Things to consider

1. There is currently an [issue with the wheels](https://github.com/ERGO-Code/HiGHS/discussions/1441) for highspy. The wheels on PyPI only work with linux at the moment. There are some candiates [here](https://github.com/ERGO-Code/HiGHS/actions/runs/6066943604) in the artifacts. Installing from source will work on all OSs. Broken wheels are handled by optlang and if code is run on a platform with a broken highspy wheel it will not be listed as an available solver.

2. This is not specific to the hybrid interface but in some case one has to set the configuration for LP/QP methods before switching if the next solver does not support he same methods. Maybe this should be handled more gracefully in optlang by using the default and issuing a warning instead of raising an error.

3. HIGHS and OSQP only support getting the full set of primals/duals at once, so there is no good way of getting primals for only one variable. Right now, the interface will thus obtain the full solution on every solve, which makes basis recycling a bit slower. So it is not the best solver for FVA or gene deletions. 

4. Is it okay if I also fix the `minimal_medium` pandas deprecation warning here?

## Full test and benchmark results

<details>

```
===================================================== test session starts ======================================================
platform linux -- Python 3.11.6, pytest-7.3.0, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/cdiener/code/cobrapy
configfile: tox.ini
testpaths: tests
plugins: cov-4.0.0, mock-3.10.0, anyio-3.6.2, benchmark-4.0.0
collected 670 items                                                                                                            

tests/test_core/test_configuration.py ......                                                                             [  0%]
tests/test_core/test_core_reaction.py ...........s.........................................x.......                      [ 10%]
tests/test_core/test_dictlist.py ......................                                                                  [ 13%]
tests/test_core/test_formula.py .....                                                                                    [ 14%]
tests/test_core/test_gene.py .                                                                                           [ 14%]
tests/test_core/test_gpr.py .....................x..x.............................................                       [ 24%]
tests/test_core/test_group.py ..                                                                                         [ 24%]
tests/test_core/test_metabolite.py ....s..s.                                                                             [ 26%]
tests/test_core/test_model.py ...............................................................s.                          [ 35%]
tests/test_core/test_solution.py ..s                                                                                     [ 36%]
tests/test_flux_analysis/test_deletion.py ....s.....                                                                     [ 37%]
tests/test_flux_analysis/test_fastcc.py ....                                                                             [ 38%]
tests/test_flux_analysis/test_geometric.py ..                                                                            [ 38%]
tests/test_flux_analysis/test_moma.py .                                                                                  [ 38%]
tests/test_flux_analysis/test_parsimonious.py ..                                                                         [ 39%]
tests/test_flux_analysis/test_reaction.py .                                                                              [ 39%]
tests/test_flux_analysis/test_room.py ....                                                                               [ 40%]
tests/test_flux_analysis/test_variability.py .......                                                                     [ 41%]
tests/test_flux_analysis/test_deletion.py ..........                                                                     [ 42%]
tests/test_flux_analysis/test_fastcc.py ....                                                                             [ 43%]
tests/test_flux_analysis/test_geometric.py ..                                                                            [ 43%]
tests/test_flux_analysis/test_moma.py .                                                                                  [ 43%]
tests/test_flux_analysis/test_parsimonious.py ..                                                                         [ 43%]
tests/test_flux_analysis/test_reaction.py .                                                                              [ 44%]
tests/test_flux_analysis/test_room.py ....                                                                               [ 44%]
tests/test_flux_analysis/test_variability.py .......                                                                     [ 45%]
tests/test_flux_analysis/test_deletion.py ..........                                                                     [ 47%]
tests/test_flux_analysis/test_fastcc.py ....                                                                             [ 47%]
tests/test_flux_analysis/test_geometric.py ..                                                                            [ 48%]
tests/test_flux_analysis/test_moma.py .                                                                                  [ 48%]
tests/test_flux_analysis/test_parsimonious.py ..                                                                         [ 48%]
tests/test_flux_analysis/test_reaction.py .                                                                              [ 48%]
tests/test_flux_analysis/test_room.py ....                                                                               [ 49%]
tests/test_flux_analysis/test_variability.py .......                                                                     [ 50%]
tests/test_flux_analysis/test_deletion.py ...                                                                            [ 50%]
tests/test_flux_analysis/test_moma.py .                                                                                  [ 50%]
tests/test_flux_analysis/test_deletion.py ...                                                                            [ 51%]
tests/test_flux_analysis/test_moma.py .                                                                                  [ 51%]
tests/test_flux_analysis/test_deletion.py ......                                                                         [ 52%]
tests/test_flux_analysis/test_gapfilling.py .                                                                            [ 52%]
tests/test_flux_analysis/test_helpers.py ...                                                                             [ 52%]
tests/test_flux_analysis/test_loopless.py .......                                                                        [ 54%]
tests/test_flux_analysis/test_phenotype_phase_plane.py ......                                                            [ 54%]
tests/test_flux_analysis/test_variability.py .......                                                                     [ 55%]
tests/test_io/test_annotation.py ..                                                                                      [ 56%]
tests/test_io/test_annotation_format.py ..                                                                               [ 56%]
tests/test_io/test_io_order.py ...........................                                                               [ 60%]
tests/test_io/test_json.py ....                                                                                          [ 61%]
tests/test_io/test_mat.py ...............                                                                                [ 63%]
tests/test_io/test_notes.py .                                                                                            [ 63%]
tests/test_io/test_pickle.py ..                                                                                          [ 63%]
tests/test_io/test_sbml.py .ssss............xxxx.x.x..s.............                                                     [ 70%]
tests/test_io/test_yaml.py .x                                                                                            [ 70%]
tests/test_io/test_web/test_load.py .......                                                                              [ 71%]
tests/test_manipulation/test_annotate.py .                                                                               [ 71%]
tests/test_manipulation/test_delete.py .......                                                                           [ 72%]
tests/test_manipulation/test_modify.py ...                                                                               [ 72%]
tests/test_manipulation/test_validate.py ..                                                                              [ 73%]
tests/test_medium/test_boundary_types.py .........                                                                       [ 74%]
tests/test_medium/test_minimal_medium.py ..........                                                                      [ 76%]
tests/test_sampling/test_achr.py ......                                                                                  [ 77%]
tests/test_sampling/test_optgp.py ......                                                                                 [ 77%]
tests/test_sampling/test_sampling.py ..........                                                                          [ 79%]
tests/test_summary/test_metabolite_summary.py .................                                                          [ 81%]
tests/test_summary/test_model_summary.py ...............                                                                 [ 84%]
tests/test_summary/test_reaction_summary.py ...........                                                                  [ 85%]
tests/test_summary/test_metabolite_summary.py .................                                                          [ 88%]
tests/test_summary/test_model_summary.py ...............                                                                 [ 90%]
tests/test_summary/test_reaction_summary.py ....................                                                         [ 93%]
tests/test_util/test_array.py ..                                                                                         [ 93%]
tests/test_util/test_context.py ...                                                                                      [ 94%]
tests/test_util/test_process_pool.py ...............                                                                     [ 96%]
tests/test_util/test_solver.py ..................s                                                                       [ 99%]
tests/test_util/test_util.py ....                                                                                        [100%]

======================================================= warnings summary =======================================================
tests/test_core/test_gpr.py::test_and_gpr[a AND b-2-gpr_genes2-a and b]
tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_and_b_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists0]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists1]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists2]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists3]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'a AND b'.
    warn(

tests/test_core/test_gpr.py::test_or_gpr[a OR b-2-gpr_genes2-a or b]
tests/test_core/test_gpr.py::test_gpr_as_symbolic_boolean[a OR b-symbolic_gpr2]
tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_or_b_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists0]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists4]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists5]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists6]
tests/test_core/test_gpr.py::test_gpr_from_symbolic[a OR b-symbolic_gpr5]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'a OR b'.
    warn(

tests/test_core/test_gpr.py::test_complicated_gpr[(a OR b) AND c]
tests/test_core/test_gpr.py::test_gpr_as_symbolic_boolean[(a OR b) AND c-symbolic_gpr6]
tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_b_c_or_and_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists3]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists6]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists8]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists9]
tests/test_core/test_gpr.py::test_gpr_from_symbolic[(a OR b) AND c-symbolic_gpr9]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule '(a OR b) AND c'.
    warn(

tests/test_core/test_gpr.py::test_gpr_that_needs_two_replacements
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule '(591001.3.peg.1891 AND 591001.3.peg.1892 AND 591001.3.peg.1893)'.
    warn(

tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_and_b_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists0]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists1]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists2]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists3]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'b AND a'.
    warn(

tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_or_b_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists0]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists4]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists5]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists6]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'b OR a'.
    warn(

tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_b_c_or_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists1]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists4]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists7]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists8]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'a OR b or c'.
    warn(

tests/test_core/test_gpr.py::test_gpr_equality_with_bolean_logic[a_b_c_and_strs]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists2]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists5]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists7]
tests/test_core/test_gpr.py::test_gpr_inequality_boolean[gpr_lists9]
  /home/cdiener/code/cobrapy/src/cobra/core/gene.py:358: SyntaxWarning: Uppercase AND/OR found in rule 'a AND b and c'.
    warn(

tests/test_core/test_model.py::test_reaction_delete
tests/test_core/test_model.py::test_reaction_delete
  /home/cdiener/code/cobrapy/src/cobra/core/reaction.py:879: DeprecationWarning: delete is deprecated. Use reaction.remove_from_model instead
    warn(

tests/test_core/test_model.py::test_group_loss_of_elements
tests/test_flux_analysis/test_gapfilling.py::test_gapfilling
  /home/cdiener/code/cobrapy/src/cobra/core/group.py:147: UserWarning: need to pass in a list
    warn("need to pass in a list")

tests/test_core/test_model.py::test_change_objective
tests/test_core/test_model.py::test_change_objective
tests/test_core/test_model.py::test_change_objective
  /home/cdiener/code/cobrapy/src/cobra/core/reaction.py:761: DeprecationWarning: Please use reaction.flux instead.
    warn("Please use reaction.flux instead.", DeprecationWarning)

tests/test_flux_analysis/test_geometric.py: 1 warning
tests/test_io/test_json.py: 6 warnings
tests/test_io/test_mat.py: 14 warnings
tests/test_io/test_pickle.py: 2 warnings
tests/test_io/test_sbml.py: 18 warnings
tests/test_io/test_yaml.py: 2 warnings
  /home/cdiener/code/cobrapy/src/cobra/util/solver.py:554: UserWarning: Solver status is 'infeasible'.
    warn(f"Solver status is '{status}'.", UserWarning)

tests/test_medium/test_minimal_medium.py: 274 warnings
  /home/cdiener/code/cobrapy/src/cobra/medium/minimal_medium.py:112: FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
    medium = pd.Series()

tests/test_util/test_process_pool.py::test_with_context
  /home/cdiener/code/cobrapy/src/cobra/util/process_pool.py:72: PytestMockWarning: Mocks returned by pytest-mock do not need to be used as context managers. The mocker fixture automatically undoes mocking at the end of a test. This warning can be ignored if it was triggered by mocking a context manager. https://pytest-mock.readthedocs.io/en/latest/remarks.html#usage-as-context-manager
    self._pool.__enter__()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

-------------------------------------------------------------------------------------------------------------------------------- benchmark: 56 tests --------------------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                       Min                         Max                        Mean                     StdDev                     Median                         IQR            Outliers           OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_subtract_metabolite_benchmark[gurobi]                           2.2210 (1.0)               42.8750 (1.0)                2.5678 (1.0)               1.6440 (1.0)               2.4480 (1.0)                0.1160 (1.0)        25;378  389,445.0767 (1.0)        4659           1
test_subtract_metabolite_benchmark[cplex]                            2.2890 (1.03)              68.3980 (1.60)               4.1441 (1.61)              3.7591 (2.29)              3.0860 (1.26)               2.0360 (17.55)     164;171  241,305.4923 (0.62)       6378           1
test_subtract_metabolite_benchmark[glpk]                             2.3340 (1.05)              48.0570 (1.12)               4.9202 (1.92)              2.8143 (1.71)              4.5730 (1.87)               0.9762 (8.42)       29;102  203,242.1688 (0.52)       1943           1
test_change_objective_benchmark[optlang-glpk]                      120.6360 (54.32)            522.4520 (12.19)            149.3786 (58.17)            38.1732 (23.22)           132.2330 (54.02)             24.0393 (207.23)    368;368    6,694.3987 (0.02)       2601           1
test_change_objective_benchmark[optlang-cplex]                     199.1030 (89.65)            459.3160 (10.71)            223.5738 (87.07)            43.9883 (26.76)           210.1320 (85.84)             21.0570 (181.52)        4;4    4,472.7953 (0.01)         48           1
test_achr_sample_benchmark                                         240.2170 (108.16)        15,246.6630 (355.61)           383.1738 (149.23)          722.3710 (439.40)          310.4670 (126.82)           168.2637 (>1000.0)       4;7    2,609.7819 (0.01)        967           1
test_optgp_sample_benchmark                                        310.3160 (139.72)           847.1020 (19.76)            433.5972 (168.86)          118.9395 (72.35)           374.1195 (152.83)           237.7370 (>1000.0)     331;0    2,306.2878 (0.01)       1014           1
test_loopless_benchmark_after                                      785.5410 (353.69)         2,219.7130 (51.77)            892.6913 (347.65)          142.5749 (86.72)           830.3280 (339.19)           129.0415 (>1000.0)    110;64    1,120.2081 (0.00)        980           1
test_loopless_benchmark_before                                     942.2160 (424.23)         3,020.4740 (70.45)          1,182.0751 (460.35)          241.3384 (146.80)        1,117.8755 (456.65)           188.4715 (>1000.0)     61;43      845.9700 (0.00)        692           1
test_minimal_medium_mip_benchmark                                4,641.6310 (>1000.0)       10,877.9680 (253.71)         5,577.8353 (>1000.0)       1,045.6055 (636.01)        5,150.4305 (>1000.0)        1,408.0545 (>1000.0)      22;3      179.2810 (0.00)        168           1
test_minimal_medium_linear_benchmark                             4,746.4850 (>1000.0)       12,780.4260 (298.09)         6,007.7749 (>1000.0)       1,645.3141 (>1000.0)       5,223.0170 (>1000.0)        1,485.7672 (>1000.0)      12;7      166.4510 (0.00)         91           1
test_copy_benchmark[optlang-glpk]                                8,639.2220 (>1000.0)      215,628.2820 (>1000.0)       13,219.7811 (>1000.0)      22,812.2820 (>1000.0)      10,561.0590 (>1000.0)        1,718.6073 (>1000.0)       1;3       75.6442 (0.00)         81           1
test_copy_benchmark[optlang-cplex]                               8,842.8780 (>1000.0)       14,316.7610 (333.92)        10,919.7518 (>1000.0)       1,222.4106 (743.56)       10,966.1480 (>1000.0)        1,376.3210 (>1000.0)       9;1       91.5772 (0.00)         30           1
test_deepcopy_benchmark                                         15,694.4280 (>1000.0)      314,824.4660 (>1000.0)       26,095.8490 (>1000.0)      44,629.7774 (>1000.0)      18,967.8615 (>1000.0)        4,623.8495 (>1000.0)       1;1       38.3203 (0.00)         44           1
test_fastcc_benchmark[glpk]                                     18,808.2300 (>1000.0)       27,621.1050 (644.22)        20,942.8220 (>1000.0)       1,611.5068 (980.24)       20,809.4850 (>1000.0)        1,774.9317 (>1000.0)      11;1       47.7491 (0.00)         43           1
test_gpr_equality_benchmark                                     20,437.4840 (>1000.0)       25,558.5890 (596.12)        22,338.0347 (>1000.0)       1,337.4611 (813.54)       22,115.0325 (>1000.0)        1,819.1530 (>1000.0)       9;0       44.7667 (0.00)         32           1
test_single_reaction_deletion_benchmark[glpk]                   20,840.1330 (>1000.0)       24,988.4670 (582.82)        22,332.7618 (>1000.0)       1,081.6181 (657.92)       22,378.5120 (>1000.0)        1,209.3540 (>1000.0)      12;3       44.7773 (0.00)         37           1
test_single_gene_deletion_linear_moma_benchmark[glpk]           23,055.7340 (>1000.0)       38,615.4990 (900.65)        26,319.2084 (>1000.0)       3,245.1638 (>1000.0)      25,390.9915 (>1000.0)        3,970.6340 (>1000.0)       5;1       37.9951 (0.00)         30           1
test_fastcc_benchmark[cplex]                                    23,700.8330 (>1000.0)       32,639.7080 (761.28)        25,774.7391 (>1000.0)       2,181.1494 (>1000.0)      25,081.3380 (>1000.0)        2,383.9635 (>1000.0)       6;2       38.7977 (0.00)         36           1
test_single_gene_deletion_linear_room_benchmark[glpk]           25,950.2090 (>1000.0)       47,668.3800 (>1000.0)       31,951.9793 (>1000.0)       5,611.0599 (>1000.0)      31,134.1310 (>1000.0)        6,255.3290 (>1000.0)       6;1       31.2970 (0.00)         19           1
test_single_gene_deletion_moma_benchmark[cplex]                 28,314.8480 (>1000.0)       40,975.5620 (955.70)        34,476.9840 (>1000.0)       4,075.9781 (>1000.0)      33,988.3440 (>1000.0)        8,056.1982 (>1000.0)      11;0       29.0049 (0.00)         25           1
test_single_gene_deletion_linear_room_benchmark[cplex]          30,500.0670 (>1000.0)       68,856.1120 (>1000.0)       42,649.5639 (>1000.0)      10,259.0894 (>1000.0)      42,607.3730 (>1000.0)       13,912.1007 (>1000.0)       6;1       23.4469 (0.00)         17           1
test_single_gene_deletion_linear_moma_benchmark[cplex]          33,484.8950 (>1000.0)       46,683.3010 (>1000.0)       37,811.7433 (>1000.0)       4,233.0393 (>1000.0)      36,566.5220 (>1000.0)        5,082.0500 (>1000.0)       5;0       26.4468 (0.00)         22           1
test_single_reaction_deletion_benchmark[cplex]                  35,597.8390 (>1000.0)       48,411.2350 (>1000.0)       41,711.3557 (>1000.0)       4,106.7386 (>1000.0)      41,938.5000 (>1000.0)        7,516.9975 (>1000.0)       9;0       23.9743 (0.00)         24           1
test_fastcc_benchmark[hybrid]                                   43,641.5370 (>1000.0)       80,763.9400 (>1000.0)       55,096.7471 (>1000.0)       8,855.5439 (>1000.0)      53,501.7400 (>1000.0)        3,900.5073 (>1000.0)       4;4       18.1499 (0.00)         15           1
test_add_metabolite_benchmark[gurobi]                           47,171.5360 (>1000.0)       51,967.1480 (>1000.0)       48,282.8281 (>1000.0)       1,196.3889 (727.73)       47,844.2310 (>1000.0)        1,031.6945 (>1000.0)       2;2       20.7113 (0.00)         19           1
test_add_metabolite_benchmark[cplex]                            47,986.2910 (>1000.0)       60,508.3480 (>1000.0)       49,912.8654 (>1000.0)       3,083.5317 (>1000.0)      49,053.2230 (>1000.0)        1,153.1555 (>1000.0)       2;3       20.0349 (0.00)         20           1
test_add_metabolite_benchmark[glpk]                             48,359.1450 (>1000.0)       53,027.6900 (>1000.0)       49,791.9914 (>1000.0)       1,125.7087 (684.74)       49,626.0440 (>1000.0)          934.4312 (>1000.0)       5;2       20.0836 (0.00)         21           1
test_flux_variability_benchmark[cplex]                          52,722.9120 (>1000.0)       69,932.2230 (>1000.0)       58,140.0347 (>1000.0)       5,739.9571 (>1000.0)      57,816.9480 (>1000.0)        7,145.2955 (>1000.0)       1;0       17.1999 (0.00)          8           1
test_pfba_benchmark[cplex]                                      63,524.4740 (>1000.0)       75,204.5270 (>1000.0)       67,568.0630 (>1000.0)       4,581.2748 (>1000.0)      66,729.9390 (>1000.0)        5,462.4390 (>1000.0)       1;0       14.7999 (0.00)          6           1
test_single_gene_deletion_fba_benchmark[glpk]                   84,127.1660 (>1000.0)      104,777.2040 (>1000.0)       89,979.0596 (>1000.0)       6,836.7151 (>1000.0)      88,520.1590 (>1000.0)        3,514.5265 (>1000.0)       1;1       11.1137 (0.00)          7           1
test_single_gene_deletion_fba_benchmark[cplex]                  84,977.2520 (>1000.0)      115,968.7560 (>1000.0)       95,540.5132 (>1000.0)       9,283.1446 (>1000.0)      92,018.1720 (>1000.0)       12,479.2015 (>1000.0)       3;0       10.4668 (0.00)         11           1
test_single_gene_deletion_linear_moma_benchmark[hybrid]         92,090.5690 (>1000.0)      132,243.2630 (>1000.0)      100,250.8305 (>1000.0)      11,864.3636 (>1000.0)      97,044.2080 (>1000.0)        8,565.2140 (>1000.0)       1;1        9.9750 (0.00)         10           1
test_single_gene_deletion_linear_room_benchmark[hybrid]         98,121.1920 (>1000.0)      136,736.3840 (>1000.0)      111,687.3335 (>1000.0)      11,959.1933 (>1000.0)     108,055.0675 (>1000.0)       14,080.9830 (>1000.0)       3;0        8.9536 (0.00)         10           1
test_flux_variability_loopless_benchmark[cplex]                108,310.3300 (>1000.0)      147,710.6330 (>1000.0)      122,901.2899 (>1000.0)      13,485.2730 (>1000.0)     117,784.3450 (>1000.0)       20,795.1735 (>1000.0)       3;0        8.1366 (0.00)          9           1
test_achr_init_benchmark                                       109,112.3240 (>1000.0)      330,553.2910 (>1000.0)      157,740.4424 (>1000.0)      74,120.0931 (>1000.0)     120,730.6570 (>1000.0)       78,853.5793 (>1000.0)       1;1        6.3395 (0.00)          9           1
test_single_gene_deletion_fba_benchmark[hybrid]                113,241.4500 (>1000.0)      137,132.8390 (>1000.0)      121,290.4381 (>1000.0)       8,749.0715 (>1000.0)     118,673.8255 (>1000.0)       13,014.4585 (>1000.0)       2;0        8.2447 (0.00)          8           1
test_flux_variability_loopless_benchmark[glpk]                 115,074.5190 (>1000.0)      138,949.7130 (>1000.0)      128,862.1222 (>1000.0)      10,297.1189 (>1000.0)     135,734.1680 (>1000.0)       18,519.6488 (>1000.0)       2;0        7.7602 (0.00)          9           1
test_flux_variability_loopless_benchmark[hybrid]               137,314.7830 (>1000.0)      144,399.8830 (>1000.0)      139,559.4689 (>1000.0)       2,447.3373 (>1000.0)     138,523.3675 (>1000.0)        2,867.5130 (>1000.0)       2;0        7.1654 (0.00)          8           1
test_pfba_benchmark[glpk]                                      149,147.0140 (>1000.0)      171,139.6850 (>1000.0)      156,251.5560 (>1000.0)       9,017.6511 (>1000.0)     151,872.4360 (>1000.0)       11,127.5995 (>1000.0)       1;0        6.3999 (0.00)          5           1
test_geometric_fba_benchmark[cplex]                            165,014.1640 (>1000.0)      318,751.5180 (>1000.0)      211,051.4112 (>1000.0)      63,702.0079 (>1000.0)     187,517.5830 (>1000.0)       75,667.7337 (>1000.0)       1;0        4.7382 (0.00)          5           1
test_geometric_fba_benchmark[glpk]                             165,591.7880 (>1000.0)      212,340.4690 (>1000.0)      192,479.0373 (>1000.0)      18,253.2109 (>1000.0)     198,895.7325 (>1000.0)       29,966.9620 (>1000.0)       2;0        5.1954 (0.00)          6           1
test_optgp_init_benchmark                                      169,941.9070 (>1000.0)      209,082.7270 (>1000.0)      185,200.1122 (>1000.0)      14,503.3889 (>1000.0)     182,255.4230 (>1000.0)       13,667.8935 (>1000.0)       2;0        5.3996 (0.00)          5           1
test_double_gene_deletion_benchmark                            180,012.9130 (>1000.0)      223,338.0280 (>1000.0)      198,281.6172 (>1000.0)      16,851.7959 (>1000.0)     200,056.9400 (>1000.0)       23,134.4025 (>1000.0)       2;0        5.0433 (0.00)          5           1
test_gpr_symbolism_benchmark                                   184,335.1930 (>1000.0)      292,671.0500 (>1000.0)      217,380.2356 (>1000.0)      42,954.1847 (>1000.0)     204,945.9880 (>1000.0)       31,897.1125 (>1000.0)       1;1        4.6002 (0.00)          5           1
test_copy_benchmark_large_model[optlang-cplex]                 188,534.2380 (>1000.0)      453,784.6940 (>1000.0)      250,888.7276 (>1000.0)     113,911.5680 (>1000.0)     204,521.9650 (>1000.0)       83,553.1767 (>1000.0)       1;1        3.9858 (0.00)          5           1
test_pfba_benchmark[hybrid]                                    220,623.0740 (>1000.0)      606,065.1290 (>1000.0)      315,945.9808 (>1000.0)     162,754.2904 (>1000.0)     249,365.9490 (>1000.0)      103,682.9632 (>1000.0)       1;1        3.1651 (0.00)          5           1
test_copy_benchmark_large_model[optlang-glpk]                  222,081.8320 (>1000.0)      413,136.2280 (>1000.0)      294,932.2254 (>1000.0)      94,491.3229 (>1000.0)     229,418.8770 (>1000.0)      163,661.6210 (>1000.0)       1;0        3.3906 (0.00)          5           1
test_single_reaction_deletion_benchmark[hybrid]                264,429.7450 (>1000.0)      326,895.6420 (>1000.0)      295,573.7994 (>1000.0)      24,217.9928 (>1000.0)     302,236.7100 (>1000.0)       34,803.6612 (>1000.0)       2;0        3.3832 (0.00)          5           1
test_single_gene_deletion_moma_benchmark[hybrid]               308,420.1310 (>1000.0)      364,447.5200 (>1000.0)      331,691.1660 (>1000.0)      22,660.2764 (>1000.0)     333,746.7560 (>1000.0)       34,370.7205 (>1000.0)       2;0        3.0149 (0.00)          5           1
test_flux_variability_benchmark[glpk]                          316,016.0120 (>1000.0)      349,599.7290 (>1000.0)      339,069.1798 (>1000.0)      13,435.8760 (>1000.0)     342,282.6260 (>1000.0)       13,813.9683 (>1000.0)       1;0        2.9493 (0.00)          5           1
test_double_reaction_deletion_benchmark                        609,252.9860 (>1000.0)      854,443.7430 (>1000.0)      773,973.5060 (>1000.0)      97,167.3241 (>1000.0)     799,363.0170 (>1000.0)      106,056.0932 (>1000.0)       1;0        1.2920 (0.00)          5           1
test_geometric_fba_benchmark[hybrid]                         1,023,727.1270 (>1000.0)    1,658,614.1540 (>1000.0)    1,346,921.9078 (>1000.0)     292,585.9094 (>1000.0)   1,267,277.0150 (>1000.0)      541,621.3995 (>1000.0)       3;0        0.7424 (0.00)          5           1
test_flux_variability_benchmark[hybrid]                      4,857,905.6960 (>1000.0)    5,153,362.8900 (>1000.0)    5,055,272.9016 (>1000.0)     115,518.2066 (>1000.0)   5,084,840.4870 (>1000.0)      114,921.6588 (>1000.0)       1;0        0.1978 (0.00)          5           1
test_single_gene_deletion_room_benchmark[cplex]              6,066,726.0810 (>1000.0)    7,149,963.7760 (>1000.0)    6,566,601.3488 (>1000.0)     447,866.3932 (>1000.0)   6,612,153.0110 (>1000.0)      747,221.5107 (>1000.0)       2;0        0.1523 (0.00)          5           1
test_single_gene_deletion_room_benchmark[hybrid]            60,739,469.0210 (>1000.0)  170,085,329.6590 (>1000.0)  106,933,118.6170 (>1000.0)  55,809,899.5292 (>1000.0)  77,876,918.9120 (>1000.0)  105,419,248.2898 (>1000.0)       2;0        0.0094 (0.00)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
============================ 648 passed, 12 skipped, 10 xfailed, 368 warnings in 980.40s (0:16:20) =============================
```

</details>
