### PR TITLE
enable redirects for Biomodels download

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+Repaired the broken Biomodels Web IO.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/io/web/biomodels_repository.py
+++ b/src/cobra/io/web/biomodels_repository.py
@@ -89,6 +89,7 @@ class BioModels(AbstractModelRepository):
             method="GET",
             url=self._url.join(f"download/{model_id}"),
             params={"filename": model.name},
+            follow_redirects=True,
         ) as response:
             response.raise_for_status()
             task_id = self._progress.add_task(


### PR DESCRIPTION
* [X] fix #1367 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

Quick fix for broken Biomodels downloads. Simply enables redirects in `httpx.stream`.
