### PR TITLE
Use correct accessor for SBML group name

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+Fixeed a bug with SBML group parsing that affects the Debian package.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/io/sbml.py
+++ b/src/cobra/io/sbml.py
@@ -1080,7 +1080,7 @@ def _sbml_to_model(
                     if f_replace and F_REACTION in f_replace:
                         obj_id = f_replace[F_REACTION](obj_id)
                     cobra_member = cobra_model.reactions.get_by_id(obj_id)
-                    cobra_member.subsystem = group.name
+                    cobra_member.subsystem = group.getName()
                 elif typecode == libsbml.SBML_FBC_GENEPRODUCT:
                     if f_replace and F_GENE in f_replace:
                         obj_id = f_replace[F_GENE](obj_id)


### PR DESCRIPTION
* [X] fix #1302
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This just adds the Debian patch to the source directly. I am still baffled this does not fail in our CI but will fail in the Debian tests :man_shrugging: 