### PR TITLE
fix: reaction bounds in _add_cycle_free function

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+* Fixes the incorrect bounds in the CycleFree loop removal.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -112,10 +112,10 @@ def _add_cycle_free(model: "Model", fluxes: Dict[str, float]) -> None:
             rxn.bounds = (flux, flux)
             continue
         if flux >= 0:
-            rxn.bounds = max(0, rxn.lower_bound), max(flux, rxn.upper_bound)
+            rxn.bounds = max(0, rxn.lower_bound), min(flux, rxn.upper_bound)
             objective_vars.append(rxn.forward_variable)
         else:
-            rxn.bounds = min(flux, rxn.lower_bound), min(0, rxn.upper_bound)
+            rxn.bounds = max(flux, rxn.lower_bound), min(0, rxn.upper_bound)
             objective_vars.append(rxn.reverse_variable)
 
     model.objective.set_linear_coefficients({v: 1.0 for v in objective_vars})


### PR DESCRIPTION
fix: reaction bounds in _add_cycle_free function are assigned according to the description in CycleFreeFlux paper

* [x] fix #1374
* [x] description of feature/fix

In _add_cycle_free function, when the original flux is > 0, the ub is forced to be the maximum value between the flux and the reaction ub. It should be the minimum between these 2 values according to the CycleFreeFlux paper. The same happens with the lb of reactions with flux < 0. It has been modified to be the maximum between the original flux and the reaction lb.

* [x] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)
