### PR TITLE
fix(core): catch missing reduced costs and shadow prices.

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 * Fixes the incorrect bounds in the CycleFree loop removal.
+* Fixes reduced costs and shadow prices not available when using non-convex models.
 
 ## Other
 

--- a/src/cobra/core/solution.py
+++ b/src/cobra/core/solution.py
@@ -174,7 +174,15 @@ def get_solution(
     reduced = np.empty(len(reactions))
     var_primals = model.solver.primal_values
     shadow = np.empty(len(metabolites))
-    if model.solver.is_integer:
+
+    try:
+        var_duals = model.solver.reduced_costs
+        constr_duals = model.solver.shadow_prices
+        duals_available = True
+    except Exception:
+        duals_available = False
+
+    if model.solver.is_integer or not duals_available:
         reduced.fill(np.nan)
         shadow.fill(np.nan)
         for i, rxn in enumerate(reactions):


### PR DESCRIPTION
This simple code change in the `get_solution` function in `core/solution.py` catches all exceptions regarding reduced costs and shadow prices not being available. If the latest change in the downstream dependency optlang (https://github.com/opencobra/optlang/pull/259) is used here, then the general exception can be replaced with a ValueError which would be more specific and still solver agnostic. Still, `Exception` should catch GurobiErrors as well as ValueErrors and only in the case where those `RC` and `Pi` variables are actually accessed, therefore I don't deem it problematic if it would stay like that.

I ran the tests via tox and also tested both minimal working examples of issue numbers #1381 and #1372, both are now working just fine.

* [x] fix #1381
* [x] fix #1372  
* [x] description of fix
* [x] tests passed
* [x] add an entry to the [next release](../release-notes/next-release.md)
