### PR TITLE
Do not error on duplicate boundary addition

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,6 +9,7 @@
 * Fixed a bug with SBML group parsing that affects the Debian package.
 
 ## Other
+* Adding a duplicate boundary reaction (with `add_boundary`) no longer errors, but instead just returns the existing reaction.
 
 ## Deprecated features
 

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -676,7 +676,8 @@ class Model(Object):
                 "identifier. Please set the `reaction_id`."
             )
         if reaction_id in self.reactions:
-            raise ValueError(f"Boundary reaction '{reaction_id}' already exists.")
+            # It already exists so just retrieve it.
+            return self.reactions.get_by_id(reaction_id)
         name = f"{metabolite.name} {type}"
         rxn = Reaction(id=reaction_id, name=name, lower_bound=lb, upper_bound=ub)
         rxn.add_metabolites({metabolite: -1})

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -677,6 +677,7 @@ class Model(Object):
             )
         if reaction_id in self.reactions:
             # It already exists so just retrieve it.
+            logger.info(f"Boundary reaction '{reaction_id}' already exists.")
             return self.reactions.get_by_id(reaction_id)
         name = f"{metabolite.name} {type}"
         rxn = Reaction(id=reaction_id, name=name, lower_bound=lb, upper_bound=ub)

--- a/tests/test_core/test_model.py
+++ b/tests/test_core/test_model.py
@@ -489,9 +489,9 @@ def test_add_existing_boundary(
         The allowed types for boundary, see add_boundary() for types.
     """
     for metabolite in metabolites:
-        model.add_boundary(metabolite, reaction_type)
-        with pytest.raises(ValueError):
-            model.add_boundary(metabolite, reaction_type)
+        rxn_added = model.add_boundary(metabolite, reaction_type)
+        rxn_dup = model.add_boundary(metabolite, reaction_type)
+        assert rxn_dup is rxn_added
 
 
 @pytest.mark.parametrize("solver", optlang_solvers)


### PR DESCRIPTION
Fixed #1398 , it does so following the pattern of `add_metabolites` where it just ignores duplicate additions.
And gives neither error nor warning.
Which works ideally for my use case, so I think might be reasonable for others.

* [x] fix #1398 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)
