### PR TITLE
Support CARVEME and GAPSEQ external IDs

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,7 +9,10 @@
 * Fixed a bug with SBML group parsing that affects the Debian package.
 
 ## Other
+
 * Adding a duplicate boundary reaction (with `add_boundary`) no longer errors, but instead just returns the existing reaction.
+* Automatic detection of the external comprtment now recognizes CARVEME and GAPSEQ ids and will no longer
+  show a warning for models generated with those tools.
 
 ## Deprecated features
 

--- a/src/cobra/medium/annotations.py
+++ b/src/cobra/medium/annotations.py
@@ -55,6 +55,8 @@ compartment_shortlist = {
         "intracellular",
         "intracellular region",
         "intracellular space",
+        "c0",  # GAPSEQ
+        "C_c"  # CARVEME
     ],
     "er": ["endoplasmic reticulum"],
     "erm": ["endoplasmic reticulum membrane"],
@@ -68,6 +70,8 @@ compartment_shortlist = {
         "extra-organism",
         "external",
         "external medium",
+        "e0",  # GAPSEQ
+        "C_e"  # CARVEME
     ],
     "f": ["flagellum", "bacterial-type flagellum"],
     "g": ["golgi", "golgi apparatus"],
@@ -78,7 +82,12 @@ compartment_shortlist = {
     "mm": ["mitochondrial membrane"],
     "m": ["mitochondrion", "mitochondria"],
     "n": ["nucleus"],
-    "p": ["periplasm", "periplasmic space"],
+    "p": [
+        "periplasm",
+        "periplasmic space",
+        "p0",  # GAPSEQ
+        "C_p"  # CARVEME
+    ],
     "x": ["peroxisome", "glyoxysome"],
     "u": ["thylakoid"],
     "vm": ["vacuolar membrane"],

--- a/src/cobra/medium/annotations.py
+++ b/src/cobra/medium/annotations.py
@@ -56,7 +56,7 @@ compartment_shortlist = {
         "intracellular region",
         "intracellular space",
         "c0",  # GAPSEQ
-        "C_c"  # CARVEME
+        "C_c",  # CARVEME
     ],
     "er": ["endoplasmic reticulum"],
     "erm": ["endoplasmic reticulum membrane"],
@@ -71,7 +71,7 @@ compartment_shortlist = {
         "external",
         "external medium",
         "e0",  # GAPSEQ
-        "C_e"  # CARVEME
+        "C_e",  # CARVEME
     ],
     "f": ["flagellum", "bacterial-type flagellum"],
     "g": ["golgi", "golgi apparatus"],
@@ -82,12 +82,7 @@ compartment_shortlist = {
     "mm": ["mitochondrial membrane"],
     "m": ["mitochondrion", "mitochondria"],
     "n": ["nucleus"],
-    "p": [
-        "periplasm",
-        "periplasmic space",
-        "p0",  # GAPSEQ
-        "C_p"  # CARVEME
-    ],
+    "p": ["periplasm", "periplasmic space", "p0", "C_p"],  # GAPSEQ  # CARVEME
     "x": ["peroxisome", "glyoxysome"],
     "u": ["thylakoid"],
     "vm": ["vacuolar membrane"],

--- a/src/cobra/medium/boundary_types.py
+++ b/src/cobra/medium/boundary_types.py
@@ -94,7 +94,7 @@ def find_external_compartment(model: "Model") -> str:
             "Consider renaming your compartments using "
             "`Model.compartments` to fix this."
         )
-        return most[0]
+        return most.iloc[0]
 
     # No info in the model, so give up
     raise RuntimeError(

--- a/tests/test_medium/test_boundary_types.py
+++ b/tests/test_medium/test_boundary_types.py
@@ -8,6 +8,7 @@ from cobra.medium import (
     find_external_compartment,
     is_boundary_type,
 )
+import logging
 
 
 def test_find_external_compartment_single(model: Model) -> None:
@@ -38,6 +39,17 @@ def test_find_external_compartment_multi(model: Model) -> None:
     # Now fails because same boundary count
     with pytest.raises(RuntimeError):
         find_external_compartment(model)
+
+
+@pytest.mark.parametrize("compartment", ["C_e", "e0"])
+def test_find_external_popular_reconstructions(model: Model, compartment, caplog) -> None:
+    """Test some additional id formats."""
+    for ex in model.exchanges:
+        ex.reactants[0].compartment = compartment
+    with caplog.at_level(logging.WARNING):
+        external = find_external_compartment(model)
+    assert external == compartment
+    assert "complete nonsense" not in caplog.text
 
 
 def test_no_names_or_boundary_reactions(empty_model: Model) -> None:

--- a/tests/test_medium/test_boundary_types.py
+++ b/tests/test_medium/test_boundary_types.py
@@ -43,7 +43,9 @@ def test_find_external_compartment_multi(model: Model) -> None:
 
 
 @pytest.mark.parametrize("compartment", ["C_e", "e0"])
-def test_find_external_popular_reconstructions(model: Model, compartment, caplog) -> None:
+def test_find_external_popular_reconstructions(
+    model: Model, compartment, caplog
+) -> None:
     """Test some additional id formats."""
     for ex in model.exchanges:
         ex.reactants[0].compartment = compartment

--- a/tests/test_medium/test_boundary_types.py
+++ b/tests/test_medium/test_boundary_types.py
@@ -1,5 +1,6 @@
 """Test functionalities of boundary type detection functions."""
 
+import logging
 import pytest
 
 from cobra.core import Metabolite, Model, Reaction
@@ -8,7 +9,6 @@ from cobra.medium import (
     find_external_compartment,
     is_boundary_type,
 )
-import logging
 
 
 def test_find_external_compartment_single(model: Model) -> None:

--- a/tests/test_medium/test_boundary_types.py
+++ b/tests/test_medium/test_boundary_types.py
@@ -1,6 +1,7 @@
 """Test functionalities of boundary type detection functions."""
 
 import logging
+
 import pytest
 
 from cobra.core import Metabolite, Model, Reaction


### PR DESCRIPTION
* [X] fix excessive warning when using models generated by those methods
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

Models generated with CARVEME and GAPSEQ would generate a lot of warnings when using any functions that use the external compartment heuristic because they were not covered by the positive list before. The heuristic would always be correct, and the compartment names are easily identifiable, so this now adds them here.