### PR TITLE
Fix the GPR copy in Python 3.13

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -4,6 +4,8 @@
 
 ## Fixes
 
+Fixes failures of GPR.copy() in Python 3.13.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -545,9 +545,13 @@ class GPR(Module):
         """
         return self._ast2str(self, names=names)
 
-    def copy(self):
+    def copy(self) -> "GPR":
         """Copy a GPR."""
-        return deepcopy(self)
+        cls = type(self)
+        gpr = cls()
+        gpr._genes = deepcopy(self._genes)
+        gpr.body = deepcopy(self.body)
+        return gpr
 
     def __copy__(self) -> "GPR":
         """Ensure a correct shallow copy."""

--- a/tests/test_core/test_gpr.py
+++ b/tests/test_core/test_gpr.py
@@ -27,6 +27,16 @@ def test_gpr() -> None:
     assert len(gpr1.genes) == 0
 
 
+def test_grp_copy() -> None:
+    """Test that copying a GPR works."""
+    gpr1 = GPR.from_string("(A and B) or C")
+    gpr2 = gpr1.copy()
+    assert gpr1 == gpr2
+    assert id(gpr1.body) is not id(gpr2.body)
+    assert gpr1._genes == gpr2._genes
+    assert id(gpr1._genes) is not id(gpr2._genes)
+
+
 @pytest.mark.parametrize("test_input", ["", "", None])
 def test_empty_gpr(test_input) -> None:
     """Test empty GPR."""
@@ -89,7 +99,6 @@ def test_and_gpr(gpr_input, num_genes, gpr_genes, gpr_output_string) -> None:
     for ko_genes in powerset_ne(gpr_genes):
         assert not gpr1.eval(ko_genes)
     assert gpr1.body
-    gpr1.copy()
 
 
 def all_except_one(iterable: Iterable[str]) -> Iterator[Tuple[str, ...]]:
@@ -132,7 +141,6 @@ def test_or_gpr(
         assert gpr1.eval(ko_genes)
     assert not gpr1.eval(gpr_genes)
     assert gpr1.body
-    gpr1.copy()
 
 
 @pytest.mark.parametrize(
@@ -158,7 +166,6 @@ def test_complicated_gpr(gpr_input: str) -> None:
     assert not gpr1.eval("c")
     assert not gpr1.eval(["a", "b"])
     assert not gpr1.eval(["a", "b", "c"])
-    gpr1.copy()
 
 
 @pytest.mark.parametrize(
@@ -185,7 +192,6 @@ def test_gpr_from_ast_or(
     for ko_genes in all_except_one(gpr_genes):
         assert gpr1.eval(ko_genes)
     assert not gpr1.eval(gpr_genes)
-    gpr1.copy()
 
 
 @pytest.mark.parametrize(
@@ -210,7 +216,6 @@ def test_gpr_from_ast_and(
     assert gpr1.eval()
     for ko_genes in powerset_ne(gpr_genes):
         assert not gpr1.eval(ko_genes)
-    gpr1.copy()
 
 
 @pytest.mark.parametrize("test_input", [["a", "b"], {"a", "b"}])


### PR DESCRIPTION
* [X] fix #1411 
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

Implements a clean copy overwrite instead of relying on deepcopy magic using the state. Not sure why this is popping up now and not before as there seem to have been no changes to copying in Python 3.13 :man_shrugging: 