### PR TITLE
Direct gene.id modification warning message.

### DIFF
--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -222,6 +222,19 @@ class Gene(Species):
         self._functional = functional
 
     @property
+    def id(self) -> str:
+        return super().id
+
+    @id.setter
+    def id(self, new_id) -> None:
+        warnings.warn(
+            "Direct modification of gene.id is discouraged and can lead to unexpected gene duplications. "
+            "Use cobra.manipulation.modify.rename_genes to safely rename genes.",
+            UserWarning
+        )
+        super(Gene, self.__class__).id.fset(self, new_id)
+    
+    @property
     def functional(self) -> bool:
         """Flag indicating if the gene is functional.
 


### PR DESCRIPTION
Unlike with metabolites or reactions, direct modification of Gene class id property may lead implicit gene duplications in the model. The user should be notified that there is a special, safe function designed just for that.

Im just not quite sure about the `super(Gene, self.__class__).id.fset(self, new_id)` syntax and will welcome any comments.
