### PR TITLE
Pin lint tools versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 88
 
-[*.{json,yml}]
+[*.{json,yml,yaml}]
 indent_size = 2
 
 [*.{md,rst}]

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -105,6 +105,15 @@ Ready to contribute? Here's how to set up cobrapy for local development.
 
        tox --parallel
 
+   We also provide some `git pre-commit hooks <https://pre-commit.com/>`_ for
+   your convenience. They run our linting steps and will ensure that your
+   contributions pass linting with every commit that you make.  When you want to
+   use them, run the following commands.
+
+   .. code-block:: console
+
+       pip install pre-commit
+       pre-commit install
 
 7. Push your branch to GitHub.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: [--check-only, --diff, src/cobra, setup.py, tests]
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: [--check, --diff, src/cobra, setup.py, tests]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.2
+    hooks:
+      - id: flake8
+        args: [src/cobra, setup.py, tests]
+        additional_dependencies:
+          - flake8-docstrings
+          - flake8-bugbear

--- a/src/cobra/core/gene.py
+++ b/src/cobra/core/gene.py
@@ -680,7 +680,7 @@ class GPR(Module):
         """
 
         def _sympy_to_ast(
-            sympy_expr: Union[spl.BooleanFunction, Symbol]
+            sympy_expr: Union[spl.BooleanFunction, Symbol],
         ) -> Union[BoolOp, Name]:
             if sympy_expr.func is spl.Or:
                 return BoolOp(

--- a/src/cobra/io/dict.py
+++ b/src/cobra/io/dict.py
@@ -68,7 +68,7 @@ _OPTIONAL_MODEL_ATTRIBUTES = {
 
 
 def _fix_type(
-    value: Union[str, float, bool, Set, Dict]
+    value: Union[str, float, bool, Set, Dict],
 ) -> Union[str, float, bool, List, OrderedDict]:
     """Convert possible types to correct Python types.
 

--- a/tests/test_core/test_solution.py
+++ b/tests/test_core/test_solution.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def test_solution_contains_only_reaction_specific_values(
-    solved_model: Tuple[Solution, "Model"]
+    solved_model: Tuple[Solution, "Model"],
 ) -> None:
     """Test solution contains specific reaction values."""
     solution, model = solved_model

--- a/tox.ini
+++ b/tox.ini
@@ -39,21 +39,21 @@ commands =
 [testenv:isort]
 skip_install = True
 deps=
-    isort
+    isort ==6.0.1
 commands=
     isort --check-only --diff {toxinidir}/src/cobra {toxinidir}/setup.py {toxinidir}/tests
 
 [testenv:black]
 skip_install = True
 deps=
-    black
+    black ==25.1.0
 commands=
     black --check --diff {toxinidir}/src/cobra {toxinidir}/setup.py {toxinidir}/tests
 
 [testenv:flake8]
 skip_install = True
 deps=
-    flake8
+    flake8 ==7.1.2
     flake8-docstrings
     flake8-bugbear
 commands=


### PR DESCRIPTION
This PR pins our lint tools versions as proposed [here](https://github.com/opencobra/cobrapy/pull/1427#issuecomment-2674230850). Additionally, I suggest to offer pre-commit hooks with the same versions to catch these during local development.
