### PR TITLE
filter check_mass_balance zeros with a floating point comparison

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -9,6 +9,8 @@ Fixes failures of GPR.copy() in Python 3.13.
 Fix compartment not being stored for metabolites created during
 reaction.build_reaction_from_string
 
+Fix `reaction.check_mass_balance` giving incorrect results for reactions with floating point coefficients.
+
 ## Other
 
 ## Deprecated features

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from copy import copy, deepcopy
 from functools import partial
-from math import isinf
+from math import isinf, isclose
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
@@ -1451,7 +1451,7 @@ class Reaction(Object):
             for element, amount in metabolite.elements.items():
                 reaction_element_dict[element] += coefficient * amount
         # filter out 0 values
-        return {k: v for k, v in reaction_element_dict.items() if v != 0}
+        return {k: v for k, v in reaction_element_dict.items() if not isclose(v, 0.0, abs_tol=1e-12)}
 
     @property
     def compartments(self) -> Set:

--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from copy import copy, deepcopy
 from functools import partial
-from math import isinf, isclose
+from math import isclose, isinf
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
@@ -1451,7 +1451,11 @@ class Reaction(Object):
             for element, amount in metabolite.elements.items():
                 reaction_element_dict[element] += coefficient * amount
         # filter out 0 values
-        return {k: v for k, v in reaction_element_dict.items() if not isclose(v, 0.0, abs_tol=1e-12)}
+        return {
+            k: v
+            for k, v in reaction_element_dict.items()
+            if not isclose(v, 0.0, abs_tol=config.tolerance)
+        }
 
     @property
     def compartments(self) -> Set:

--- a/tests/test_core/test_core_reaction.py
+++ b/tests/test_core/test_core_reaction.py
@@ -336,7 +336,7 @@ def test_mass_balance(model: Model) -> None:
     # Should be balanced even when coefficients are non-integer
     reaction_scaled = model.reactions.get_by_id("ATPS4r") * 1.3
     assert len(reaction_scaled.check_mass_balance()) == 0
-    
+
 
 def test_build_from_string(model: Model) -> None:
     """Test reaction building from string evaluation."""

--- a/tests/test_core/test_core_reaction.py
+++ b/tests/test_core/test_core_reaction.py
@@ -333,7 +333,10 @@ def test_mass_balance(model: Model) -> None:
     imbalance = reaction.check_mass_balance()
     assert "H" in imbalance
     assert imbalance["H"] == 1
-
+    # Should be balanced even when coefficients are non-integer
+    reaction_scaled = model.reactions.get_by_id("ATPS4r") * 1.3
+    assert len(reaction_scaled.check_mass_balance()) == 0
+    
 
 def test_build_from_string(model: Model) -> None:
     """Test reaction building from string evaluation."""


### PR DESCRIPTION
* [x] fix #1435 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)

Fixes #1435 by filtering out zeros in the reaction element dictionary using `math.isclose`.