### PR TITLE
bump sphinx versions, some fixes, new theme

### DIFF
--- a/documentation_builder/conf.py
+++ b/documentation_builder/conf.py
@@ -29,11 +29,11 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "autoapi.extension",
     "nbsphinx",
+    "sphinx.ext.viewcode",
 ]
 # Document Python Code
 autoapi_dirs = [join(SRC_PATH, "cobra")]
@@ -123,8 +123,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "http://docs.python.org/": None,
-    "http://docs.scipy.org/doc/numpy/": None,
-    "http://docs.scipy.org/doc/scipy/reference": None,
+    "python": ("http://docs.python.org/", None),
+    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "scipy": ("http://docs.scipy.org/doc/scipy/reference", None),
 }
 intersphinx_cache_limit = 10  # days to keep the cached inventories
+
+html_theme = "sphinx_book_theme"

--- a/documentation_builder/requirements.txt
+++ b/documentation_builder/requirements.txt
@@ -1,6 +1,6 @@
-Sphinx~=5.3
+Sphinx>=8.2
 sphinxcontrib-napoleon
-sphinx-autoapi
+sphinx-autoapi>=3.6
 nbsphinx>=0.2.4
+sphinx-book-theme~=1.1
 ipykernel
-matplotlib>=3.6


### PR DESCRIPTION
* [X] fixes the doc builds
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../release-notes/next-release.md)

This fixes the docs builds. Note that the reordering of imports is [necessary](https://github.com/sphinx-doc/sphinx/issues/12026). In some of the earlier fixes the theme got deleted as well. This now sets the book theme which is the only one I found that still shows pandas DataFrames well in dark mode.