### PR TITLE
use the importlib.resources from the standard library, not the extern…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ install_requires =
 	diskcache ~=5.0
 	future
 	httpx ~=0.24
-	importlib_resources
 	numpy >=1.13
 	optlang ~=1.8
 	pandas >=1.0,<3.0

--- a/src/cobra/io/web/cobrapy_repository.py
+++ b/src/cobra/io/web/cobrapy_repository.py
@@ -1,6 +1,6 @@
 """Provide functions for loading metabolic models from local package data."""
 
-import importlib_resources
+import importlib.resources
 
 import cobra.data
 
@@ -50,7 +50,7 @@ class Cobrapy(AbstractModelRepository):
             A gzip-compressed, UTF-8 encoded SBML document.
         """
         return (
-            importlib_resources.files(cobra.data)
+            importlib.resources.files(cobra.data)
             .joinpath(f"{model_id}.xml.gz")
             .read_bytes()
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 """Define global fixtures."""
 
+import importlib.resources
 from pathlib import Path
 from pickle import load as _load
 from typing import List, Tuple
 
-import importlib_resources
 import pytest
 
 import cobra
@@ -14,7 +14,7 @@ from cobra.util import solver as sutil
 
 
 data_dir = Path(__file__).parent / "data"
-cobra_data_dir = importlib_resources.files(cobra.data)
+cobra_data_dir = importlib.resources.files(cobra.data)
 
 
 def create_test_model(model_name: str = "salmonella") -> Model:

--- a/tests/data/update_pickles.py
+++ b/tests/data/update_pickles.py
@@ -10,11 +10,10 @@ bugs.
 """
 
 
+import importlib.resources
 from collections import OrderedDict
 from json import dump as json_dump
 from pickle import dump, load
-
-import importlib_resources
 
 import cobra
 from cobra.io import (
@@ -99,16 +98,16 @@ if __name__ == "__main__":
     # output to various formats
     with open("mini.pickle", "wb") as outfile:
         dump(mini, outfile, protocol=2)
-    save_matlab_model(mini, importlib_resources.files(cobra.data).joinpath("mini.mat"))
+    save_matlab_model(mini, importlib.resources.files(cobra.data).joinpath("mini.mat"))
     save_json_model(
-        mini, importlib_resources.files(cobra.data).joinpath("mini.json"), pretty=True
+        mini, importlib.resources.files(cobra.data).joinpath("mini.json"), pretty=True
     )
-    save_yaml_model(mini, importlib_resources.files(cobra.data).joinpath("mini.yml"))
+    save_yaml_model(mini, importlib.resources.files(cobra.data).joinpath("mini.yml"))
     write_sbml_model(mini, "mini_fbc2.xml")
     write_sbml_model(mini, "mini_fbc2.xml.bz2")
     write_sbml_model(mini, "mini_fbc2.xml.gz")
     write_sbml_model(
-        mini, importlib_resources.files(cobra.data).joinpath("mini_cobra.xml")
+        mini, importlib.resources.files(cobra.data).joinpath("mini_cobra.xml")
     )
     raven = load_matlab_model("raven.mat")
     with open("raven.pickle", "wb") as outfile:

--- a/tests/test_io/test_json.py
+++ b/tests/test_io/test_json.py
@@ -1,11 +1,11 @@
 """Test functionalities of I/O in JSON format."""
 
 import json
+from importlib.resources import files
 from pathlib import Path
 from typing import Any, Callable, Dict, Union
 
 import pytest
-from importlib_resources import files
 
 from cobra import Model
 from cobra import io as cio

--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,6 @@ known_third_party =
     diskcache
     future
     httpx
-    importlib_resources
     libsbml
     numpy
     optlang


### PR DESCRIPTION
HI,

This cleanup is similar to previous one:

https://github.com/opencobra/cobrapy/pull/1402

I'm trying to more structurate/systematize this process of pruning out usage of copies of what is already in the standard library:

https://wiki.debian.org/Python/Backports

With a baseline of Python 3.9 you should be safe.

The version equivalence table is here https://pypi.org/project/importlib-resources/
