### PR TITLE
Update README.rst readthedocs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ methods both easier to implement and easier to use, thereby bringing the power
 of COBRA to more researchers.
 
 The documentation is browseable online at `readthedocs
-<https://cobrapy.readthedocs.org/en/stable/>`_ and can also be `downloaded
+<https://cobrapy.readthedocs.io/en/latest/>`_ and can also be `downloaded
 <https://readthedocs.org/projects/cobrapy/downloads/>`_.
 
 Please use the `Google Group <http://groups.google.com/group/cobra-pie>`_ for


### PR DESCRIPTION
Replaces an old readthedocs link ("stable" release link; broken and no longer updated) to the link to the latest build. Closes #1379 and #1441.

* [x] fix #1379 and #1441 
* [x] description: replaces the link the "stable" release with the "latest" release. "stable" release docs are no longer published.
* [ ] tests added/passed: N/A
* [x] add an entry to the [next release](../release-notes/next-release.md): minor change to README, release note not recommended.
