### PR TITLE
Update type hinting for DictList

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -11,6 +11,8 @@
 
 ## Other
 
+- Updated type hinting for the `DictList` class so that the type of `Object` contained by a `DictList` can be specified. For example, the hinted return type of `model.reactions.get_by_id` is now `Reaction` instead of `Object`.
+
 ## Deprecated features
 
 - Changed the type of the `loopless` parameter in `flux_variability_analysis` from `bool` to `Optional[str]`. Using `loopless=False` or `loopless=True` (boolean) is now deprecated.

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -525,7 +525,7 @@ class DictList(List[_TObject]):
         """Remove slice."""
         self.__delitem__(slice(i, j))
 
-    def __getattr__(self, attr: Any) -> Any:
+    def __getattr__(self, attr: Any) -> _TObject:
         """Get an attribute by id."""
         try:
             return DictList.get_by_id(self, attr)

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -16,8 +16,10 @@ from typing import (
     Union,
 )
 
+from .object import Object
 
-_TObject = TypeVar("_TObject")
+
+_TObject = TypeVar("_TObject", bound=Object)
 
 
 class DictList(List[_TObject]):

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -19,10 +19,10 @@ from typing import (
 from .object import Object
 
 
-_TObject = TypeVar("_TObject", bound=Object)
+CobraObject = TypeVar("CobraObject", bound=Object)
 
 
-class DictList(List[_TObject]):
+class DictList(List[CobraObject]):
     """
     Define a combined dict and list.
 
@@ -53,12 +53,12 @@ class DictList(List[_TObject]):
                 self.extend(other)
 
     # noinspection PyShadowingBuiltins
-    def has_id(self, id: Union[_TObject, str]) -> bool:
+    def has_id(self, id: Union[CobraObject, str]) -> bool:
         """Check if id is in DictList."""
         return id in self._dict
 
     # noinspection PyShadowingBuiltins
-    def _check(self, id: Union[_TObject, str]) -> None:
+    def _check(self, id: Union[CobraObject, str]) -> None:
         """Make sure duplicate id's are not added.
 
         This function is called before adding in elements.
@@ -72,7 +72,7 @@ class DictList(List[_TObject]):
         self._dict = {v.id: k for k, v in enumerate(self)}
 
     # noinspection PyShadowingBuiltins
-    def get_by_id(self, id: Union[_TObject, str]) -> _TObject:
+    def get_by_id(self, id: Union[CobraObject, str]) -> CobraObject:
         """Return the element with a matching id."""
         return list.__getitem__(self, self._dict[id])
 
@@ -80,7 +80,9 @@ class DictList(List[_TObject]):
         """Return a list of the given attribute for every object."""
         return [getattr(i, attribute) for i in self]
 
-    def get_by_any(self, iterable: List[Union[str, _TObject, int]]) -> List[_TObject]:
+    def get_by_any(
+        self, iterable: List[Union[str, CobraObject, int]]
+    ) -> List[CobraObject]:
         """Get a list of members using several different ways of indexing.
 
         Parameters
@@ -96,7 +98,7 @@ class DictList(List[_TObject]):
             a list of members
         """
 
-        def get_item(item: Any) -> _TObject:
+        def get_item(item: Any) -> CobraObject:
             if isinstance(item, int):
                 return self[item]
             elif isinstance(item, str):
@@ -114,7 +116,7 @@ class DictList(List[_TObject]):
         self,
         search_function: Union[str, Pattern, Callable],
         attribute: Union[str, None] = None,
-    ) -> "DictList[_TObject]":
+    ) -> "DictList[CobraObject]":
         """Query the list.
 
         Parameters
@@ -171,21 +173,21 @@ class DictList(List[_TObject]):
         results._extend_nocheck(matches)
         return results
 
-    def _replace_on_id(self, new_object: _TObject) -> None:
+    def _replace_on_id(self, new_object: CobraObject) -> None:
         """Replace an object by another with the same id."""
         the_id = new_object.id
         the_index = self._dict[the_id]
         list.__setitem__(self, the_index, new_object)
 
     # overriding default list functions with new ones
-    def append(self, entity: _TObject) -> None:
+    def append(self, entity: CobraObject) -> None:
         """Append object to end."""
         the_id = entity.id
         self._check(the_id)
         self._dict[the_id] = len(self)
         list.append(self, entity)
 
-    def union(self, iterable: Iterable[_TObject]) -> None:
+    def union(self, iterable: Iterable[CobraObject]) -> None:
         """Add elements with id's not already in the model."""
         _dict = self._dict
         append = self.append
@@ -193,7 +195,7 @@ class DictList(List[_TObject]):
             if i.id not in _dict:
                 append(i)
 
-    def extend(self, iterable: Iterable[_TObject]) -> None:
+    def extend(self, iterable: Iterable[CobraObject]) -> None:
         """Extend list by appending elements from the iterable.
 
         Sometimes during initialization from an older pickle, _dict
@@ -226,7 +228,7 @@ class DictList(List[_TObject]):
                     f"Is it present twice?"
                 )
 
-    def _extend_nocheck(self, iterable: Iterable[_TObject]) -> None:
+    def _extend_nocheck(self, iterable: Iterable[CobraObject]) -> None:
         """Extend without checking for uniqueness.
 
         This function should only be used internally by DictList when it
@@ -248,7 +250,7 @@ class DictList(List[_TObject]):
         for i, obj in enumerate(islice(self, current_length, None), current_length):
             _dict[obj.id] = i
 
-    def __sub__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
+    def __sub__(self, other: Iterable[CobraObject]) -> "DictList[CobraObject]":
         """Remove a value or values, and returns the new DictList.
 
         x.__sub__(y) <==> x - y
@@ -268,7 +270,7 @@ class DictList(List[_TObject]):
             total.remove(item)
         return total
 
-    def __isub__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
+    def __isub__(self, other: Iterable[CobraObject]) -> "DictList[CobraObject]":
         """Remove a value or values in place.
 
         x.__sub__(y) <==> x -= y
@@ -282,7 +284,7 @@ class DictList(List[_TObject]):
             self.remove(item)
         return self
 
-    def __add__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
+    def __add__(self, other: Iterable[CobraObject]) -> "DictList[CobraObject]":
         """Add item while returning a new DictList.
 
         x.__add__(y) <==> x + y
@@ -298,7 +300,7 @@ class DictList(List[_TObject]):
         total.extend(other)
         return total
 
-    def __iadd__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
+    def __iadd__(self, other: Iterable[CobraObject]) -> "DictList[CobraObject]":
         """Add item while returning the same DictList.
 
         x.__iadd__(y) <==> x += y
@@ -313,7 +315,7 @@ class DictList(List[_TObject]):
         self.extend(other)
         return self
 
-    def __reduce__(self) -> Tuple[Type["DictList"], Tuple, dict, Iterator[_TObject]]:
+    def __reduce__(self) -> Tuple[Type["DictList"], Tuple, dict, Iterator[CobraObject]]:
         """Return a reduced version of DictList.
 
         This reduced version details the class, an empty Tuple, a dictionary of the
@@ -340,7 +342,7 @@ class DictList(List[_TObject]):
         self._generate_index()
 
     # noinspection PyShadowingBuiltins
-    def index(self, id: Union[str, _TObject], *args) -> int:
+    def index(self, id: Union[str, CobraObject], *args) -> int:
         """Determine the position in the list.
 
         Parameters
@@ -364,7 +366,7 @@ class DictList(List[_TObject]):
         except KeyError:
             raise ValueError(f"{str(id)} not found")
 
-    def __contains__(self, entity: Union[str, _TObject]) -> bool:
+    def __contains__(self, entity: Union[str, CobraObject]) -> bool:
         """Ask if the DictList contain an entity.
 
         DictList.__contains__(entity) <==> entity in DictList
@@ -381,14 +383,14 @@ class DictList(List[_TObject]):
             the_id = entity
         return the_id in self._dict
 
-    def __copy__(self) -> "DictList[_TObject]":
+    def __copy__(self) -> "DictList[CobraObject]":
         """Copy the DictList into a new one."""
         the_copy = DictList()
         list.extend(the_copy, self)
         the_copy._dict = self._dict.copy()
         return the_copy
 
-    def insert(self, index: int, entity: _TObject) -> None:
+    def insert(self, index: int, entity: CobraObject) -> None:
         """Insert entity before index."""
         self._check(entity.id)
         list.insert(self, index, entity)
@@ -399,7 +401,7 @@ class DictList(List[_TObject]):
                 _dict[i] = j + 1
         _dict[entity.id] = index
 
-    def pop(self, *args) -> _TObject:
+    def pop(self, *args) -> CobraObject:
         """Remove and return item at index (default last)."""
         value = list.pop(self, *args)
         index = self._dict.pop(value.id)
@@ -413,11 +415,11 @@ class DictList(List[_TObject]):
                 _dict[i] = j - 1
         return value
 
-    def add(self, x: _TObject) -> None:
+    def add(self, x: CobraObject) -> None:
         """Opposite of `remove`. Mirrors set.add."""
         self.extend([x])
 
-    def remove(self, x: Union[str, _TObject]) -> None:
+    def remove(self, x: Union[str, CobraObject]) -> None:
         """.. warning :: Internal use only.
 
         Each item is unique in the list which allows this
@@ -449,8 +451,8 @@ class DictList(List[_TObject]):
         self._generate_index()
 
     def __getitem__(
-        self, i: Union[int, slice, Iterable, _TObject, "DictList[_TObject]"]
-    ) -> Union["DictList[_TObject]", _TObject]:
+        self, i: Union[int, slice, Iterable, CobraObject, "DictList[CobraObject]"]
+    ) -> Union["DictList[CobraObject]", CobraObject]:
         """Get item from DictList."""
         if isinstance(i, int):
             return list.__getitem__(self, i)
@@ -470,7 +472,7 @@ class DictList(List[_TObject]):
             return list.__getitem__(self, i)
 
     def __setitem__(
-        self, i: Union[slice, int], y: Union[List[_TObject], _TObject]
+        self, i: Union[slice, int], y: Union[List[CobraObject], CobraObject]
     ) -> None:
         """Set an item via index or slice.
 
@@ -513,11 +515,13 @@ class DictList(List[_TObject]):
             if j > index:
                 _dict[i] = j - 1
 
-    def __getslice__(self, i: int, j: int) -> "DictList[_TObject]":
+    def __getslice__(self, i: int, j: int) -> "DictList[CobraObject]":
         """Get a slice from it to j of DictList."""
         return self.__getitem__(slice(i, j))
 
-    def __setslice__(self, i: int, j: int, y: Union[List[_TObject], _TObject]) -> None:
+    def __setslice__(
+        self, i: int, j: int, y: Union[List[CobraObject], CobraObject]
+    ) -> None:
         """Set slice, where y is an iterable."""
         self.__setitem__(slice(i, j), y)
 
@@ -525,7 +529,7 @@ class DictList(List[_TObject]):
         """Remove slice."""
         self.__delitem__(slice(i, j))
 
-    def __getattr__(self, attr: Any) -> _TObject:
+    def __getattr__(self, attr: Any) -> CobraObject:
         """Get an attribute by id."""
         try:
             return DictList.get_by_id(self, attr)

--- a/src/cobra/core/dictlist.py
+++ b/src/cobra/core/dictlist.py
@@ -12,13 +12,15 @@ from typing import (
     Pattern,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
-from .object import Object
+
+_TObject = TypeVar("_TObject")
 
 
-class DictList(list):
+class DictList(List[_TObject]):
     """
     Define a combined dict and list.
 
@@ -49,12 +51,12 @@ class DictList(list):
                 self.extend(other)
 
     # noinspection PyShadowingBuiltins
-    def has_id(self, id: Union[Object, str]) -> bool:
+    def has_id(self, id: Union[_TObject, str]) -> bool:
         """Check if id is in DictList."""
         return id in self._dict
 
     # noinspection PyShadowingBuiltins
-    def _check(self, id: Union[Object, str]) -> None:
+    def _check(self, id: Union[_TObject, str]) -> None:
         """Make sure duplicate id's are not added.
 
         This function is called before adding in elements.
@@ -68,7 +70,7 @@ class DictList(list):
         self._dict = {v.id: k for k, v in enumerate(self)}
 
     # noinspection PyShadowingBuiltins
-    def get_by_id(self, id: Union[Object, str]) -> Object:
+    def get_by_id(self, id: Union[_TObject, str]) -> _TObject:
         """Return the element with a matching id."""
         return list.__getitem__(self, self._dict[id])
 
@@ -76,7 +78,7 @@ class DictList(list):
         """Return a list of the given attribute for every object."""
         return [getattr(i, attribute) for i in self]
 
-    def get_by_any(self, iterable: List[Union[str, Object, int]]) -> list:
+    def get_by_any(self, iterable: List[Union[str, _TObject, int]]) -> List[_TObject]:
         """Get a list of members using several different ways of indexing.
 
         Parameters
@@ -92,7 +94,7 @@ class DictList(list):
             a list of members
         """
 
-        def get_item(item: Any) -> Any:
+        def get_item(item: Any) -> _TObject:
             if isinstance(item, int):
                 return self[item]
             elif isinstance(item, str):
@@ -110,7 +112,7 @@ class DictList(list):
         self,
         search_function: Union[str, Pattern, Callable],
         attribute: Union[str, None] = None,
-    ) -> "DictList":
+    ) -> "DictList[_TObject]":
         """Query the list.
 
         Parameters
@@ -167,21 +169,21 @@ class DictList(list):
         results._extend_nocheck(matches)
         return results
 
-    def _replace_on_id(self, new_object: Object) -> None:
+    def _replace_on_id(self, new_object: _TObject) -> None:
         """Replace an object by another with the same id."""
         the_id = new_object.id
         the_index = self._dict[the_id]
         list.__setitem__(self, the_index, new_object)
 
     # overriding default list functions with new ones
-    def append(self, entity: Object) -> None:
+    def append(self, entity: _TObject) -> None:
         """Append object to end."""
         the_id = entity.id
         self._check(the_id)
         self._dict[the_id] = len(self)
         list.append(self, entity)
 
-    def union(self, iterable: Iterable[Object]) -> None:
+    def union(self, iterable: Iterable[_TObject]) -> None:
         """Add elements with id's not already in the model."""
         _dict = self._dict
         append = self.append
@@ -189,7 +191,7 @@ class DictList(list):
             if i.id not in _dict:
                 append(i)
 
-    def extend(self, iterable: Iterable[Object]) -> None:
+    def extend(self, iterable: Iterable[_TObject]) -> None:
         """Extend list by appending elements from the iterable.
 
         Sometimes during initialization from an older pickle, _dict
@@ -222,7 +224,7 @@ class DictList(list):
                     f"Is it present twice?"
                 )
 
-    def _extend_nocheck(self, iterable: Iterable[Object]) -> None:
+    def _extend_nocheck(self, iterable: Iterable[_TObject]) -> None:
         """Extend without checking for uniqueness.
 
         This function should only be used internally by DictList when it
@@ -244,7 +246,7 @@ class DictList(list):
         for i, obj in enumerate(islice(self, current_length, None), current_length):
             _dict[obj.id] = i
 
-    def __sub__(self, other: Iterable[Object]) -> "DictList":
+    def __sub__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
         """Remove a value or values, and returns the new DictList.
 
         x.__sub__(y) <==> x - y
@@ -264,7 +266,7 @@ class DictList(list):
             total.remove(item)
         return total
 
-    def __isub__(self, other: Iterable[Object]) -> "DictList":
+    def __isub__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
         """Remove a value or values in place.
 
         x.__sub__(y) <==> x -= y
@@ -278,7 +280,7 @@ class DictList(list):
             self.remove(item)
         return self
 
-    def __add__(self, other: Iterable[Object]) -> "DictList":
+    def __add__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
         """Add item while returning a new DictList.
 
         x.__add__(y) <==> x + y
@@ -294,7 +296,7 @@ class DictList(list):
         total.extend(other)
         return total
 
-    def __iadd__(self, other: Iterable[Object]) -> "DictList":
+    def __iadd__(self, other: Iterable[_TObject]) -> "DictList[_TObject]":
         """Add item while returning the same DictList.
 
         x.__iadd__(y) <==> x += y
@@ -309,7 +311,7 @@ class DictList(list):
         self.extend(other)
         return self
 
-    def __reduce__(self) -> Tuple[Type["DictList"], Tuple, dict, Iterator]:
+    def __reduce__(self) -> Tuple[Type["DictList"], Tuple, dict, Iterator[_TObject]]:
         """Return a reduced version of DictList.
 
         This reduced version details the class, an empty Tuple, a dictionary of the
@@ -336,7 +338,7 @@ class DictList(list):
         self._generate_index()
 
     # noinspection PyShadowingBuiltins
-    def index(self, id: Union[str, Object], *args) -> int:
+    def index(self, id: Union[str, _TObject], *args) -> int:
         """Determine the position in the list.
 
         Parameters
@@ -360,7 +362,7 @@ class DictList(list):
         except KeyError:
             raise ValueError(f"{str(id)} not found")
 
-    def __contains__(self, entity: Union[str, Object]) -> bool:
+    def __contains__(self, entity: Union[str, _TObject]) -> bool:
         """Ask if the DictList contain an entity.
 
         DictList.__contains__(entity) <==> entity in DictList
@@ -377,14 +379,14 @@ class DictList(list):
             the_id = entity
         return the_id in self._dict
 
-    def __copy__(self) -> "DictList":
+    def __copy__(self) -> "DictList[_TObject]":
         """Copy the DictList into a new one."""
         the_copy = DictList()
         list.extend(the_copy, self)
         the_copy._dict = self._dict.copy()
         return the_copy
 
-    def insert(self, index: int, entity: Object) -> None:
+    def insert(self, index: int, entity: _TObject) -> None:
         """Insert entity before index."""
         self._check(entity.id)
         list.insert(self, index, entity)
@@ -395,7 +397,7 @@ class DictList(list):
                 _dict[i] = j + 1
         _dict[entity.id] = index
 
-    def pop(self, *args) -> Object:
+    def pop(self, *args) -> _TObject:
         """Remove and return item at index (default last)."""
         value = list.pop(self, *args)
         index = self._dict.pop(value.id)
@@ -409,11 +411,11 @@ class DictList(list):
                 _dict[i] = j - 1
         return value
 
-    def add(self, x: Object) -> None:
+    def add(self, x: _TObject) -> None:
         """Opposite of `remove`. Mirrors set.add."""
         self.extend([x])
 
-    def remove(self, x: Union[str, Object]) -> None:
+    def remove(self, x: Union[str, _TObject]) -> None:
         """.. warning :: Internal use only.
 
         Each item is unique in the list which allows this
@@ -445,8 +447,8 @@ class DictList(list):
         self._generate_index()
 
     def __getitem__(
-        self, i: Union[int, slice, Iterable, Object, "DictList"]
-    ) -> Union["DictList", Object]:
+        self, i: Union[int, slice, Iterable, _TObject, "DictList[_TObject]"]
+    ) -> Union["DictList[_TObject]", _TObject]:
         """Get item from DictList."""
         if isinstance(i, int):
             return list.__getitem__(self, i)
@@ -465,7 +467,9 @@ class DictList(list):
         else:
             return list.__getitem__(self, i)
 
-    def __setitem__(self, i: Union[slice, int], y: Union[list, Object]) -> None:
+    def __setitem__(
+        self, i: Union[slice, int], y: Union[List[_TObject], _TObject]
+    ) -> None:
         """Set an item via index or slice.
 
         Parameters
@@ -507,11 +511,11 @@ class DictList(list):
             if j > index:
                 _dict[i] = j - 1
 
-    def __getslice__(self, i: int, j: int) -> "DictList":
+    def __getslice__(self, i: int, j: int) -> "DictList[_TObject]":
         """Get a slice from it to j of DictList."""
         return self.__getitem__(slice(i, j))
 
-    def __setslice__(self, i: int, j: int, y: Union[list, Object]) -> None:
+    def __setslice__(self, i: int, j: int, y: Union[List[_TObject], _TObject]) -> None:
         """Set slice, where y is an iterable."""
         self.__setitem__(slice(i, j), y)
 

--- a/src/cobra/core/model.py
+++ b/src/cobra/core/model.py
@@ -81,10 +81,10 @@ class Model(Object):
             self._solver = id_or_model.solver
         else:
             Object.__init__(self, id_or_model, name=name)
-            self.genes = DictList()
-            self.reactions = DictList()  # A list of cobra.Reactions
-            self.metabolites = DictList()  # A list of cobra.Metabolites
-            self.groups = DictList()  # A list of cobra.Groups
+            self.genes: DictList[Gene] = DictList()
+            self.reactions: DictList[Reaction] = DictList()
+            self.metabolites: DictList[Metabolite] = DictList()
+            self.groups: DictList[Group] = DictList()
             # genes based on their ids {Gene.id: Gene}
             self._compartments = {}
             self._contexts = []


### PR DESCRIPTION
* [x] Resolves #1464 
* [x] Improves type hinting for the `DictList` class by adding a TypeVar. This allows the specific type of object contained within an instantiated `DictList` to be defined. For example, the type for `model.reactions` is now `DictList[Reaction]` instead of just `DictList`. This means that now the hinted return type for `model.reactions.get_by_id` is `Reaction` instead of `Object`. 
* [x] No tests added since only type hinting was changed.
* [x] add an entry to the [next release](../release-notes/next-release.md)
