### PR TITLE
Temporarily remove web caching due to diskcache CVE 

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.10, 3.13]
+        python-version: ["3.10", "3.13"]
     timeout-minutes: 360
 
     steps:

--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -10,6 +10,7 @@
 ## Fixes
 
 - Updated BioModel URL from `https://www.ebi.ac.ak/biomodels/model/` to `https://biomodels.org/model/`.
+- Caching of downloads from model repositories has been temporarily deactivated due to [CVE in diskcache](https://github.com/grantjenks/python-diskcache/issues/357). This will be re-enabled as soon as a fix is implemented or we find an adequate substitute.
 
 ## Other
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ zip_safe = True
 install_requires =
 	appdirs ~=1.4
 	depinfo ~=2.2
-	diskcache ~=5.0
 	future
 	httpx ~=0.24
 	numpy >=1.13

--- a/src/cobra/io/web/load.py
+++ b/src/cobra/io/web/load.py
@@ -4,7 +4,6 @@ import gzip
 import logging
 from typing import TYPE_CHECKING, Iterable
 
-import diskcache
 import httpx
 import libsbml
 
@@ -57,8 +56,6 @@ def load_model(
         specific.
     repositories : iterable, optional
         An iterable of repository accessor instances. The model_id is searched in order.
-    cache : bool, optional
-        Whether or not to use the local caching mechanism (default yes).
 
     Returns
     -------
@@ -84,50 +81,8 @@ def load_model(
     BioModels
 
     """
-    if cache:
-        data = _cached_load(
-            model_id=model_id,
-            repositories=repositories,
-        )
-    else:
-        data = _fetch_model(model_id=model_id, repositories=repositories)
+    data = _fetch_model(model_id=model_id, repositories=repositories)
     return get_model_from_gzip_sbml(data)
-
-
-def _cached_load(
-    model_id: str,
-    repositories: Iterable[AbstractModelRepository],
-) -> bytes:
-    """
-    Attempt to load a gzip-compressed SBML document from the cache.
-
-    If the given model identifier is not in the cache, the remote repositories are
-    searched.
-
-    Parameters
-    ----------
-    model_id : str
-        The identifier of the desired metabolic model. This is typically repository
-        specific.
-    repositories : iterable
-        An iterable of repository accessor instances. The model_id is searched in order.
-
-    Returns
-    -------
-    bytes
-        A gzip-compressed, UTF-8 encoded SBML document.
-
-    """
-    with diskcache.Cache(
-        directory=str(configuration.cache_directory),
-        size_limit=configuration.max_cache_size,
-    ) as cache:
-        try:
-            return cache[model_id]
-        except KeyError:
-            data = _fetch_model(model_id=model_id, repositories=repositories)
-            cache.set(key=model_id, value=data, expire=configuration.cache_expiration)
-            return data
 
 
 def _fetch_model(

--- a/tests/test_io/test_web/test_load.py
+++ b/tests/test_io/test_web/test_load.py
@@ -102,7 +102,7 @@ def test_remote_load(model_id: str, num_metabolites: int, num_reactions: int) ->
     assert len(model.reactions) == num_reactions
 
 
-pytest.skip("caching currently removed because of a CVE in diskcache")
+@pytest.mark.skip("caching currently removed because of a CVE in diskcache")
 def test_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bigg_models: Mock, biomodels: Mock
 ) -> None:

--- a/tests/test_io/test_web/test_load.py
+++ b/tests/test_io/test_web/test_load.py
@@ -102,6 +102,7 @@ def test_remote_load(model_id: str, num_metabolites: int, num_reactions: int) ->
     assert len(model.reactions) == num_reactions
 
 
+pytest.skip("caching currently removed because of a CVE in diskcache")
 def test_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bigg_models: Mock, biomodels: Mock
 ) -> None:


### PR DESCRIPTION
* [X] fix failing safety checks
* [X] description of feature/fix
* [X] tests added/passed
* [ ] add an entry to the [next release](../release-notes/next-release.md)

The `diskcache` package is currently flagged with a [CVE](https://github.com/grantjenks/python-diskcache/issues/357). Unfortunately the project seems to be abandoned and no fix has been merged for 1+ months. This temporarily removes the dependency of diskcache by disabling the caching. I am happy to reactivate *if* the CVE gets fixed or an alternative pops up. I could not find a package that does the same. 