### PR TITLE
fix: allow Formula.__add__ to accept a str operand

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -6,6 +6,7 @@
 
 ## Fixes
 - Rare race condition in cache directory creation from running seperate processes loading cobrapy on clean machine fixed. (https://github.com/opencobra/cobrapy/issues/1476)
+- `Formula.__add__` now accepts a plain `str` for the right-hand operand, matching its documented type hint and docstring. Previously `Formula("H2O") + "C"` raised `AttributeError`.
 
 
 ## Other

--- a/src/cobra/core/formula.py
+++ b/src/cobra/core/formula.py
@@ -49,7 +49,9 @@ class Formula(Object):
         Formula: Formula
            The combined formula
         """
-        return Formula(self.formula + other_formula.formula)
+        if isinstance(other_formula, Formula):
+            other_formula = other_formula.formula
+        return Formula(self.formula + other_formula)
 
     def parse_composition(self) -> None:
         """Break the chemical formula down by element."""

--- a/tests/test_core/test_formula.py
+++ b/tests/test_core/test_formula.py
@@ -26,3 +26,15 @@ def test_formula_wrong() -> None:
     with pytest.warns(UserWarning):
         w = Formula("NOX").weight
         assert w is None
+
+
+def test_formula_add_formula() -> None:
+    """Test combining two Formula objects."""
+    f = Formula("H2O") + Formula("C")
+    assert f.formula == "H2OC"
+
+
+def test_formula_add_str() -> None:
+    """Test combining a Formula with a plain string, per the documented API."""
+    f = Formula("H2O") + "C"
+    assert f.formula == "H2OC"


### PR DESCRIPTION
* [x] fix #(no linked issue)
* [x] `Formula.__add__` is typed `Union[Formula, str]` and its docstring lists `other_formula : Formula, str`, but the code always read `other_formula.formula`. `Formula("H2O") + "C"` raised `AttributeError: 'str' object has no attribute 'formula'` instead of returning a combined formula. Now the operand is only unwrapped to `.formula` when it's a `Formula`, otherwise the string is used directly.
* [x] tests added/passed
* [x] add an entry to the next release notes