### PR TITLE
Fix build_reaction_from_string clobbering user-set bounds

### DIFF
--- a/src/cobra/core/reaction.py
+++ b/src/cobra/core/reaction.py
@@ -1555,19 +1555,29 @@ class Reaction(Object):
         # reversible case
         arrow_match = reversible_arrow_finder.search(reaction_str)
         if arrow_match is not None:
-            self.bounds = config.lower_bound, config.upper_bound
+            # Only reset bounds when they are inconsistent with a reversible
+            # arrow (i.e. the current bounds do not allow flux in both
+            # directions).  Preserves user-set bounds that are already valid.
+            if not (self._lower_bound < 0 < self._upper_bound):
+                self.bounds = config.lower_bound, config.upper_bound
         else:  # irreversible
             # try forward
             arrow_match = forward_arrow_finder.search(reaction_str)
             if arrow_match is not None:
-                self.bounds = 0, config.upper_bound
+                # Only reset when the lower bound contradicts forward-only
+                # directionality (lb < 0).  Preserve a tighter upper bound.
+                if self._lower_bound < 0:
+                    self.bounds = 0, config.upper_bound
             else:
                 # must be reverse
                 arrow_match = reverse_arrow_finder.search(reaction_str)
                 if arrow_match is None:
                     raise ValueError(f"no suitable arrow found in '{reaction_str}'")
                 else:
-                    self.bounds = config.lower_bound, 0
+                    # Only reset when the upper bound contradicts reverse-only
+                    # directionality (ub > 0).  Preserve a tighter lower bound.
+                    if self._upper_bound > 0:
+                        self.bounds = config.lower_bound, 0
         reactant_str = reaction_str[: arrow_match.start()].strip()
         product_str = reaction_str[arrow_match.end() :].strip()
 

--- a/tests/test_core/test_core_reaction.py
+++ b/tests/test_core/test_core_reaction.py
@@ -396,6 +396,64 @@ def test_build_from_string_creating_metabolites() -> None:
     assert model.reactions.R1.compartments == set(["c"])
 
 
+def test_build_from_string_preserves_compatible_bounds() -> None:
+    """Test that build_reaction_from_string preserves bounds consistent with the arrow.
+
+    Regression test for https://github.com/opencobra/cobrapy/issues/1463.
+    Before the fix, ALL three arrow branches unconditionally reset bounds to
+    the config defaults, discarding any user-set bounds.
+    """
+    from cobra.core.configuration import Configuration
+
+    config = Configuration()
+
+    # --- forward arrow: lb >= 0 is consistent, should be preserved ---
+    model = Model()
+    rxn = Reaction("fwd", lower_bound=0, upper_bound=10)
+    model.add_reactions([rxn])
+    rxn.build_reaction_from_string("A --> B", verbose=False)
+    assert rxn.bounds == (
+        0,
+        10,
+    ), "forward-compatible bounds must be preserved (issue #1463)"
+
+    # Tighter non-zero lb that is still >= 0 should also be preserved
+    model2 = Model()
+    rxn2 = Reaction("fwd2", lower_bound=5, upper_bound=10)
+    model2.add_reactions([rxn2])
+    rxn2.build_reaction_from_string("A --> B", verbose=False)
+    assert rxn2.bounds == (5, 10)
+
+    # Inconsistent lb < 0 for a forward arrow → reset to config default
+    model3 = Model()
+    rxn3 = Reaction("fwd_incompat", lower_bound=-10, upper_bound=10)
+    model3.add_reactions([rxn3])
+    rxn3.build_reaction_from_string("A --> B", verbose=False)
+    assert rxn3.lower_bound == 0
+    assert rxn3.upper_bound == config.upper_bound
+
+    # --- reverse arrow: ub <= 0 is consistent, should be preserved ---
+    model4 = Model()
+    rxn4 = Reaction("rev", lower_bound=-10, upper_bound=0)
+    model4.add_reactions([rxn4])
+    rxn4.build_reaction_from_string("A <-- B", verbose=False)
+    assert rxn4.bounds == (-10, 0)
+
+    # --- reversible arrow: lb < 0 < ub is consistent, should be preserved ---
+    model5 = Model()
+    rxn5 = Reaction("revs", lower_bound=-10, upper_bound=10)
+    model5.add_reactions([rxn5])
+    rxn5.build_reaction_from_string("A <=> B", verbose=False)
+    assert rxn5.bounds == (-10, 10)
+
+    # Inconsistent lb >= 0 for a reversible arrow → reset to config default
+    model6 = Model()
+    rxn6 = Reaction("revs_incompat", lower_bound=0, upper_bound=10)
+    model6.add_reactions([rxn6])
+    rxn6.build_reaction_from_string("A <=> B", verbose=False)
+    assert rxn6.bounds == (config.lower_bound, config.upper_bound)
+
+
 def test_bounds_setter(model: Model) -> None:
     """Test reaction bounds setter."""
     rxn = model.reactions.get_by_id("PGI")


### PR DESCRIPTION
## What the problem was

`build_reaction_from_string` unconditionally reset a reaction's bounds to the
configuration defaults every time it detected an arrow in the equation string.
A reaction created with custom, arrow-consistent bounds (e.g. `lower_bound=0,
upper_bound=10` with a forward `-->` arrow) always came out with `upper_bound=1000`
after the call — silently discarding the user's value.

All three arrow branches were affected:
- `-->` (forward irreversible) → always wrote `(0, config.upper_bound)`
- `<--` (reverse irreversible) → always wrote `(config.lower_bound, 0)`
- `<=>` (reversible)           → always wrote `(config.lower_bound, config.upper_bound)`

Minimal reproduction (reported in #1463):

```python
import cobra
rxn = cobra.Reaction("rxn", lower_bound=0, upper_bound=10)
cobra.Model().add_reactions([rxn])
rxn.build_reaction_from_string("A->B")
print(rxn.bounds)  # Was: (0, 1000.0)  — Expected: (0, 10)
```

## What the fix does

Reset bounds **only when the pre-existing bounds contradict the arrow's direction**:

| Arrow | Reset condition |
|-------|----------------|
| `-->` | `lower_bound < 0` (lb that forbids forward flux) |
| `<--` | `upper_bound > 0` (ub that forbids reverse flux) |
| `<=>` | NOT `(lb < 0 < ub)` (bounds that prevent at least one direction) |

Compatible bounds (like `(0, 10)` with `-->`) are left untouched.
Inconsistent bounds (like `(-10, 10)` with `-->`) are still reset to defaults,
preserving the original intent that arrow type controls directionality.

The change is in `src/cobra/core/reaction.py`, 10 lines modified in the three
arrow branches.  No other code is touched.

## How it was tested

**RED → GREEN (local, verified):**

1. Ran the exact repro from the issue — confirmed `(0, 1000.0)` output on
   `devel` HEAD before the fix, `(0, 10)` output after.

2. Enumerated all three arrow branches × consistent / inconsistent bounds
   (8 cases) — all behaved correctly after the fix.

3. New regression test `test_build_from_string_preserves_compatible_bounds`
   added in `tests/test_core/test_core_reaction.py`. It covers:
   - forward arrow preserving `(0, 10)` and `(5, 10)` (consistent)
   - forward arrow resetting `(-10, 10)` (inconsistent lb)
   - reverse arrow preserving `(-10, 0)` (consistent)
   - reversible arrow preserving `(-10, 10)` (consistent)
   - reversible arrow resetting `(0, 10)` (inconsistent — no negative lb)

   The test **FAILS** on `devel` HEAD (`(0, 1000.0) != (0, 10)`) and
   **PASSES** with the fix applied.

4. Pre-existing tests `test_build_from_string` and
   `test_build_from_string_creating_metabolites` both pass without changes.

5. Full `tests/test_core/test_core_reaction.py` run: **54 passed, 6 errors**
   (the 6 errors are baseline — missing `pytest-benchmark` fixture, identical
   on pristine `devel`).

6. Linters: `flake8`, `black --check`, `isort --check-only` — all clean on
   both changed files.

Fixes #1463
