### PR TITLE
feat: add method="potentials" to add_loopless (41x faster construction at genome scale)

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+- `add_loopless` gained `method="potentials"`, which encodes the loop law through free metabolite potentials (`G = S_intᵀμ`) instead of a computed null-space basis. The feasible flux space is identical to the existing methods; only construction cost differs. On Recon2 the null-space step dominates construction (98% of a 17-minute build), which "potentials" skips entirely, building the same constraints in seconds. `flux_variability_analysis` accepts `loopless="potentials"` accordingly.
+
 ## Fixes
 
 ## Other

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -45,11 +45,18 @@ def add_loopless(
         Cutoff used for null space. Coefficients with an absolute value
         smaller than `zero_cutoff` are considered to be zero. The default
         uses the `model.tolerance` (default None).
-    method : str, "original" or "fastSNP", optional
-        The method to use for finding the null space. The "original" method
-        uses the original method from [1]_, while "fastSNP" uses a faster
-        implementation based on the FastSNP algorithm. The "fastSNP" method
-        is much faster and should be used in most cases.
+    method : str, "original", "fastSNP" or "potentials", optional
+        How to encode the loop law. The "original" method uses the null-space
+        formulation from [1]_; "fastSNP" uses the same formulation over a
+        sparse null-space basis found with the Fast-SNP algorithm [2]_.
+        "potentials" skips null-space computation entirely: it introduces one
+        free potential variable per metabolite and defines each Gibbs energy
+        as G = S_intᵀ μ, which is orthogonal to every internal cycle
+        identically (range(S_intᵀ) is the orthogonal complement of
+        null(S_int)). The encoded feasible flux space is the same for all
+        three methods; they differ only in construction cost. On large models
+        the basis computation dominates -- 98% of a 17-minute build on Recon2
+        -- so "potentials" is the fastest choice there by a wide margin.
     reactions : list of str, optional
         The list of reaction IDs to constrain. All cycles within these
         reactions will be removed. If `None`, all reactions will be constrained.
@@ -64,12 +71,12 @@ def add_loopless(
        loopless flux optimization of metabolic models. Saa PA, Nielsen LK.
        Bioinformatics. 2016 Dec;32(24):3807–3814. doi: 10.1093/bioinformatics/btw555.
     """
-    if method not in ["original", "fastSNP"]:
+    if method not in ["original", "fastSNP", "potentials"]:
         raise ValueError(f"unsupported method: {method}")
 
     zero_cutoff = normalize_cutoff(model, zero_cutoff)
 
-    if reactions is None and method == "fastSNP":
+    if reactions is None and method in ("fastSNP", "potentials"):
         reactions = find_cyclic_reactions(model, zero_cutoff=zero_cutoff)[0]
 
     reactions_to_constrain = [
@@ -85,7 +92,9 @@ def add_loopless(
 
     s_int = create_stoichiometric_matrix(model)[:, np.array(reactions_to_constrain)]
 
-    if method == "original":
+    if method == "potentials":
+        n_int = None
+    elif method == "original":
         n_int = nullspace(s_int).T
     elif method == "fastSNP":
         bounds_int = np.array(
@@ -109,7 +118,7 @@ def add_loopless(
     # Add indicator variables and new constraints
     to_add = []
     for i, ridx in enumerate(reactions_to_constrain):
-        if not (np.abs(n_int[:, i]) > zero_cutoff).any():
+        if n_int is not None and not (np.abs(n_int[:, i]) > zero_cutoff).any():
             continue
 
         rxn = model.reactions[ridx]
@@ -133,6 +142,36 @@ def add_loopless(
         to_add.extend([indicator, on_off_constraint, delta_g, delta_g_range])
 
     model.add_cons_vars(to_add)
+
+    if method == "potentials":
+        # G = S_intᵀ μ: one free potential per metabolite, one defining
+        # constraint per constrained reaction. No null space is ever computed;
+        # orthogonality to every internal cycle holds identically because a
+        # cycle n satisfies S_int n = 0, hence n·G = (S_int n)·μ = 0.
+        potentials = {
+            met.id: prob.Variable(f"potential_{met.id}")
+            for ridx in reactions_to_constrain
+            for met in model.reactions[ridx].metabolites
+        }
+        model.add_cons_vars(list(potentials.values()))
+        to_link = []
+        for ridx in reactions_to_constrain:
+            rxn = model.reactions[ridx]
+            name = f"potential_constraint_{rxn.id}"
+            if f"delta_g_{rxn.id}" not in model.variables:
+                continue
+            to_link.append(prob.Constraint(Zero, lb=0, ub=0, name=name))
+        model.add_cons_vars(to_link)
+        for ridx in reactions_to_constrain:
+            rxn = model.reactions[ridx]
+            name = f"potential_constraint_{rxn.id}"
+            if name not in model.constraints:
+                continue
+            coefs = {potentials[met.id]: -float(coef)
+                     for met, coef in rxn.metabolites.items()}
+            coefs[model.variables[f"delta_g_{rxn.id}"]] = 1.0
+            model.constraints[name].set_linear_coefficients(coefs)
+        return
 
     # Add nullspace constraints for G_i
     for i, row in enumerate(n_int):

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -167,8 +167,10 @@ def add_loopless(
             name = f"potential_constraint_{rxn.id}"
             if name not in model.constraints:
                 continue
-            coefs = {potentials[met.id]: -float(coef)
-                     for met, coef in rxn.metabolites.items()}
+            coefs = {
+                potentials[met.id]: -float(coef)
+                for met, coef in rxn.metabolites.items()
+            }
             coefs[model.variables[f"delta_g_{rxn.id}"]] = 1.0
             model.constraints[name].set_linear_coefficients(coefs)
         return

--- a/src/cobra/flux_analysis/variability.py
+++ b/src/cobra/flux_analysis/variability.py
@@ -106,7 +106,7 @@ def flux_variability_analysis(
     reaction_list : list of cobra.Reaction or str, optional
         The reactions for which to obtain min/max fluxes. If None will use
         all reactions in the model (default None).
-    loopless : str, "fastSNP" or "cycleFreeFlux", optional
+    loopless : str, "fastSNP", "potentials" or "cycleFreeFlux", optional
         If this value is set, only loopless solutions will be returned.
         Boolean values are deprecated. Provided value means the algorithm
         to constrain the model to loopless solutions.
@@ -148,7 +148,8 @@ def flux_variability_analysis(
     Using the loopless option will lead to a significant increase in
     computation time (about a factor of 100 for large models).
 
-    If `loopless` is set to "fastSNP", the optimal loopless flux bounds will be
+    If `loopless` is set to "fastSNP" or "potentials", the optimal loopless
+    flux bounds will be
     found by adding the loopless constraints to the model using efficient
     Fast-SNP algorithm (see [2]_).
 
@@ -181,9 +182,10 @@ def flux_variability_analysis(
         )
         loopless = "cycleFreeFlux" if loopless else None
 
-    if loopless not in (None, "fastSNP", "cycleFreeFlux"):
+    if loopless not in (None, "fastSNP", "potentials", "cycleFreeFlux"):
         raise ValueError(
-            "The `loopless` argument must be either None, 'fastSNP' or 'cycleFreeFlux'."
+            "The `loopless` argument must be either None, 'fastSNP', "
+            "'potentials' or 'cycleFreeFlux'."
         )
 
     if reaction_list is None:
@@ -282,7 +284,7 @@ def flux_variability_analysis(
                 continue
 
             run_cycle_free_flux = bool(loopless_reactions)
-            if loopless_reactions and loopless == "fastSNP":
+            if loopless_reactions and loopless in ("fastSNP", "potentials"):
                 add_loopless(
                     model,
                     method=loopless,

--- a/tests/test_flux_analysis/test_loopless.py
+++ b/tests/test_flux_analysis/test_loopless.py
@@ -42,7 +42,7 @@ def ll_test_model(request: pytest.FixtureRequest) -> Model:
     return test_model
 
 
-@pytest.mark.parametrize("method", ["fastSNP", "original"])
+@pytest.mark.parametrize("method", ["fastSNP", "original", "potentials"])
 def test_loopless_benchmark_before(benchmark: Callable, method: str) -> None:
     """Benchmark initial condition."""
     test_model = construct_ll_test_model()
@@ -82,7 +82,7 @@ def test_loopless_solution_fluxes(model: Model) -> None:
     assert ll_solution.objective_value == pytest.approx(sol.objective_value)
 
 
-@pytest.mark.parametrize("method", ["fastSNP", "original"])
+@pytest.mark.parametrize("method", ["fastSNP", "original", "potentials"])
 def test_add_loopless(ll_test_model: Model, method: str) -> None:
     """Test add_loopless()."""
     add_loopless(ll_test_model, method=method)


### PR DESCRIPTION
### Motivation

`add_loopless` becomes construction-bound at genome scale. Timing its sub-phases on Recon 2.05 (7,324 reactions, 3,842 cyclic):

| phase | time | share |
|---|---|---|
| `find_cyclic_reactions` | 9.9 s | 1% |
| **`nullspace_fast_snp`** | **1000.6 s** | **98%** |
| optlang constraint construction | 15.4 s | 1% |
| total | 1025.9 s | |

A CPU sample during the dominant phase shows 100% of time in Python property-getter chains constructing the basis LPs — the solver is idle. The null-space computation, not the solver and not the constraint loop, is where the minutes go.

### Change

The basis is avoidable entirely. The loop law requires ΔG orthogonal to every internal cycle, and

```
G ⊥ null(S_int)  ⟺  G ∈ range(S_intᵀ)  ⟺  G = S_intᵀ μ
```

`method="potentials"` introduces one free variable per participating metabolite and defines each `delta_g` through that identity — orthogonality holds identically (a cycle `n` satisfies `S_int·n = 0`, hence `n·G = (S_int·n)·μ = 0`), so **no null space is ever computed**. The indicator/big-M machinery is reused unchanged. This is also the formulation with a physical reading: μ are chemical potentials, ΔG their differences — the same parameterization TFA-style methods use.

`flux_variability_analysis` accepts `loopless="potentials"` and routes it through the same exact path as `"fastSNP"`. **All defaults unchanged.**

### Equivalence

The encoded flux space is identical to the existing methods:

- loopless optima agree with `method="fastSNP"` to **8e-13** (e_coli_core) and **7e-10** (iJR904) across 50 objectives each
- the existing `test_add_loopless` loop-elimination test passes parametrized over `"potentials"` (feasible without the forced loop reaction, infeasible with it)

### Performance

| model | fastSNP construction | potentials construction |
|---|---|---|
| Recon 2.05 | 1025.9 s | **24.8 s** (3,842 indicators, 2,109 potentials) |

Small models are unaffected (construction was already sub-second).

### Tests

Existing `test_add_loopless` and `test_loopless_benchmark_before` parametrizations extended with `"potentials"`; 9/9 relevant tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)