### PR TITLE
fix: raise when BioModels lists no SBML document (OMEX-only models)

### DIFF
--- a/src/cobra/io/web/biomodels_repository.py
+++ b/src/cobra/io/web/biomodels_repository.py
@@ -70,6 +70,9 @@ class BioModels(AbstractModelRepository):
         ------
         httpx.HTTPError
             In case there are any connection problems.
+        RuntimeError
+            If the model's file listing contains no SBML document, for example
+            when the model is only deposited as a COMBINE (OMEX) archive.
 
         """
         data = BytesIO()
@@ -83,7 +86,12 @@ class BioModels(AbstractModelRepository):
             if model.name.endswith("xml"):
                 break
         else:
-            RuntimeError(f"Could not find an SBML document for '{model_id}'.")
+            raise RuntimeError(
+                f"Could not find an SBML document for '{model_id}'. The model's main "
+                f"files are "
+                f"{sorted(f.name for f in files.main) if files.main else 'empty'}. "
+                f"Models deposited as COMBINE (OMEX) archives are not supported yet."
+            )
         with self._progress, httpx.stream(
             method="GET",
             url=self._url.join(f"download/{model_id}"),

--- a/tests/test_io/test_web/test_load.py
+++ b/tests/test_io/test_web/test_load.py
@@ -10,6 +10,7 @@ import pytest
 
 from cobra import Configuration
 from cobra.io import BiGGModels, BioModels, load_model
+from cobra.io.web import biomodels_repository
 
 
 if TYPE_CHECKING:
@@ -75,6 +76,45 @@ def test_unknown_model() -> None:
     """Expect that a not found error is raised (e2e)."""
     with pytest.raises(RuntimeError):
         load_model("MODELWHO?", cache=False)
+
+
+@pytest.mark.parametrize(
+    "main_files",
+    [
+        pytest.param(
+            [{"name": "253_2019_9630_MOESM3_ESM.omex", "fileSize": "106359"}],
+            id="omex-only",
+        ),
+        pytest.param([], id="empty-listing"),
+    ],
+)
+def test_biomodels_without_sbml_document(
+    mocker: "MockerFixture", main_files: list
+) -> None:
+    """Expect a clear error when BioModels lists no SBML document.
+
+    Some models are deposited only as COMBINE (OMEX) archives, so the file
+    listing contains no ``.xml`` entry. The download must not be attempted,
+    because the archive bytes are not an SBML document and would surface much
+    later as a ``UnicodeDecodeError``.
+
+    Parameters
+    ----------
+    mocker : pytest_mock.MockerFixture
+        The mocking fixture.
+    main_files : list
+        The ``main`` section of the mocked BioModels files response.
+
+    """
+    response = mocker.Mock()
+    response.json.return_value = {"additional": [], "main": main_files}
+    mocker.patch.object(biomodels_repository.httpx, "get", return_value=response)
+    stream = mocker.patch.object(biomodels_repository.httpx, "stream")
+
+    with pytest.raises(RuntimeError, match="Could not find an SBML document"):
+        BioModels().get_sbml(model_id="BIOMD0000001089")
+
+    stream.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem

`cobra.io.load_model("BIOMD0000001089")` fails with

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 10: invalid start byte
```

which says nothing about what actually went wrong.

The cause is in `BioModels.get_sbml`. It walks the repository's `main` file
listing looking for an SBML document and has a `for`/`else` to handle the case
where there isn't one:

```python
for model in files.main:
    if model.name.endswith("xml"):
        break
else:
    RuntimeError(f"Could not find an SBML document for '{model_id}'.")
```

The `else` branch constructs the exception but never raises it. So the guard
does nothing, `model` is left pointing at the last (non-SBML) entry, and the
method goes on to download it anyway. For this model that file is
`253_2019_9630_MOESM3_ESM.omex` — a COMBINE archive, i.e. a zip — and the zip
bytes only blow up later in `get_model_from_gzip_sbml`, where the decode
happens. As @Midnighter noted on the issue, more models are being deposited as
OMEX archives, so this path is getting more common rather than less.

There is a second failure mode behind the same missing `raise`: if `main` is
empty the loop body never runs, `model` is never bound, and the next line
raises `UnboundLocalError: cannot access local variable 'model'` instead of
anything meaningful.

I checked the live API to confirm the shape rather than guessing —
`https://biomodels.org/model/files/BIOMD0000001089` currently returns a `main`
section whose only entry is the `.omex` file, with no `.xml` alongside it.

### The fix

Raise the error that was already meant to be raised, and include the file names
that were actually found so the message points at the cause:

```
Could not find an SBML document for 'BIOMD0000001089'. The model's main files
are ['253_2019_9630_MOESM3_ESM.omex']. Models deposited as COMBINE (OMEX)
archives are not supported yet.
```

This also fixes the empty-listing case, since the `else` branch now exits
before anything reads `model`. `load_model` already wraps repository lookups,
so callers see a `RuntimeError` on a path that is documented to raise one.

I deliberately kept this to the reporting bug. Actually reading OMEX archives
is a feature, not a fix, and it belongs in its own PR — this one just makes the
failure honest instead of surfacing as a decode error 100 lines away.

I also added the `RuntimeError` to the method's `Raises` docstring section,
which only listed `httpx.HTTPError`.

### Testing

Added `test_biomodels_without_sbml_document`, parametrised over the two cases —
an OMEX-only listing (mirroring the real response above) and an empty listing.
It asserts the `RuntimeError` and that `httpx.stream` is never called, since
not downloading a file we know is unusable is the actual behavioural change.

Confirmed the test is not vacuous by stashing only the source file and keeping
the test, against `main`:

```
$ git stash push -- src/cobra/io/web/biomodels_repository.py
$ python -m pytest tests/test_io/test_web/test_load.py::test_biomodels_without_sbml_document -q
E       UnboundLocalError: cannot access local variable 'model' where it is not associated with a value
2 failed
```

With the fix applied:

```
$ python -m pytest tests/test_io/test_web/test_load.py -q
7 passed, 1 skipped, 1 xfailed

$ python -m pytest tests/test_io -q
74 passed, 24 skipped, 7 xfailed in 11.41s
```

Linters, at the versions pinned in `tox.ini`:

```
$ black --check src/cobra/io/web/biomodels_repository.py tests/test_io/test_web/test_load.py
2 files would be left unchanged.
$ isort --check-only ...    # clean
$ flake8 ...                # clean
```

The tests are fully mocked, so they don't add another network-dependent case to
a suite that already has trouble with BioModels being flaky (#1455).

Fixes #1466
