### PR TITLE
Use a typevar for resettable

### DIFF
--- a/release-notes/next-release.md
+++ b/release-notes/next-release.md
@@ -7,6 +7,7 @@
 ## Fixes
 
 - fixed import failure when hopsy was not installed
+- type-annotations on resetable properties fixed.
 
 ## Other
 

--- a/src/cobra/util/context.py
+++ b/src/cobra/util/context.py
@@ -1,7 +1,7 @@
 """Context manager for the package."""
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 
 if TYPE_CHECKING:
@@ -80,6 +80,7 @@ def get_context(obj: "Object") -> Optional[HistoryManager]:
 
 
 F = TypeVar("F", bound=Callable)
+
 
 def resettable(func: F) -> F:
     """

--- a/src/cobra/util/context.py
+++ b/src/cobra/util/context.py
@@ -79,7 +79,7 @@ def get_context(obj: "Object") -> Optional[HistoryManager]:
         pass
 
 
-F = TypeVar('F', bound=Callable)
+F = TypeVar("F", bound=Callable)
 
 def resettable(func: F) -> F:
     """

--- a/src/cobra/util/context.py
+++ b/src/cobra/util/context.py
@@ -79,7 +79,9 @@ def get_context(obj: "Object") -> Optional[HistoryManager]:
         pass
 
 
-def resettable(func: Callable[[Any], Any]) -> Callable[[Any], Any]:
+F = TypeVar('F', bound=Callable)
+
+def resettable(func: F) -> F:
     """
     Simplify the context management of simple object attributes.
 


### PR DESCRIPTION
the resettable decorator had incorrect type annotation.
`Callable[[Any], Any]]` is only correct for methods with no 1 argument.
But it is used on property setters, which always have 2 arguments: `self` and `value`.
We could change it to `Callable[[Any, Any], Any]]` which would say just that.
But i think just making it a type-var is better. Then it just falls though so the wrapped function can be checked

Mypy does not pickup this error at site-of-use.
But pyrefly does.


* [ ] fix #(issue number)
* [x] description of feature/fix
* [ ] tests added/passed
* [x] add an entry to the [next release](../release-notes/next-release.md)

